### PR TITLE
integration tests: fix random number colliding with fixed number

### DIFF
--- a/integration_tests/suite/base/test_pagings.py
+++ b/integration_tests/suite/base/test_pagings.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import (
@@ -245,7 +245,7 @@ def test_delete_multi_tenant(main, sub):
     response.assert_deleted()
 
 
-@fixtures.paging()
+@fixtures.paging(number='667')
 def test_bus_events(paging):
     yield s.check_bus_event, 'config.pagings.created', confd.pagings.post, {
         'number': '666'


### PR DESCRIPTION
Why:

* The paging fixture is created with a random number. If this number is
equal to the fixed 666 number of the test, then the test fails.

How:

* Use a fixed number for the fixture also.