### PR TITLE
registrar: fix offset/limit query

### DIFF
--- a/integration_tests/suite/base/test_registrars.py
+++ b/integration_tests/suite/base/test_registrars.py
@@ -1,4 +1,4 @@
-# Copyright 2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import re
@@ -119,6 +119,9 @@ def test_sorting_offset_limit(registrar1, registrar2):
     yield s.check_sorting, url, registrar1, registrar2, 'proxy_main_host', '99.20.30.'
     yield s.check_sorting, url, registrar1, registrar2, 'name', 'SortRegistrar'
     yield s.check_sorting, url, registrar1, registrar2, 'main_port', 'SortRegistrar'
+
+    yield s.check_offset, url, registrar1, registrar2, 'name', 'Sort'
+    yield s.check_limit, url, registrar1, registrar2, 'name', 'Sort'
 
 
 @fixtures.registrar()

--- a/wazo_confd/plugins/registrar/dao.py
+++ b/wazo_confd/plugins/registrar/dao.py
@@ -107,7 +107,7 @@ class RegistrarDao:
         return registrars
 
     def _paginate_registrars(self, registrars, offset=0, limit=None):
-        if limit:
+        if limit and (offset + limit) < len(registrars):
             return registrars[offset : offset + limit]
         return registrars[offset:]
 
@@ -123,14 +123,12 @@ class RegistrarDao:
         return registrar
 
     def search(self, **criteria):
+        offset = criteria.pop('offset', 0)
+        limit = criteria.pop('limit', None)
         registrars = self._find_registrars(criteria)
         if registrars:
             total = len(registrars)
-            registrars = self._paginate_registrars(
-                registrars,
-                criteria.get('offset', 0),
-                criteria.get('limit'),
-            )
+            registrars = self._paginate_registrars(registrars, offset, limit)
         else:
             registrars = []
             total = 0


### PR DESCRIPTION
it was overwritten by a filter that always returned empty list