### PR TITLE
nginx: increase timeout for ha endpoint

### DIFF
--- a/etc/nginx/locations/https-available/wazo-confd
+++ b/etc/nginx/locations/https-available/wazo-confd
@@ -1,10 +1,9 @@
 location ^~ /api/confd/ {
     proxy_pass http://127.0.0.1:9486/;
 
-    location ^~ /api/confd/1.1/users/import {
-        proxy_pass http://127.0.0.1:9486/1.1/users/import;
-        proxy_read_timeout 180s;
-    }
+    # Mostly used for /user/import and /ha but can be useful for other
+    # endpoints on slow host (e.i. /devices)
+    proxy_read_timeout 180s;
 
     location ~ /api/confd/1.1/(moh|sounds)/(.*)/files {
         proxy_pass http://127.0.0.1:9486/1.1/$1/$2/files;


### PR DESCRIPTION
I don't know if it's the right choice (add regex) or if we should only set the same timeout for all endpoints. The same logic can also be applied to the `client_max_body_size`