### PR TITLE
user import: handle auth error on user creation

### DIFF
--- a/wazo_confd/plugins/user_import/auth_client.py
+++ b/wazo_confd/plugins/user_import/auth_client.py
@@ -19,6 +19,7 @@ class AuthClientProxy:
     def __init__(self, auth_client):
         self._auth_client = auth_client
         self._users_created = []
+        self.users = self._auth_client.users
 
     def new_user(self, *args, **kwargs):
         try:

--- a/wazo_confd/plugins/user_import/auth_client.py
+++ b/wazo_confd/plugins/user_import/auth_client.py
@@ -1,41 +1,55 @@
 # Copyright 2018-2019 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+import logging
+
 from werkzeug.local import LocalProxy as Proxy
 
 from flask import g
-
+from requests import HTTPError
 from wazo_auth_client import Client as AuthClient
+from xivo_dao.helpers.exception import ServiceError
+
+logger = logging.getLogger(__name__)
 
 auth_config = {}
 
 
-class AuthClientProxy(AuthClient):
-    def __init__(self, *args, **kwargs):
-        super(AuthClientProxy, self).__init__(*args, **kwargs)
-        self.users_created = []
-        # 30 minutes should be enought to import all users
-        token = self.token.new(expiration=30 * 60)['token']
-        self.set_token(token)
+class AuthClientProxy:
+    def __init__(self, auth_client):
+        self._auth_client = auth_client
+        self._users_created = []
 
     def new_user(self, *args, **kwargs):
-        user = self.users.new(*args, **kwargs)
-        self.users_created.append(user)
+        try:
+            user = self._auth_client.users.new(*args, **kwargs)
+        except HTTPError as e:
+            raise ServiceError(str(e))
+
+        self._users_created.append(user)
         return user
 
     def edit_user(self, *args, **kwargs):
         # rollback system can be added here
-        self.users.edit(*args, **kwargs)
+        self.auth_client.users.edit(*args, **kwargs)
 
     def rollback(self):
-        for user in self.users_created:
-            self.users.delete(user['uuid'])
+        for user in self._users_created:
+            self._auth_client.users.delete(user['uuid'])
+
+    @classmethod
+    def from_config(cls, *args, **kwargs):
+        client = AuthClient(*args, **kwargs)
+        # 30 minutes should be enought to import all users
+        token = client.token.new(expiration=30 * 30)['token']
+        client.set_token(token)
+        return cls(client)
 
 
 def get_auth_client():
     client = g.get('auth_client_user_import')
     if not client:
-        client = g.auth_client_user_import = AuthClientProxy(**auth_config)
+        client = g.auth_client_user_import = AuthClientProxy.from_config(**auth_config)
     return client
 
 

--- a/wazo_confd/plugins/user_import/tests/test_auth_client.py
+++ b/wazo_confd/plugins/user_import/tests/test_auth_client.py
@@ -1,0 +1,37 @@
+# Copyright 2019 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from unittest import TestCase
+from unittest.mock import Mock, sentinel as s
+from requests import HTTPError
+from hamcrest import (
+    assert_that,
+    calling,
+    raises,
+)
+
+from xivo_dao.helpers.exception import ServiceError
+
+from ..auth_client import AuthClientProxy as Client
+
+
+class TestRollback(TestCase):
+    def setUp(self):
+        self.auth_client = Mock()
+        self.client = Client(self.auth_client)
+
+    def test_that_an_error_in_auth_will_raise_a_service_error(self):
+        self.auth_client.users.new.side_effect = HTTPError()
+
+        assert_that(
+            calling(self.client.new_user), raises(ServiceError),
+        )
+
+    def test_that_rollback_deletes_created_users(self):
+        self.auth_client.users.new.return_value = {'uuid': s.user_uuid}
+
+        self.client.new_user(uuid=s.user_uuid)
+
+        self.client.rollback()
+
+        self.auth_client.users.delete.assert_called_once_with(s.user_uuid)


### PR DESCRIPTION
if the creation of the auth user associated to a pbx user fails log the error
and keep working on the import.

This change has the following effect.

1. No 500 error because the error is handled
2. No leaked auth user which then cause 409 errors when trying to create users
3. Allow the auth users to be rolledback at the end of the import