### PR TITLE
devices: add the device id on the corrupt device error

### DIFF
--- a/wazo_confd/plugins/device/model.py
+++ b/wazo_confd/plugins/device/model.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 
@@ -25,7 +25,9 @@ class Device:
     def config(self):
         if self._config is None:
             raise Exception(
-                "Provd Device has no config associated. The device may be corrupt"
+                "Provd Device({}) has no config associated. The device may be corrupt".format(
+                    self.id
+                )
             )
         return self._config
 


### PR DESCRIPTION
When you have a device with a config that does not exists anymore you GET a 500
when doing a GET on /devices with no indication of the bad device. From that
point you need to have a good understanding of wazo-provd-cli to be able to find
that corrupted device and remove it.