### PR TITLE
agent_skill: reload app-queue after di/association

### DIFF
--- a/wazo_confd/plugins/agent_skill/notifier.py
+++ b/wazo_confd/plugins/agent_skill/notifier.py
@@ -6,21 +6,28 @@ from xivo_bus.resources.agent_skill.event import (
     AgentSkillDissociatedEvent,
 )
 
-from wazo_confd import bus
+from wazo_confd import bus, sysconfd
 
 
 class AgentSkillNotifier:
-    def __init__(self, bus):
+    def __init__(self, bus, sysconfd):
         self.bus = bus
+        self.sysconfd = sysconfd
+
+    def send_sysconfd_handlers(self):
+        handlers = {'ipbx': ['module reload app_queue.so'], 'agentbus': []}
+        self.sysconfd.exec_request_handlers(handlers)
 
     def skill_associated(self, skill, agent_skill):
+        self.send_sysconfd_handlers()
         event = AgentSkillAssociatedEvent(skill.id, agent_skill.skill.id)
         self.bus.send_bus_event(event)
 
     def skill_dissociated(self, skill, agent_skill):
+        self.send_sysconfd_handlers()
         event = AgentSkillDissociatedEvent(skill.id, agent_skill.skill.id)
         self.bus.send_bus_event(event)
 
 
 def build_notifier():
-    return AgentSkillNotifier(bus)
+    return AgentSkillNotifier(bus, sysconfd)

--- a/wazo_confd/plugins/agent_skill/tests/test_notifier.py
+++ b/wazo_confd/plugins/agent_skill/tests/test_notifier.py
@@ -12,13 +12,21 @@ from xivo_bus.resources.agent_skill.event import (
 
 from ..notifier import AgentSkillNotifier
 
+EXPECTED_HANDLERS = {'ipbx': ['module reload app_queue.so'], 'agentbus': []}
+
 
 class TestAgentMemberNotifier(unittest.TestCase):
     def setUp(self):
         self.bus = Mock()
+        self.sysconfd = Mock()
         self.agent = Mock(id=1)
         self.agent_skill = Mock(skill=Mock(id=1))
-        self.notifier = AgentSkillNotifier(self.bus)
+        self.notifier = AgentSkillNotifier(self.bus, self.sysconfd)
+
+    def test_skill_associate_then_call_expected_handlers(self):
+        self.notifier.skill_associated(self.agent, self.agent_skill)
+
+        self.sysconfd.exec_request_handlers.assert_called_once_with(EXPECTED_HANDLERS)
 
     def test_skill_associate_then_bus_event(self):
         expected_event = AgentSkillAssociatedEvent(
@@ -28,6 +36,11 @@ class TestAgentMemberNotifier(unittest.TestCase):
         self.notifier.skill_associated(self.agent, self.agent_skill)
 
         self.bus.send_bus_event.assert_called_once_with(expected_event)
+
+    def test_skill_dissociate_then_call_expected_handlers(self):
+        self.notifier.skill_dissociated(self.agent, self.agent_skill)
+
+        self.sysconfd.exec_request_handlers.assert_called_once_with(EXPECTED_HANDLERS)
 
     def test_skill_dissociate_then_bus_event(self):
         expected_event = AgentSkillDissociatedEvent(


### PR DESCRIPTION
reason: asterisk need to reload queueskills.conf