### PR TITLE
pjsip doc: remove internal fields from the cached doc

### DIFF
--- a/integration_tests/suite/base/test_pjsip_doc.py
+++ b/integration_tests/suite/base/test_pjsip_doc.py
@@ -1,7 +1,7 @@
 # Copyright 2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from hamcrest import assert_that, has_entries, starts_with
+from hamcrest import all_of, assert_that, has_entries, starts_with, not_
 from . import confd
 
 
@@ -14,16 +14,21 @@ def test_get():
             aor=has_entries(),
             auth=has_entries(),
             contact=has_entries(),
-            endpoint=has_entries(
-                direct_media_method=has_entries(
-                    name='direct_media_method',
-                    default='invite',
-                    synopsis='Direct Media method type',
-                    description=starts_with('Method for setting up'),
-                    choices=has_entries(
-                        invite='', reinvite='Alias for the "invite" value.', update='',
-                    ),
-                )
+            endpoint=all_of(
+                has_entries(
+                    direct_media_method=has_entries(
+                        name='direct_media_method',
+                        default='invite',
+                        synopsis='Direct Media method type',
+                        description=starts_with('Method for setting up'),
+                        choices=has_entries(
+                            invite='',
+                            reinvite='Alias for the "invite" value.',
+                            update='',
+                        ),
+                    )
+                ),
+                not_(has_entries(type='endpoint')),
             ),
             system=has_entries(),
             transport=has_entries(),

--- a/wazo_confd/plugins/pjsip/plugin.py
+++ b/wazo_confd/plugins/pjsip/plugin.py
@@ -27,12 +27,15 @@ class PJSIPDoc:
         return variable in self.get_section_variables(section_name)
 
     def get_section_variables(self, section_name):
-        return self.content.get(section_name, {}).keys() - self._internal_fields
+        return self.content.get(section_name, {}).keys()
 
     @property
     def content(self):
         if self._content is None:
             self._content = self._fetch()
+            for section_name in self._content.keys():
+                for field in self._internal_fields:
+                    self._content[section_name].pop(field, None)
         return self._content
 
     def _fetch(self):


### PR DESCRIPTION
content is served to the /asterisk/pjsip/doc keeping the type field there and
not accepting it in a PUT on /asterisk/pjsip/global or /asterisk/pjsip/system is
misleading