### PR TITLE
access_feature: fix swagger

### DIFF
--- a/wazo_confd/plugins/access_feature/api.yml
+++ b/wazo_confd/plugins/access_feature/api.yml
@@ -112,8 +112,9 @@ definitions:
           - phonebook
       enabled:
         type: boolean
-    - required:
-      - access_feature
+    required:
+    - host
+    - feature
   AccessFeatureItems:
     title: AccessFeatureItems
     properties:


### PR DESCRIPTION
reason: there was a superfluous required field with a field that does
not exist. The syntax was also wrong. It is weird that the validator has
not seen this mistake.