### PR TITLE
use provd without ssl by default

### DIFF
--- a/etc/wazo-confd/config.yml
+++ b/etc/wazo-confd/config.yml
@@ -68,6 +68,8 @@ consul:
 provd:
     host: localhost
     port: 8666
+    prefix: null
+    https: false
 
 #xivo-sysconfd connection information
 sysconfd:

--- a/integration_tests/assets/etc/wazo-confd/conf.d/50-default.yml
+++ b/integration_tests/assets/etc/wazo-confd/conf.d/50-default.yml
@@ -7,21 +7,11 @@ auth:
     host: auth
 ari:
     host: ari
-    port: 5039
 bus:
-    username: guest
-    password: guest
     host: rabbitmq
-    port: 5672
-    exchange_name: xivo
-    exchange_type: topic
-    exchange_durable: True
 provd:
     host: provd
-    port: 8666
-    verify_certificate: False
 sysconfd:
     host: sysconfd
-    port: 8668
 service_discovery:
   enabled: false

--- a/integration_tests/suite/helpers/provd.py
+++ b/integration_tests/suite/helpers/provd.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import docker
@@ -165,5 +165,5 @@ class ProvdHelper:
 
 
 def create_helper(host='localhost', port='8666', token='valid-token-multitenant'):
-    client = ProvdClient(host=host, port=port, verify_certificate=False, token=token)
+    client = ProvdClient(host=host, port=port, prefix='', https=False, token=token)
     return ProvdHelper(client)

--- a/wazo_confd/config.py
+++ b/wazo_confd/config.py
@@ -54,11 +54,7 @@ DEFAULT_CONFIG = {
         'exchange_durable': True,
     },
     'consul': {'scheme': 'http', 'host': 'localhost', 'port': 8500},
-    'provd': {
-        'host': 'localhost',
-        'port': 8666,
-        'verify_certificate': '/usr/share/xivo-certs/server.crt',
-    },
+    'provd': {'host': 'localhost', 'port': 8666, 'prefix': None, 'https': False},
     'sysconfd': {'host': 'localhost', 'port': '8668'},
     'enabled_plugins': {
         'access_feature': True,


### PR DESCRIPTION
Depends-on: https://github.com/wazo-platform/wazo-provd/pull/28