### PR TITLE
accessd_feature: restart phoned when update values

### DIFF
--- a/wazo_confd/_sysconfd.py
+++ b/wazo_confd/_sysconfd.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2013-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import requests
@@ -78,6 +78,9 @@ class SysconfdPublisher:
 
     def restart_provd(self):
         self.service_action('wazo-provd', 'restart')
+
+    def restart_phoned(self):
+        self.service_action('wazo-phoned', 'restart')
 
     def dhcpd_update(self):
         url = "{}/dhcpd_update".format(self.base_url)

--- a/wazo_confd/plugins/access_feature/notifier.py
+++ b/wazo_confd/plugins/access_feature/notifier.py
@@ -1,4 +1,4 @@
-# Copyright 2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from xivo_bus.resources.access_feature.event import (
@@ -7,7 +7,7 @@ from xivo_bus.resources.access_feature.event import (
     EditAccessFeatureEvent,
 )
 
-from wazo_confd import bus
+from wazo_confd import bus, sysconfd
 
 from .schema import AccessFeatureSchema
 
@@ -16,21 +16,25 @@ class AccessFeatureNotifier:
 
     schema = AccessFeatureSchema(exclude=['links'])
 
-    def __init__(self, bus):
+    def __init__(self, bus, sysconfd):
         self.bus = bus
+        self.sysconfd = sysconfd
 
     def created(self, access_feature):
+        self.sysconfd.restart_phoned()
         event = CreateAccessFeatureEvent(self.schema.dump(access_feature))
         self.bus.send_bus_event(event)
 
     def edited(self, access_feature):
+        self.sysconfd.restart_phoned()
         event = EditAccessFeatureEvent(self.schema.dump(access_feature))
         self.bus.send_bus_event(event)
 
     def deleted(self, access_feature):
+        self.sysconfd.restart_phoned()
         event = DeleteAccessFeatureEvent(self.schema.dump(access_feature))
         self.bus.send_bus_event(event)
 
 
 def build_notifier():
-    return AccessFeatureNotifier(bus)
+    return AccessFeatureNotifier(bus, sysconfd)

--- a/wazo_confd/plugins/access_feature/tests/test_notifier.py
+++ b/wazo_confd/plugins/access_feature/tests/test_notifier.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import unittest
@@ -16,9 +16,15 @@ from ..notifier import AccessFeatureNotifier
 class TestAccessFeatureNotifier(unittest.TestCase):
     def setUp(self):
         self.bus = Mock()
+        self.sysconfd = Mock()
         self.access_feature = {'id': 123}
 
-        self.notifier = AccessFeatureNotifier(self.bus)
+        self.notifier = AccessFeatureNotifier(self.bus, self.sysconfd)
+
+    def test_when_access_feature_created_then_phoned_restarted(self):
+        self.notifier.created(self.access_feature)
+
+        self.sysconfd.restart_phoned.assert_called_once()
 
     def test_when_access_feature_created_then_event_sent_on_bus(self):
         expected_event = CreateAccessFeatureEvent(self.access_feature)
@@ -27,12 +33,22 @@ class TestAccessFeatureNotifier(unittest.TestCase):
 
         self.bus.send_bus_event.assert_called_once_with(expected_event)
 
+    def test_when_access_feature_edited_then_phoned_restarted(self):
+        self.notifier.edited(self.access_feature)
+
+        self.sysconfd.restart_phoned.assert_called_once()
+
     def test_when_access_feature_edited_then_event_sent_on_bus(self):
         expected_event = EditAccessFeatureEvent(self.access_feature)
 
         self.notifier.edited(self.access_feature)
 
         self.bus.send_bus_event.assert_called_once_with(expected_event)
+
+    def test_when_access_feature_deleted_then_phoned_restarted(self):
+        self.notifier.deleted(self.access_feature)
+
+        self.sysconfd.restart_phoned.assert_called_once()
 
     def test_when_access_feature_deleted_then_event_sent_on_bus(self):
         expected_event = DeleteAccessFeatureEvent(self.access_feature)


### PR DESCRIPTION
It is a temporary solution. xivo-sysconfd should listen on events and
restart service asynchronous ... or better, phoned should listen on
events and reload service according ... or even better, phoned should
handle its own configuration.

Summary: this is one of the worst solution that can be done

EDIT: but the best for the time involved 