### PR TITLE
wizard: add the provd_ready field to GET /wizard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 20.02
+
+* The GET on `1.1/wizard` not returns the `provd_ready` field
+
 ## 20.01
 
 * The voicemail `name` no longer change according to the user `firstname`/`lastname`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 20.02
 
-* The GET on `1.1/wizard` not returns the `provd_ready` field
+* The GET on `1.1/wizard` now returns the `configurable` and `configurable_status`' fields
 
 ## 20.01
 

--- a/integration_tests/suite/wizard/test_wizard.py
+++ b/integration_tests/suite/wizard/test_wizard.py
@@ -272,7 +272,11 @@ class TestWizardGet(IntegrationTest):
         data = copy.deepcopy(COMPLETE_POST_BODY)
 
         response = self.confd.wizard.get()
-        assert_that(response.item, has_entries(configured=False, provd_ready=True))
+        assert_that(response.item, has_entries(
+            configured=False,
+            configurable=True,
+            configurable_status=has_entries({'wazo-auth': 'ok', 'wazo-provd': 'ok'}),
+        ))
 
         response = self.confd.wizard.post(data)
         response.assert_ok()
@@ -283,7 +287,10 @@ class TestWizardGet(IntegrationTest):
         self.stop_service('provd')
 
         response = self.confd.wizard.get()
-        assert_that(response.item, has_entries(provd_ready=False))
+        assert_that(response.item, has_entries(
+            configurable=False,
+            configurable_status=has_entries({'wazo-provd': 'fail'}),
+        ))
 
 
 class TestWizardPost(IntegrationTest):

--- a/integration_tests/suite/wizard/test_wizard.py
+++ b/integration_tests/suite/wizard/test_wizard.py
@@ -272,11 +272,16 @@ class TestWizardGet(IntegrationTest):
         data = copy.deepcopy(COMPLETE_POST_BODY)
 
         response = self.confd.wizard.get()
-        assert_that(response.item, has_entries(
-            configured=False,
-            configurable=True,
-            configurable_status=has_entries({'wazo-auth': 'ok', 'wazo-provd': 'ok'}),
-        ))
+        assert_that(
+            response.item,
+            has_entries(
+                configured=False,
+                configurable=True,
+                configurable_status=has_entries(
+                    {'wazo-auth': 'ok', 'wazo-provd': 'ok'}
+                ),
+            ),
+        )
 
         response = self.confd.wizard.post(data)
         response.assert_ok()
@@ -287,10 +292,13 @@ class TestWizardGet(IntegrationTest):
         self.stop_service('provd')
 
         response = self.confd.wizard.get()
-        assert_that(response.item, has_entries(
-            configurable=False,
-            configurable_status=has_entries({'wazo-provd': 'fail'}),
-        ))
+        assert_that(
+            response.item,
+            has_entries(
+                configurable=False,
+                configurable_status=has_entries({'wazo-provd': 'fail'}),
+            ),
+        )
 
 
 class TestWizardPost(IntegrationTest):

--- a/integration_tests/suite/wizard/test_wizard.py
+++ b/integration_tests/suite/wizard/test_wizard.py
@@ -265,7 +265,7 @@ class TestWizardDefaultValue(IntegrationTest):
             assert_that(queries.sccp_has_language('en_US'))
 
 
-class TestWizard(IntegrationTest):
+class TestWizardGet(IntegrationTest):
     @mocks.sysconfd()
     @mocks.auth()
     def test_get(self, sysconfd, auth):
@@ -285,6 +285,8 @@ class TestWizard(IntegrationTest):
         response = self.confd.wizard.get()
         assert_that(response.item, has_entries(provd_ready=False))
 
+
+class TestWizardPost(IntegrationTest):
     @mocks.sysconfd()
     @mocks.auth()
     def test_post(self, sysconfd, auth):

--- a/wazo_confd/plugins/wizard/api.yml
+++ b/wazo_confd/plugins/wizard/api.yml
@@ -95,9 +95,12 @@ definitions:
       configured:
         type: boolean
         description: Whether Wazo has already been configured or not
-      provd_ready:
+      configurable:
         type: boolean
-        description: Whether wazo-provd is ready to receive requests or not
+        description: Whether all services which the wizard depends on are started or not
+      configurable_status:
+        type: object
+        description: A mapping of all dependencies and there statuses
   WizardDiscover:
     title: WizardDiscover
     properties:

--- a/wazo_confd/plugins/wizard/api.yml
+++ b/wazo_confd/plugins/wizard/api.yml
@@ -95,6 +95,9 @@ definitions:
       configured:
         type: boolean
         description: Whether Wazo has already been configured or not
+      provd_ready:
+        type: boolean
+        description: Whether wazo-provd is ready to receive requests or not
   WizardDiscover:
     title: WizardDiscover
     properties:

--- a/wazo_confd/plugins/wizard/resource.py
+++ b/wazo_confd/plugins/wizard/resource.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from flask import request
@@ -60,6 +60,7 @@ class WizardSchema(BaseSchema):
 
 class ConfiguredSchema(BaseSchema):
     configured = fields.Boolean()
+    provd_ready = fields.Boolean()
 
 
 class WizardResource(ErrorCatchingResource):

--- a/wazo_confd/plugins/wizard/resource.py
+++ b/wazo_confd/plugins/wizard/resource.py
@@ -60,7 +60,8 @@ class WizardSchema(BaseSchema):
 
 class ConfiguredSchema(BaseSchema):
     configured = fields.Boolean()
-    provd_ready = fields.Boolean()
+    configurable = fields.Boolean()
+    configurable_status = fields.Dict()
 
 
 class WizardResource(ErrorCatchingResource):

--- a/wazo_confd/plugins/wizard/service.py
+++ b/wazo_confd/plugins/wizard/service.py
@@ -69,7 +69,9 @@ class WizardService:
 
         return {
             'configured': wizard_db.get_xivo_configured().configured,
-            'configurable': all([state == 'ok' for state in configurable_status.values()]),
+            'configurable': all(
+                [state == 'ok' for state in configurable_status.values()]
+            ),
             'configurable_status': configurable_status,
         }
 


### PR DESCRIPTION
GET /wizard now include a boolean indicating if provd is ready to handle HTTP
requests. This is useful because the POST on /wizard will fail if provd is not
started.