### PR TITLE
registrars: fix search test

### DIFF
--- a/integration_tests/suite/base/test_registrars.py
+++ b/integration_tests/suite/base/test_registrars.py
@@ -88,7 +88,7 @@ def error_checks(url):
 def test_search(registrar, hidden):
     url = confd.registrars
     searches = {
-        'proxy_main_host': '2.3',
+        'proxy_main_host': '1.2.3',
         'id': 'leid',
         'name': 'ereg',
         'outbound_proxy_port': 5060,


### PR DESCRIPTION
reason: main_host is autogenerated and the test failed once because we
were searching for `2.3` and the main_host of the HiddenRegistrar was
`55.22.37.54`, thus being returned. Fixed by searching for `1.2.3`
instead.