### PR TITLE
WAZO-1809: add tenant_uuid to forward and service events

### DIFF
--- a/wazo_confd/plugins/user/notifier.py
+++ b/wazo_confd/plugins/user/notifier.py
@@ -75,7 +75,9 @@ class UserServiceNotifier:
         services = schema.dump(user)
         for type_ in schema.types:
             service = services.get(type_, services)
-            event = EditUserServiceEvent(user.id, user.uuid, type_, service['enabled'])
+            event = EditUserServiceEvent(
+                user.id, user.uuid, user.tenant_uuid, type_, service['enabled']
+            )
             self.bus.send_bus_event(
                 event, headers={'user_uuid:{uuid}'.format(uuid=user.uuid): True}
             )

--- a/wazo_confd/plugins/user/notifier.py
+++ b/wazo_confd/plugins/user/notifier.py
@@ -96,7 +96,12 @@ class UserForwardNotifier:
         for type_ in schema.types:
             forward = forwards.get(type_, forwards)
             event = EditUserForwardEvent(
-                user.id, user.uuid, type_, forward['enabled'], forward['destination']
+                user.id,
+                user.uuid,
+                user.tenant_uuid,
+                type_,
+                forward['enabled'],
+                forward['destination'],
             )
             self.bus.send_bus_event(
                 event, headers={'user_uuid:{uuid}'.format(uuid=user.uuid): True}

--- a/wazo_confd/plugins/user/tests/test_notifier.py
+++ b/wazo_confd/plugins/user/tests/test_notifier.py
@@ -110,7 +110,7 @@ class TestUserServiceNotifier(unittest.TestCase):
     def setUp(self):
         self.bus = Mock()
         self.user = Mock(
-            User, uuid='1234-abcd', dnd_enabled=True, incallfilter_enabled=True
+            User, uuid='1234-abcd', tenant_uuid='5678-efgh', dnd_enabled=True, incallfilter_enabled=True
         )
 
         self.notifier = UserServiceNotifier(self.bus)
@@ -118,7 +118,11 @@ class TestUserServiceNotifier(unittest.TestCase):
     def test_when_user_service_dnd_edited_then_event_sent_on_bus(self):
         schema = ServiceDNDSchema()
         expected_event = EditUserServiceEvent(
-            self.user.id, self.user.uuid, schema.types[0], self.user.dnd_enabled
+            self.user.id,
+            self.user.uuid,
+            self.user.tenant_uuid,
+            schema.types[0],
+            self.user.dnd_enabled,
         )
 
         self.notifier.edited(self.user, schema)
@@ -133,6 +137,7 @@ class TestUserServiceNotifier(unittest.TestCase):
         expected_event = EditUserServiceEvent(
             self.user.id,
             self.user.uuid,
+            self.user.tenant_uuid,
             schema.types[0],
             self.user.incallfilter_enabled,
         )

--- a/wazo_confd/plugins/user/tests/test_notifier.py
+++ b/wazo_confd/plugins/user/tests/test_notifier.py
@@ -110,7 +110,11 @@ class TestUserServiceNotifier(unittest.TestCase):
     def setUp(self):
         self.bus = Mock()
         self.user = Mock(
-            User, uuid='1234-abcd', tenant_uuid='5678-efgh', dnd_enabled=True, incallfilter_enabled=True
+            User,
+            uuid='1234-abcd',
+            tenant_uuid='5678-efgh',
+            dnd_enabled=True,
+            incallfilter_enabled=True,
         )
 
         self.notifier = UserServiceNotifier(self.bus)

--- a/wazo_confd/plugins/user/tests/test_notifier.py
+++ b/wazo_confd/plugins/user/tests/test_notifier.py
@@ -157,6 +157,7 @@ class TestUserForwardNotifier(unittest.TestCase):
             User,
             id='1234',
             uuid='1234-abcd',
+            tenant_uuid='5678-efgh',
             busy_enabled=True,
             busy_destination='123',
             noanswer_enabled=False,
@@ -172,6 +173,7 @@ class TestUserForwardNotifier(unittest.TestCase):
         expected_event = EditUserForwardEvent(
             self.user.id,
             self.user.uuid,
+            self.user.tenant_uuid,
             'busy',
             self.user.busy_enabled,
             self.user.busy_destination,
@@ -189,6 +191,7 @@ class TestUserForwardNotifier(unittest.TestCase):
         expected_event = EditUserForwardEvent(
             self.user.id,
             self.user.uuid,
+            self.user.tenant_uuid,
             'noanswer',
             self.user.noanswer_enabled,
             self.user.noanswer_destination,
@@ -206,6 +209,7 @@ class TestUserForwardNotifier(unittest.TestCase):
         expected_event = EditUserForwardEvent(
             self.user.id,
             self.user.uuid,
+            self.user.tenant_uuid,
             'unconditional',
             self.user.unconditional_enabled,
             self.user.unconditional_destination,
@@ -225,6 +229,7 @@ class TestUserForwardNotifier(unittest.TestCase):
         expected_busy_event = EditUserForwardEvent(
             self.user.id,
             self.user.uuid,
+            self.user.tenant_uuid,
             'busy',
             self.user.busy_enabled,
             self.user.busy_destination,
@@ -232,6 +237,7 @@ class TestUserForwardNotifier(unittest.TestCase):
         expected_noanswer_event = EditUserForwardEvent(
             self.user.id,
             self.user.uuid,
+            self.user.tenant_uuid,
             'noanswer',
             self.user.noanswer_enabled,
             self.user.noanswer_destination,
@@ -239,6 +245,7 @@ class TestUserForwardNotifier(unittest.TestCase):
         expected_unconditional_event = EditUserForwardEvent(
             self.user.id,
             self.user.uuid,
+            self.user.tenant_uuid,
             'unconditional',
             self.user.unconditional_enabled,
             self.user.unconditional_destination,


### PR DESCRIPTION
Depends-On: https://github.com/wazo-platform/xivo-bus/pull/23