### PR TITLE
send registration_section_options in sip events

### DIFF
--- a/wazo_confd/plugins/endpoint_sip/notifier.py
+++ b/wazo_confd/plugins/endpoint_sip/notifier.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2020 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2021 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from xivo_bus.resources.endpoint_sip.event import (
@@ -20,6 +20,7 @@ ENDPOINT_SIP_FIELDS = [
     'name',
     'label',
     'auth_section_options.username',
+    'registration_section_options.client_uri',
     'trunk.id',
     'line.id',
 ]

--- a/wazo_confd/plugins/endpoint_sip/tests/test_notifier.py
+++ b/wazo_confd/plugins/endpoint_sip/tests/test_notifier.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2020 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2021 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import unittest
@@ -32,6 +32,7 @@ class TestSipEndpointNotifier(unittest.TestCase):
             tenant_uuid=str(uuid.uuid4()),
             label='label',
             auth_section_options=[['username', 'username']],
+            registration_section_options=[['client_uri', 'client_uri']],
             trunk={'id': 2},
             line=None,
         )
@@ -41,6 +42,7 @@ class TestSipEndpointNotifier(unittest.TestCase):
             'tenant_uuid': self.sip.tenant_uuid,
             'name': self.sip.name,
             'auth_section_options': self.sip.auth_section_options,
+            'registration_section_options': self.sip.registration_section_options,
             'label': self.sip.label,
             'trunk': self.sip.trunk,
             'line': self.sip.line,


### PR DESCRIPTION
reason: wazo-calld need it when the endpoint_sip is associated to a
trunk to know its sip_username