### PR TITLE
zone messages: allow GET for non master tenant users

### DIFF
--- a/integration_tests/suite/base/test_voicemail_zonemessages.py
+++ b/integration_tests/suite/base/test_voicemail_zonemessages.py
@@ -115,11 +115,13 @@ def test_edit_voicemail_zonemessages_with_none_message():
 
 
 def test_restrict_only_master_tenant():
-    response = confd.asterisk.voicemail.zonemessages.get(token=TOKEN_SUB_TENANT)
-    response.assert_status(401)
-
     response = confd.asterisk.voicemail.zonemessages.put(token=TOKEN_SUB_TENANT)
     response.assert_status(401)
+
+
+def test_that_list_is_not_restricted_to_the_master_tenant():
+    response = confd.asterisk.voicemail.zonemessages.get(token=TOKEN_SUB_TENANT)
+    response.assert_status(200)
 
 
 def test_bus_event_when_edited():

--- a/wazo_confd/plugins/voicemail_zonemessages/resource.py
+++ b/wazo_confd/plugins/voicemail_zonemessages/resource.py
@@ -57,7 +57,6 @@ class VoicemailZoneMessagesList(ConfdResource):
         super().__init__()
         self.service = service
 
-    @required_master_tenant()
     @required_acl('confd.asterisk.voicemail.zonemessages.get')
     def get(self):
         options = self.service.list()


### PR DESCRIPTION
this is used when displaying the zone message selection in a form