### PR TITLE
Pull request for fix-external-app

### DIFF
--- a/integration_tests/suite/base/test_external_apps.py
+++ b/integration_tests/suite/base/test_external_apps.py
@@ -125,7 +125,7 @@ def test_get_multi_tenant(main, sub):
     response.assert_match(404, e.not_found(resource='ExternalApp'))
 
     response = confd.external.apps(sub['name']).get(wazo_tenant=MAIN_TENANT)
-    assert_that(response.item, has_entries(**sub))
+    response.assert_match(404, e.not_found(resource='ExternalApp'))
 
 
 def test_create_minimal_parameters():
@@ -188,7 +188,7 @@ def test_edit_multi_tenant(main, sub):
     response.assert_match(404, e.not_found(resource='ExternalApp'))
 
     response = confd.external.apps(sub['name']).put(wazo_tenant=MAIN_TENANT)
-    response.assert_updated()
+    response.assert_match(404, e.not_found(resource='ExternalApp'))
 
 
 @fixtures.external_app()
@@ -206,7 +206,7 @@ def test_delete_multi_tenant(main, sub):
     response.assert_match(404, e.not_found(resource='ExternalApp'))
 
     response = confd.external.apps(sub['name']).delete(wazo_tenant=MAIN_TENANT)
-    response.assert_deleted()
+    response.assert_match(404, e.not_found(resource='ExternalApp'))
 
 
 def test_bus_events():

--- a/integration_tests/suite/base/test_external_apps.py
+++ b/integration_tests/suite/base/test_external_apps.py
@@ -153,6 +153,14 @@ def test_create_all_parameters():
     confd.external.apps(response.item['name']).delete().assert_deleted()
 
 
+@fixtures.external_app(wazo_tenant=MAIN_TENANT)
+def test_create_multi_tenant_with_same_name(main):
+    response = confd.external.apps(main['name']).post(wazo_tenant=SUB_TENANT)
+    response.assert_created('external_apps', location='external/apps')
+
+    confd.external.apps(main['name']).delete().assert_deleted()
+
+
 @fixtures.external_app()
 def test_edit_minimal_parameters(external_app):
     response = confd.external.apps(external_app['name']).put()

--- a/wazo_confd/plugins/external_app/resource.py
+++ b/wazo_confd/plugins/external_app/resource.py
@@ -37,9 +37,6 @@ class ExternalAppItem(ItemResource):
         return {'Location': url_for('external_apps', name=app.name, _external=True)}
 
     def add_tenant_to_form(self, form):
-        if not self._has_write_tenant_uuid():
-            return form
-
         tenant = Tenant.autodetect()
         tenant_dao.find_or_create_tenant(tenant.uuid)
         form['tenant_uuid'] = tenant.uuid
@@ -67,3 +64,8 @@ class ExternalAppItem(ItemResource):
     @required_acl('confd.external.apps.{name}.delete')
     def delete(self, name):
         return super().delete(name)
+
+    def _add_tenant_uuid(self):
+        # NOTE(fblackburn): Do not cross tenant when name is an identifier
+        tenant_uuids = self._build_tenant_list({'recurse': False})
+        return {'tenant_uuids': tenant_uuids}

--- a/wazo_confd/plugins/external_app/validator.py
+++ b/wazo_confd/plugins/external_app/validator.py
@@ -1,16 +1,26 @@
 # Copyright 2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+from xivo_dao.helpers import errors
 from xivo_dao.resources.external_app import dao as external_app_dao
 
-from wazo_confd.helpers.validator import UniqueField, ValidationGroup
+from wazo_confd.helpers.validator import ValidationGroup, Validator
+
+
+class UniqueNameField(Validator):
+    def __init__(self, dao):
+        self.dao = dao
+
+    def validate(self, external_app):
+        tenant_uuid = external_app.tenant_uuid
+        name = external_app.name
+        found = self.dao.find_by(tenant_uuid=tenant_uuid, name=name)
+        if found is not None:
+            metadata = {'tenant_uuid': tenant_uuid, 'name': name}
+            raise errors.resource_exists('ExternalApp', **metadata)
 
 
 def build_validator():
     return ValidationGroup(
-        create=[
-            UniqueField(
-                'name', lambda name: external_app_dao.find_by(name=name), 'ExternalApp'
-            )
-        ],
+        create=[UniqueNameField(external_app_dao)],
     )


### PR DESCRIPTION
* external_app: allow to use same name across tenant
* external_app: do not cross tenant for endpoints

  reason: name is not unique compared to id/uuid and it's not relevant to
  return the first item in all tenants you're authorized. We should just
  keep the tenant from the header or tenant to search the item and avoid
  recurse