### PR TITLE
WAZO-999: add call_pickup_targets in schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * A new read-only parameter has been added to the users resource:
 
-  * `call_pickup_targets`
+  * `call_pickup_target_users`
 
 ## 19.17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 19.18
+
+* A new read-only parameter has been added to the users resource:
+
+  * `call_pickup_targets`
+
 ## 19.17
 
 * Legacy search parameter with `q` has been removed from user resource

--- a/integration_tests/suite/base/test_call_pickup_target_group.py
+++ b/integration_tests/suite/base/test_call_pickup_target_group.py
@@ -116,11 +116,8 @@ def test_associate_multi_tenant(
 @fixtures.group()
 @fixtures.group()
 def test_get_user_interceptor_user_relation(call_pickup, user1, user2, user3, line1, line2, line3, group1, group2):
-    with a.user_line(user1, line1), a.user_line(user2, line2), a.user_line(user3, line3):
-        response = confd.groups(group1['id']).members.users.put(users=[user2])
-        response.assert_updated()
-        response = confd.groups(group2['id']).members.users.put(users=[user3])
-        response.assert_updated()
+    with a.user_line(user1, line1), a.user_line(user2, line2), a.user_line(user3, line3), \
+            a.group_member_user(group1, user2), a.group_member_user(group2, user3):
 
         with a.call_pickup_interceptor_user(call_pickup, user1):
             with a.call_pickup_target_group(call_pickup, group1, group2):
@@ -147,13 +144,9 @@ def test_get_user_interceptor_user_relation(call_pickup, user1, user2, user3, li
 @fixtures.group()
 @fixtures.group()
 def test_get_group_interceptor_user_relation(call_pickup, user1, user2, user3, line1, line2, line3, group1, group2, group3):
-    with a.user_line(user1, line1), a.user_line(user2, line2), a.user_line(user3, line3):
-        response = confd.groups(group1['id']).members.users.put(users=[user1])
-        response.assert_updated()
-        response = confd.groups(group2['id']).members.users.put(users=[user2])
-        response.assert_updated()
-        response = confd.groups(group3['id']).members.users.put(users=[user3])
-        response.assert_updated()
+    with a.user_line(user1, line1), a.user_line(user2, line2), a.user_line(user3, line3), \
+            a.group_member_user(group1, user1), a.group_member_user(group2, user2), \
+            a.group_member_user(group3, user3):
 
         with a.call_pickup_interceptor_group(call_pickup, group1):
             with a.call_pickup_target_group(call_pickup, group2, group3):

--- a/integration_tests/suite/base/test_call_pickup_target_group.py
+++ b/integration_tests/suite/base/test_call_pickup_target_group.py
@@ -107,6 +107,34 @@ def test_associate_multi_tenant(
 
 
 @fixtures.call_pickup()
+@fixtures.user()
+@fixtures.group()
+@fixtures.group()
+def test_interceptor_user_has_targets(call_pickup, user1, group1, group2):
+    response = confd.callpickups(call_pickup['id']).targets.groups.put(
+        groups=[group1, group2]
+    )
+    response.assert_updated()
+    response = confd.callpickups(call_pickup['id']).interceptors.users.put(
+        users=[user1]
+    )
+    response.assert_updated()
+
+    response = confd.users(user1['id']).get()
+    assert_that(
+        response.item,
+        has_entries(
+            call_pickup_targets=has_entries(
+                groups=contains_inanyorder(
+                    has_entries(id=group1['id']),
+                    has_entries(id=group2['id']),
+                )
+            )
+        ),
+    )
+
+
+@fixtures.call_pickup()
 @fixtures.group()
 @fixtures.group()
 def test_get_groups_associated_to_call_pickup(call_pickup, group1, group2):

--- a/integration_tests/suite/base/test_call_pickup_target_group.py
+++ b/integration_tests/suite/base/test_call_pickup_target_group.py
@@ -110,28 +110,22 @@ def test_associate_multi_tenant(
 @fixtures.user()
 @fixtures.group()
 @fixtures.group()
-def test_interceptor_user_has_targets(call_pickup, user1, group1, group2):
-    response = confd.callpickups(call_pickup['id']).targets.groups.put(
-        groups=[group1, group2]
-    )
-    response.assert_updated()
-    response = confd.callpickups(call_pickup['id']).interceptors.users.put(
-        users=[user1]
-    )
-    response.assert_updated()
+def test_get_interceptor_user_relation(call_pickup, user, group1, group2):
 
-    response = confd.users(user1['id']).get()
-    assert_that(
-        response.item,
-        has_entries(
-            call_pickup_targets=has_entries(
-                groups=contains_inanyorder(
-                    has_entries(id=group1['id']),
-                    has_entries(id=group2['id']),
-                )
+    with a.call_pickup_interceptor_user(call_pickup, user):
+        with a.call_pickup_target_group(call_pickup, group1, group2):
+            response = confd.users(user['id']).get()
+            assert_that(
+                response.item,
+                has_entries(
+                    call_pickup_targets=has_entries(
+                        groups=contains_inanyorder(
+                            has_entries(id=group1['id']),
+                            has_entries(id=group2['id']),
+                        )
+                    )
+                ),
             )
-        ),
-    )
 
 
 @fixtures.call_pickup()

--- a/integration_tests/suite/base/test_call_pickup_target_group.py
+++ b/integration_tests/suite/base/test_call_pickup_target_group.py
@@ -115,9 +115,12 @@ def test_associate_multi_tenant(
 @fixtures.line_sip()
 @fixtures.group()
 @fixtures.group()
-def test_get_user_interceptor_user_relation(call_pickup, user1, user2, user3, line1, line2, line3, group1, group2):
-    with a.user_line(user1, line1), a.user_line(user2, line2), a.user_line(user3, line3), \
-            a.group_member_user(group1, user2), a.group_member_user(group2, user3):
+def test_get_user_interceptor_user_relation(
+    call_pickup, user1, user2, user3, line1, line2, line3, group1, group2
+):
+    with a.user_line(user1, line1), a.user_line(user2, line2), a.user_line(
+        user3, line3
+    ), a.group_member_user(group1, user2), a.group_member_user(group2, user3):
 
         with a.call_pickup_interceptor_user(call_pickup, user1):
             with a.call_pickup_target_group(call_pickup, group1, group2):
@@ -143,10 +146,16 @@ def test_get_user_interceptor_user_relation(call_pickup, user1, user2, user3, li
 @fixtures.group()
 @fixtures.group()
 @fixtures.group()
-def test_get_group_interceptor_user_relation(call_pickup, user1, user2, user3, line1, line2, line3, group1, group2, group3):
-    with a.user_line(user1, line1), a.user_line(user2, line2), a.user_line(user3, line3), \
-            a.group_member_user(group1, user1), a.group_member_user(group2, user2), \
-            a.group_member_user(group3, user3):
+def test_get_group_interceptor_user_relation(
+    call_pickup, user1, user2, user3, line1, line2, line3, group1, group2, group3
+):
+    with a.user_line(user1, line1), a.user_line(user2, line2), a.user_line(
+        user3, line3
+    ), a.group_member_user(group1, user1), a.group_member_user(
+        group2, user2
+    ), a.group_member_user(
+        group3, user3
+    ):
 
         with a.call_pickup_interceptor_group(call_pickup, group1):
             with a.call_pickup_target_group(call_pickup, group2, group3):

--- a/integration_tests/suite/base/test_call_pickup_target_user.py
+++ b/integration_tests/suite/base/test_call_pickup_target_user.py
@@ -108,21 +108,44 @@ def test_associate_multi_tenant(main_call_pickup, sub_call_pickup, main_user, su
 @fixtures.user()
 @fixtures.user()
 @fixtures.user()
-def test_get_interceptor_user_relation(call_pickup, user1, user2, user3):
+def test_get_user_interceptor_user_relation(call_pickup, user1, user2, user3):
     with a.call_pickup_interceptor_user(call_pickup, user1):
         with a.call_pickup_target_user(call_pickup, user2, user3):
             response = confd.users(user1['id']).get()
             assert_that(
                 response.item,
                 has_entries(
-                    call_pickup_targets=has_entries(
-                        users=contains_inanyorder(
-                            has_entries(uuid=user2['uuid']),
-                            has_entries(uuid=user3['uuid']),
-                        )
-                    )
+                    call_pickup_target_users=contains_inanyorder(
+                        has_entries(uuid=user2['uuid']),
+                        has_entries(uuid=user3['uuid']),
+                    ),
                 ),
             )
+
+
+@fixtures.call_pickup()
+@fixtures.user()
+@fixtures.user()
+@fixtures.user()
+@fixtures.line_sip()
+@fixtures.group()
+def test_get_group_interceptor_user_relation(call_pickup, user1, user2, user3, line, group):
+    with a.user_line(user1, line):
+        response = confd.groups(group['id']).members.users.put(users=[user1])
+        response.assert_updated()
+
+        with a.call_pickup_interceptor_group(call_pickup, group):
+            with a.call_pickup_target_user(call_pickup, user2, user3):
+                response = confd.users(user1['id']).get()
+                assert_that(
+                    response.item,
+                    has_entries(
+                        call_pickup_target_users=contains_inanyorder(
+                            has_entries(uuid=user2['uuid']),
+                            has_entries(uuid=user3['uuid']),
+                        ),
+                    ),
+                )
 
 
 @fixtures.call_pickup()

--- a/integration_tests/suite/base/test_call_pickup_target_user.py
+++ b/integration_tests/suite/base/test_call_pickup_target_user.py
@@ -108,28 +108,21 @@ def test_associate_multi_tenant(main_call_pickup, sub_call_pickup, main_user, su
 @fixtures.user()
 @fixtures.user()
 @fixtures.user()
-def test_interceptor_user_has_targets(call_pickup, user1, user2, user3):
-    response = confd.callpickups(call_pickup['id']).targets.users.put(
-        users=[user2, user3]
-    )
-    response.assert_updated()
-    response = confd.callpickups(call_pickup['id']).interceptors.users.put(
-        users=[user1]
-    )
-    response.assert_updated()
-
-    response = confd.users(user1['id']).get()
-    assert_that(
-        response.item,
-        has_entries(
-            call_pickup_targets=has_entries(
-                users=contains_inanyorder(
-                    has_entries(uuid=user2['uuid']),
-                    has_entries(uuid=user3['uuid']),
-                )
+def test_get_interceptor_user_relation(call_pickup, user1, user2, user3):
+    with a.call_pickup_interceptor_user(call_pickup, user1):
+        with a.call_pickup_target_user(call_pickup, user2, user3):
+            response = confd.users(user1['id']).get()
+            assert_that(
+                response.item,
+                has_entries(
+                    call_pickup_targets=has_entries(
+                        users=contains_inanyorder(
+                            has_entries(uuid=user2['uuid']),
+                            has_entries(uuid=user3['uuid']),
+                        )
+                    )
+                ),
             )
-        ),
-    )
 
 
 @fixtures.call_pickup()

--- a/integration_tests/suite/base/test_call_pickup_target_user.py
+++ b/integration_tests/suite/base/test_call_pickup_target_user.py
@@ -130,10 +130,7 @@ def test_get_user_interceptor_user_relation(call_pickup, user1, user2, user3):
 @fixtures.line_sip()
 @fixtures.group()
 def test_get_group_interceptor_user_relation(call_pickup, user1, user2, user3, line, group):
-    with a.user_line(user1, line):
-        response = confd.groups(group['id']).members.users.put(users=[user1])
-        response.assert_updated()
-
+    with a.user_line(user1, line), a.group_member_user(group, user1):
         with a.call_pickup_interceptor_group(call_pickup, group):
             with a.call_pickup_target_user(call_pickup, user2, user3):
                 response = confd.users(user1['id']).get()

--- a/integration_tests/suite/base/test_call_pickup_target_user.py
+++ b/integration_tests/suite/base/test_call_pickup_target_user.py
@@ -129,7 +129,9 @@ def test_get_user_interceptor_user_relation(call_pickup, user1, user2, user3):
 @fixtures.user()
 @fixtures.line_sip()
 @fixtures.group()
-def test_get_group_interceptor_user_relation(call_pickup, user1, user2, user3, line, group):
+def test_get_group_interceptor_user_relation(
+    call_pickup, user1, user2, user3, line, group
+):
     with a.user_line(user1, line), a.group_member_user(group, user1):
         with a.call_pickup_interceptor_group(call_pickup, group):
             with a.call_pickup_target_user(call_pickup, user2, user3):

--- a/integration_tests/suite/base/test_call_pickup_target_user.py
+++ b/integration_tests/suite/base/test_call_pickup_target_user.py
@@ -107,6 +107,34 @@ def test_associate_multi_tenant(main_call_pickup, sub_call_pickup, main_user, su
 @fixtures.call_pickup()
 @fixtures.user()
 @fixtures.user()
+@fixtures.user()
+def test_interceptor_user_has_targets(call_pickup, user1, user2, user3):
+    response = confd.callpickups(call_pickup['id']).targets.users.put(
+        users=[user2, user3]
+    )
+    response.assert_updated()
+    response = confd.callpickups(call_pickup['id']).interceptors.users.put(
+        users=[user1]
+    )
+    response.assert_updated()
+
+    response = confd.users(user1['id']).get()
+    assert_that(
+        response.item,
+        has_entries(
+            call_pickup_targets=has_entries(
+                users=contains_inanyorder(
+                    has_entries(uuid=user2['uuid']),
+                    has_entries(uuid=user3['uuid']),
+                )
+            )
+        ),
+    )
+
+
+@fixtures.call_pickup()
+@fixtures.user()
+@fixtures.user()
 def test_get_users_associated_to_call_pickup(call_pickup, user1, user2):
     with a.call_pickup_target_user(call_pickup, user1, user2):
         response = confd.callpickups(call_pickup['id']).get()

--- a/integration_tests/suite/base/test_users.py
+++ b/integration_tests/suite/base/test_users.py
@@ -574,7 +574,7 @@ def test_get(user):
             services={'dnd': {'enabled': False}, 'incallfilter': {'enabled': False}},
             voicemail=none(),
             queues=empty(),
-            call_pickup_targets=has_entries(users=empty(), groups=empty()),
+            call_pickup_target_users=empty(),
         ),
     )
 

--- a/integration_tests/suite/base/test_users.py
+++ b/integration_tests/suite/base/test_users.py
@@ -574,6 +574,7 @@ def test_get(user):
             services={'dnd': {'enabled': False}, 'incallfilter': {'enabled': False}},
             voicemail=none(),
             queues=empty(),
+            call_pickup_targets=has_entries(users=empty(), groups=empty()),
         ),
     )
 

--- a/wazo_confd/plugins/user/api.yml
+++ b/wazo_confd/plugins/user/api.yml
@@ -399,7 +399,7 @@ definitions:
     - $ref: '#/definitions/UserRelationSwitchboards'
     - $ref: '#/definitions/UserRelationVoicemail'
     - $ref: '#/definitions/UserRelationQueues'
-    - $ref: '#/definitions/UserCallPickupTargets'
+    - $ref: '#/definitions/UserRelationCallPickupTargets'
     - required:
       - firstname
   UserRelationBase:
@@ -490,8 +490,8 @@ definitions:
         readOnly: True
       number:
         type: string
-  UserCallPickupTargets:
-    title: UserCallPickupTargets
+  UserRelationCallPickupTargets:
+    title: UserRelationCallPickupTargets
     properties:
       call_pickup_targets:
         properties:

--- a/wazo_confd/plugins/user/api.yml
+++ b/wazo_confd/plugins/user/api.yml
@@ -493,16 +493,10 @@ definitions:
   UserRelationCallPickupTargets:
     title: UserRelationCallPickupTargets
     properties:
-      call_pickup_targets:
-        properties:
-          users:
-            type: array
-            items:
-              $ref: '#/definitions/UserRelationBase'
-          groups:
-            type: array
-            items:
-              $ref: '#/definitions/GroupRelationBase'
+      call_pickup_target_users:
+        type: array
+        items:
+          $ref: '#/definitions/UserRelationBase'
   UserService:
     title: UserService
     properties:

--- a/wazo_confd/plugins/user/api.yml
+++ b/wazo_confd/plugins/user/api.yml
@@ -399,6 +399,7 @@ definitions:
     - $ref: '#/definitions/UserRelationSwitchboards'
     - $ref: '#/definitions/UserRelationVoicemail'
     - $ref: '#/definitions/UserRelationQueues'
+    - $ref: '#/definitions/UserCallPickupTargets'
     - required:
       - firstname
   UserRelationBase:
@@ -489,6 +490,19 @@ definitions:
         readOnly: True
       number:
         type: string
+  UserCallPickupTargets:
+    title: UserCallPickupTargets
+    properties:
+      call_pickup_targets:
+        properties:
+          users:
+            type: array
+            items:
+              $ref: '#/definitions/UserRelationBase'
+          groups:
+            type: array
+            items:
+              $ref: '#/definitions/GroupRelationBase'
   UserService:
     title: UserService
     properties:

--- a/wazo_confd/plugins/user/schema.py
+++ b/wazo_confd/plugins/user/schema.py
@@ -55,7 +55,10 @@ class UserSchema(BaseSchema):
         'CallPermissionSchema', only=['id', 'name', 'links'], many=True, dump_only=True
     )
     call_pickup_user_targets_flat = fields.Nested(
-        'UserSchema', only=['uuid', 'firstname', 'lastname', 'links'], many=True, dump_only=True
+        'UserSchema',
+        only=['uuid', 'firstname', 'lastname', 'links'],
+        many=True,
+        dump_only=True,
     )
 
     fallbacks = fields.Nested('UserFallbackSchema', dump_only=True)

--- a/wazo_confd/plugins/user/schema.py
+++ b/wazo_confd/plugins/user/schema.py
@@ -1,7 +1,6 @@
 # Copyright 2016-2019 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-import itertools
 from marshmallow import fields, post_dump, pre_dump
 from marshmallow.validate import Length, Range, Regexp
 

--- a/wazo_confd/plugins/user/schema.py
+++ b/wazo_confd/plugins/user/schema.py
@@ -99,7 +99,7 @@ class UserSchema(BaseSchema):
     )
 
     @pre_dump
-    def predump(self, data, **kwargs):
+    def flatten_call_pickup_targets(self, data, **kwargs):
         data.call_pickup_user_targets_flat = list(
             set(self._flatten(data.call_pickup_user_targets))
         )
@@ -110,7 +110,7 @@ class UserSchema(BaseSchema):
         return data
 
     @post_dump
-    def postdump(self, data):
+    def format_call_pickup_targets(self, data):
         if not self.only or 'call_pickup_targets' in self.only:
             call_pickup_user_targets = data.pop('call_pickup_user_targets_flat', [])
             call_pickup_group_targets = data.pop('call_pickup_group_targets_flat', [])

--- a/wazo_confd/plugins/user/tests/test_schema.py
+++ b/wazo_confd/plugins/user/tests/test_schema.py
@@ -10,9 +10,14 @@ from ..schema import UserSchema
 
 
 class TestSchema(unittest.TestCase):
-
     def test_flatten(self):
         user_1, user_2, user_3, user_4, user_5 = Mock(), Mock(), Mock(), Mock(), Mock()
-        data_to_flatten = [user_1, [[user_2, user_3]], [[[user_4, [[user_5]]]]], [], [[]]]
+        data_to_flatten = [
+            user_1,
+            [[user_2, user_3]],
+            [[[user_4, [[user_5]]]]],
+            [],
+            [[]],
+        ]
         result = list(UserSchema._flatten(data_to_flatten))
         assert_that(result, equal_to([user_1, user_2, user_3, user_4, user_5]))

--- a/wazo_confd/plugins/user/tests/test_schema.py
+++ b/wazo_confd/plugins/user/tests/test_schema.py
@@ -1,0 +1,18 @@
+# Copyright 2019 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import unittest
+from mock import Mock
+
+from hamcrest import assert_that, equal_to
+
+from ..schema import UserSchema
+
+
+class TestSchema(unittest.TestCase):
+
+    def test_flatten(self):
+        user_1, user_2, user_3, user_4, user_5 = Mock(), Mock(), Mock(), Mock(), Mock()
+        data_to_flatten = [user_1, [[user_2, user_3]], [[[user_4, [[user_5]]]]], [], [[]]]
+        result = list(UserSchema._flatten(data_to_flatten))
+        assert_that(result, equal_to([user_1, user_2, user_3, user_4, user_5]))

--- a/wazo_confd/plugins/user_line/tests/test_notifier.py
+++ b/wazo_confd/plugins/user_line/tests/test_notifier.py
@@ -33,7 +33,9 @@ class TestUserLineNotifier(unittest.TestCase):
         self.sysconfd = Mock()
         self.user = Mock(uuid=USER_UUID, id=1, tenant_uuid=TENANT_UUID)
         self.serialized_user = {
-            'uuid': self.user.uuid, 'id': self.user.id, 'tenant_uuid': self.user.tenant_uuid
+            'uuid': self.user.uuid,
+            'id': self.user.id,
+            'tenant_uuid': self.user.tenant_uuid,
         }
         self.line = Mock(
             id=2, endpoint_sip={'id': 3}, endpoint_sccp=None, endpoint_custom=None


### PR DESCRIPTION
reason: this is to make it possible to see which users and groups a user
can intercept.
Depends-On: wazo-platform/xivo-dao#14