### PR TITLE
register sip: only allow configured transports

### DIFF
--- a/integration_tests/suite/base/test_registers_sip.py
+++ b/integration_tests/suite/base/test_registers_sip.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import assert_that, empty, has_entries, none, not_
@@ -32,7 +32,10 @@ def test_put_errors(register_sip):
 
 
 def error_checks(url):
-    yield s.check_bogus_field_returns_error, url, 'transport', 'invalid'
+    yield s.check_bogus_field_returns_error, url, 'transport', 'invalid', {
+        'remote_host': 'foo',
+        'sip_username': 'foo',
+    }
     yield s.check_bogus_field_returns_error, url, 'transport', 123
     yield s.check_bogus_field_returns_error, url, 'transport', True
     yield s.check_bogus_field_returns_error, url, 'transport', []
@@ -119,7 +122,8 @@ def test_create_minimal_parameters():
     )
 
 
-def test_create_all_parameters():
+@fixtures.transport(name='tcp')
+def test_create_all_parameters(transport):
     parameters = dict(
         transport='tcp',
         sip_username='sip-username',
@@ -145,8 +149,9 @@ def test_edit_minimal_parameters(register_sip):
     response.assert_updated()
 
 
+@fixtures.transport(name='tcp')
 @fixtures.register_sip()
-def test_edit_all_parameters(register_sip):
+def test_edit_all_parameters(transport, register_sip):
     parameters = dict(
         transport='tcp',
         sip_username='sip-username',

--- a/wazo_confd/plugins/register_sip/resource.py
+++ b/wazo_confd/plugins/register_sip/resource.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import re
@@ -6,7 +6,7 @@ import re
 from flask import url_for, request
 from marshmallow import fields, post_load, pre_dump, validates_schema
 from marshmallow.exceptions import ValidationError
-from marshmallow.validate import OneOf, Range, Regexp
+from marshmallow.validate import Range, Regexp
 
 from xivo_dao.alchemy.staticsip import StaticSIP
 
@@ -36,9 +36,7 @@ INVALID_CALLBACK_EXTENSION = r'^[^~ ]*$'
 
 class RegisterSIPSchema(BaseSchema):
     id = fields.Integer(dump_only=True)
-    transport = fields.String(
-        validate=OneOf(['udp', 'tcp', 'tls', 'ws', 'wss']), allow_none=True
-    )
+    transport = fields.String(allow_none=True)
     sip_username = fields.String(validate=Regexp(INVALID_CHAR), required=True)
     auth_username = fields.String(validate=Regexp(INVALID_CHAR), allow_none=True)
     auth_password = fields.String(validate=Regexp(INVALID_CHAR), allow_none=True)

--- a/wazo_confd/plugins/register_sip/validator.py
+++ b/wazo_confd/plugins/register_sip/validator.py
@@ -1,8 +1,54 @@
-# Copyright 2017-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from wazo_confd.helpers.validator import ValidationGroup
+import re
+
+from xivo_dao.resources.pjsip_transport import dao as transport_dao
+from wazo_confd.helpers.validator import ValidationGroup, Validator
+from xivo_dao.helpers import errors
+from xivo_dao.helpers.exception import NotFoundError
+
+REGISTER_REGEX = re.compile(
+    r'''^
+                            (?:(?P<transport>.*)://)?
+                            (?P<sip_username>[^:/]*)
+                            (?::(?P<auth_password>[^:/]*))?
+                            (?::(?P<auth_username>[^:/]*))?
+                            @
+                            (?P<remote_host>[^:~/]*)
+                            (?::(?P<remote_port>\d*))?
+                            (?:/(?P<callback_extension>[^~]*))?
+                            (?:~(?P<expiration>\d*))?
+                            $''',
+    re.VERBOSE,
+)
+
+
+class GetTransportValidator(Validator):
+    def validate(self, model):
+        self._validate(model)
+
+    def validate_with_tenant_uuids(self, model, tenant_uuids):
+        self._validate(model, tenant_uuids)
+
+    def _validate(self, model, tenant_uuids=None):
+        register = REGISTER_REGEX.match(model.var_val)
+        result = register.groupdict()
+        transport_name = result['transport']
+        if not transport_name:
+            return
+
+        try:
+            if tenant_uuids is None:
+                transport_dao.get_by(name=transport_name)
+            else:
+                transport_dao.get_by(name=transport_name, tenant_uuids=tenant_uuids)
+        except NotFoundError:
+            metadata = {'transport': transport_name}
+            raise errors.param_not_found('transport', 'Transport', **metadata)
 
 
 def build_validator():
-    return ValidationGroup()
+    return ValidationGroup(
+        create=[GetTransportValidator()], edit=[GetTransportValidator()],
+    )


### PR DESCRIPTION
I did not go all the way with a foreign key to allow transports to be renamed. This code will be removed pretty soon.