### PR TITLE
pjsip: rename global-trunk to trunk-with-registration

### DIFF
--- a/integration_tests/suite/base/test_event_handlers.py
+++ b/integration_tests/suite/base/test_event_handlers.py
@@ -30,7 +30,7 @@ def test_create_default_templates_when_not_exist():
                 has_entries(label='global'),
                 has_entries(label='webrtc'),
                 has_entries(label='webrtc_video'),
-                has_entries(label='trunk_with_registration'),
+                has_entries(label='registration_trunk'),
                 has_entries(label='twilio_trunk'),
             ),
         )

--- a/integration_tests/suite/base/test_event_handlers.py
+++ b/integration_tests/suite/base/test_event_handlers.py
@@ -30,7 +30,7 @@ def test_create_default_templates_when_not_exist():
                 has_entries(label='global'),
                 has_entries(label='webrtc'),
                 has_entries(label='webrtc_video'),
-                has_entries(label='global_trunk'),
+                has_entries(label='trunk_with_registration'),
                 has_entries(label='twilio_trunk'),
             ),
         )

--- a/integration_tests/suite/base/test_sync_db.py
+++ b/integration_tests/suite/base/test_sync_db.py
@@ -69,7 +69,7 @@ def test_create_default_templates_when_not_exist():
                 transport=has_entries(uuid=transport_wss['uuid']),
             ),
             has_entries(label='webrtc_video'),
-            has_entries(label='trunk_with_registration'),
+            has_entries(label='registration_trunk'),
             has_entries(label='twilio_trunk'),
         ),
     )

--- a/integration_tests/suite/base/test_sync_db.py
+++ b/integration_tests/suite/base/test_sync_db.py
@@ -69,7 +69,7 @@ def test_create_default_templates_when_not_exist():
                 transport=has_entries(uuid=transport_wss['uuid']),
             ),
             has_entries(label='webrtc_video'),
-            has_entries(label='global_trunk'),
+            has_entries(label='trunk_with_registration'),
             has_entries(label='twilio_trunk'),
         ),
     )

--- a/wazo_confd/plugins/event_handlers/service.py
+++ b/wazo_confd/plugins/event_handlers/service.py
@@ -133,8 +133,8 @@ class DefaultSIPTemplateService:
             tenant.webrtc_video_sip_template_uuid,
         )
 
-        trunk_with_registration_config = {
-            'label': 'trunk_with_registration',
+        registration_trunk_config = {
+            'label': 'registration_trunk',
             'template': True,
             'tenant_uuid': tenant.uuid,
             'transport': None,
@@ -154,9 +154,9 @@ class DefaultSIPTemplateService:
             'outbound_auth_section_options': [],
             'templates': [global_template],
         }
-        trunk_with_registration_template = self.create_or_merge_sip_template(
-            trunk_with_registration_config,
-            tenant.trunk_with_registration_sip_template_uuid,
+        registration_trunk_template = self.create_or_merge_sip_template(
+            registration_trunk_config,
+            tenant.registration_trunk_sip_template_uuid,
         )
 
         twilio_trunk_config = {
@@ -205,7 +205,7 @@ class DefaultSIPTemplateService:
                 ['match', '54.244.51.0'],
             ],
             'outbound_auth_section_options': [],
-            'templates': [trunk_with_registration_template],
+            'templates': [registration_trunk_template],
         }
         twilio_trunk_template = self.create_or_merge_sip_template(
             twilio_trunk_config,
@@ -215,8 +215,6 @@ class DefaultSIPTemplateService:
         tenant.global_sip_template_uuid = global_template.uuid
         tenant.webrtc_sip_template_uuid = webrtc_template.uuid
         tenant.webrtc_video_sip_template_uuid = webrtc_video_template.uuid
-        tenant.trunk_with_registration_sip_template_uuid = (
-            trunk_with_registration_template.uuid
-        )
+        tenant.registration_trunk_sip_template_uuid = registration_trunk_template.uuid
         tenant.twilio_trunk_sip_template_uuid = twilio_trunk_template.uuid
         tenant.sip_templates_generated = True

--- a/wazo_confd/plugins/event_handlers/service.py
+++ b/wazo_confd/plugins/event_handlers/service.py
@@ -133,8 +133,8 @@ class DefaultSIPTemplateService:
             tenant.webrtc_video_sip_template_uuid,
         )
 
-        global_trunk_config = {
-            'label': 'global_trunk',
+        trunk_with_registration_config = {
+            'label': 'trunk_with_registration',
             'template': True,
             'tenant_uuid': tenant.uuid,
             'transport': None,
@@ -154,9 +154,9 @@ class DefaultSIPTemplateService:
             'outbound_auth_section_options': [],
             'templates': [global_template],
         }
-        global_trunk_template = self.create_or_merge_sip_template(
-            global_trunk_config,
-            tenant.global_trunk_sip_template_uuid,
+        trunk_with_registration_template = self.create_or_merge_sip_template(
+            trunk_with_registration_config,
+            tenant.trunk_with_registration_sip_template_uuid,
         )
 
         twilio_trunk_config = {
@@ -205,7 +205,7 @@ class DefaultSIPTemplateService:
                 ['match', '54.244.51.0'],
             ],
             'outbound_auth_section_options': [],
-            'templates': [global_trunk_template],
+            'templates': [trunk_with_registration_template],
         }
         twilio_trunk_template = self.create_or_merge_sip_template(
             twilio_trunk_config,
@@ -215,6 +215,8 @@ class DefaultSIPTemplateService:
         tenant.global_sip_template_uuid = global_template.uuid
         tenant.webrtc_sip_template_uuid = webrtc_template.uuid
         tenant.webrtc_video_sip_template_uuid = webrtc_video_template.uuid
-        tenant.global_trunk_sip_template_uuid = global_trunk_template.uuid
+        tenant.trunk_with_registration_sip_template_uuid = (
+            trunk_with_registration_template.uuid
+        )
         tenant.twilio_trunk_sip_template_uuid = twilio_trunk_template.uuid
         tenant.sip_templates_generated = True


### PR DESCRIPTION
this template only adds registration options and generate warnings in the CLI
when trunks do not have a registration