### PR TITLE
confbridge: add links to the sample config file in the API spec

### DIFF
--- a/wazo_confd/plugins/confbridge/api.yml
+++ b/wazo_confd/plugins/confbridge/api.yml
@@ -15,11 +15,15 @@ paths:
     put:
       operationId: update_asterisk_confbridge_wazo_default_bridge
       summary: Update ConfBridge wazo_default_bridge option
-      description: '**Required ACL:** `confd.asterisk.confbridge.wazo_default_bridge.update`
-
+      description: |
+        **Required ACL:** `confd.asterisk.confbridge.wazo_default_bridge.update`
 
         **WARNING** This endpoint restore to default value or delete all fields that
-        are not defined.'
+        are not defined.
+
+        All available configuration options are listed in the
+        [sample](https://raw.githubusercontent.com/asterisk/asterisk/master/configs/samples/confbridge.conf.sample)
+        Asterisk configuration file.
       tags:
       - asterisk
       - conferences
@@ -52,11 +56,16 @@ paths:
     put:
       operationId: update_asterisk_confbridge_wazo_default_user
       summary: Update ConfBridge wazo_default_user option
-      description: '**Required ACL:** `confd.asterisk.confbridge.wazo_default_user.update`
+      description: |
+        **Required ACL:** `confd.asterisk.confbridge.wazo_default_user.update`
 
 
         **WARNING** This endpoint restore to default value or delete all fields that
-        are not defined.'
+        are not defined.
+
+        All available configuration options are listed in the
+        [sample](https://raw.githubusercontent.com/asterisk/asterisk/master/configs/samples/confbridge.conf.sample)
+        Asterisk configuration file.
       tags:
       - asterisk
       - conferences

--- a/wazo_confd/plugins/conference/api.yml
+++ b/wazo_confd/plugins/conference/api.yml
@@ -25,7 +25,9 @@ paths:
       description: |
         **Required ACL:** `confd.conferences.create`
 
-        All conferences have the same menu. Please consult the asterisk documentation for definitions:
+        All conferences have the same menu. Please consult the asterisk
+        [documentation](https://raw.githubusercontent.com/asterisk/asterisk/master/configs/samples/confbridge.conf.sample)
+        for definitions:
         ```
         * = playback_and_continue
         1 = toggle_mute


### PR DESCRIPTION
Add links to the sample configuration file for confbridge in the API spec since
the help in the wiki misses some of the fields that are available.