### PR TITLE
Wazo 2043 external app fallback

### DIFF
--- a/wazo_confd/plugins/endpoint_sip/api.yml
+++ b/wazo_confd/plugins/endpoint_sip/api.yml
@@ -237,7 +237,7 @@ parameters:
     description: |
       Different view of the SIP endpoint
 
-      The `default` view, when the argument is ommited, is to include only options that
+      The `default` view, when the argument is omitted, is to include only options that
       are defined on the specified endpoint.
 
       The `merged` view includes all options from included templates.

--- a/wazo_confd/plugins/user_external_app/api.yml
+++ b/wazo_confd/plugins/user_external_app/api.yml
@@ -15,6 +15,7 @@ paths:
       - $ref: '#/parameters/limit'
       - $ref: '#/parameters/offset'
       - $ref: '#/parameters/search'
+      - $ref: '#/parameters/user_external_app_view'
       responses:
         '200':
           description: User external apps list
@@ -56,6 +57,7 @@ paths:
       - $ref: '#/parameters/tenantuuid'
       - $ref: '#/parameters/useruuid'
       - $ref: '#/parameters/externalappname'
+      - $ref: '#/parameters/user_external_app_view'
       responses:
         '200':
           description: External App
@@ -104,6 +106,26 @@ paths:
           $ref: '#/responses/DeleteError'
         '404':
           $ref: '#/responses/NotFoundError'
+
+parameters:
+  user_external_app_view:
+    required: false
+    type: string
+    name: view
+    enum:
+      - fallback
+    in: query
+    description: |
+      Different view of the external app endpoint
+
+      The `default` view, when the argument is omitted, is to return the user value for this
+      external app
+
+      The `fallback` view return the user value for this external app, but if not found, will
+      fallback to the tenant configured value
+
+      **WARNING**: Using fallback view on list will disabled all pagination and search features
+
 definitions:
   UserExternalApp:
     title: UserExternalApp

--- a/wazo_confd/plugins/user_external_app/schema.py
+++ b/wazo_confd/plugins/user_external_app/schema.py
@@ -2,9 +2,13 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from marshmallow import fields
-from marshmallow.validate import Length
+from marshmallow.validate import Length, OneOf
 
 from wazo_confd.helpers.mallow import BaseSchema
+
+
+class GETQueryStringSchema(BaseSchema):
+    view = fields.String(validate=OneOf(['fallback']), missing=None)
 
 
 class UserExternalAppSchema(BaseSchema):

--- a/wazo_confd/plugins/user_external_app/service.py
+++ b/wazo_confd/plugins/user_external_app/service.py
@@ -1,6 +1,8 @@
 # Copyright 2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+from xivo_dao.helpers import errors
+from xivo_dao.resources.external_app import dao as external_app_dao
 from xivo_dao.resources.user_external_app import dao as user_external_app_dao
 
 from wazo_confd.helpers.resource import CRUDService
@@ -10,16 +12,40 @@ from .validator import build_validator
 
 
 class UserExternalAppService(CRUDService):
-    def search(self, user_uuid, parameters):
+    def __init__(self, dao, external_app_dao, validator, notifier):
+        self.dao = dao
+        self.external_app_dao = external_app_dao
+        self.validator = validator
+        self.notifier = notifier
+
+    def search(self, user_uuid, tenant_uuid, parameters):
+        if 'fallback' == parameters.get('view'):
+            # NOTE(fblackburn): pagination and sorting are disabled with fallback
+            _, result_by_user = self.dao.search(user_uuid)
+            params = {'tenant_uuids': [tenant_uuid]}
+            _, result_by_tenant = self.external_app_dao.search(**params)
+            result = {app.name: app for app in result_by_tenant + result_by_user}
+            return len(result.values()), result.values()
+
         return self.dao.search(user_uuid, **parameters)
 
-    def get(self, user_uuid, external_app_name):
-        return self.dao.get(user_uuid, external_app_name)
+    def get(self, user_uuid, tenant_uuid, name, view=None):
+        result = self.dao.find(user_uuid, name)
+        if result:
+            return result
+
+        if view == 'fallback':
+            result = self.external_app_dao.find(name, tenant_uuids=[tenant_uuid])
+            if result:
+                return result
+
+        raise errors.not_found('UserExternalApp', name=name)
 
 
 def build_service():
     return UserExternalAppService(
         user_external_app_dao,
+        external_app_dao,
         build_validator(),
         build_notifier(),
     )


### PR DESCRIPTION
About the `Why did you add a view=fallback on listing`:
I think it's a nice feature to have and doesn't require much effort while adding the `get`. Moreover, if limitations are documented properly, then why not.
But I don't have a strong opinion, if someone think it should not be implemented now, I have no objection to remove this part (sorry to not have separated my commits)