### PR TITLE
recording: remove the recording warning

### DIFF
--- a/wazo_confd/plugins/user/api.yml
+++ b/wazo_confd/plugins/user/api.yml
@@ -336,7 +336,7 @@ definitions:
         call_record_incoming_external_enabled:
           type: boolean
           default: false
-          description: "Record all external calls received by this user. Limitation: transfers are not supported"
+          description: "Record all external calls received by this user."
         call_record_outgoing_internal_enabled:
           type: boolean
           default: false
@@ -344,7 +344,7 @@ definitions:
         call_record_incoming_internal_enabled:
           type: boolean
           default: false
-          description: "Record all internal calls received by this user. Limitation: transfers are not supported"
+          description: "Record all internal calls received by this user."
         online_call_record_enabled:
           type: boolean
           default: false


### PR DESCRIPTION
in 21.03 the AGI has been updated to record the side of the call matching the
user with the recording option. The previous versions always recorded the
calling side of the channel.