### PR TITLE
trunk endpoint sip: add the client_uri to registration section

### DIFF
--- a/integration_tests/suite/base/test_trunk_endpoint_sip.py
+++ b/integration_tests/suite/base/test_trunk_endpoint_sip.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2020 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2021 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import assert_that, has_entries, contains
@@ -149,6 +149,7 @@ def test_dissociate_multi_tenant(main_trunk, sub_trunk, main_sip, sub_sip):
     label='label',
     name='label',
     auth_section_options=[['username', 'my-username'], ['password', 'my-password']],
+    registration_section_options=[['client_uri', 'client-uri']],
 )
 def test_get_endpoint_sip_relation(trunk, sip):
     with a.trunk_endpoint_sip(trunk, sip):
@@ -162,6 +163,9 @@ def test_get_endpoint_sip_relation(trunk, sip):
                     name='label',
                     auth_section_options=contains(
                         contains('username', 'my-username'),
+                    ),
+                    registration_section_options=contains(
+                        contains('client_uri', 'client-uri'),
                     ),
                 )
             ),

--- a/wazo_confd/plugins/trunk/schema.py
+++ b/wazo_confd/plugins/trunk/schema.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2020 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2021 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from marshmallow import fields
@@ -19,6 +19,7 @@ class TrunkSchema(BaseSchema):
             'label',
             'name',
             'auth_section_options.username',
+            'registration_section_options.client_uri',
             'links',
         ],
         dump_only=True,

--- a/wazo_confd/plugins/trunk_endpoint/notifier.py
+++ b/wazo_confd/plugins/trunk_endpoint/notifier.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2020 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2021 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
@@ -30,6 +30,7 @@ ENDPOINT_SIP_FIELDS = [
     'tenant_uuid',
     'name',
     'auth_section_options.username',
+    'registration_section_options.client_uri',
 ]
 
 ENDPOINT_IAX_FIELDS = [

--- a/wazo_confd/plugins/trunk_endpoint/tests/test_notifier.py
+++ b/wazo_confd/plugins/trunk_endpoint/tests/test_notifier.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2020 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2021 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import unittest
@@ -34,6 +34,7 @@ class TestTrunkEndpointNotifier(unittest.TestCase):
         self.sip = Mock(
             uuid=str(uuid.uuid4()),
             auth_section_options=[['username', 'username']],
+            registration_section_options=[['client_uri', 'client-uri']],
             tenant_uuid=tenant_uuid,
         )
         self.sip.name = 'limitation of mock instantiation with name ...'
@@ -54,6 +55,7 @@ class TestTrunkEndpointNotifier(unittest.TestCase):
                 'tenant_uuid': self.sip.tenant_uuid,
                 'name': self.sip.name,
                 'auth_section_options': self.sip.auth_section_options,
+                'registration_section_options': self.sip.registration_section_options,
             },
         )
 
@@ -114,6 +116,7 @@ class TestTrunkEndpointNotifier(unittest.TestCase):
                 'tenant_uuid': self.sip.tenant_uuid,
                 'name': self.sip.name,
                 'auth_section_options': self.sip.auth_section_options,
+                'registration_section_options': self.sip.registration_section_options,
             },
         )
 


### PR DESCRIPTION
the client_uri field is required to match the endpoint to a trunk registration
event.