### PR TITLE
test: use explicit ipv4 addr to connect docker

### DIFF
--- a/integration_tests/suite/base/test_documentation.py
+++ b/integration_tests/suite/base/test_documentation.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2020 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2021 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
@@ -19,6 +19,6 @@ logger.setLevel(logging.INFO)
 class TestDocumentation(unittest.TestCase):
     def test_documentation_errors(self):
         confd_port = BaseIntegrationTest.service_port(9486, 'confd')
-        api_url = 'http://localhost:{port}/1.1/api/api.yml'.format(port=confd_port)
+        api_url = 'http://127.0.0.1:{port}/1.1/api/api.yml'.format(port=confd_port)
         api = requests.get(api_url)
         validate_v2_spec(yaml.safe_load(api.text))

--- a/integration_tests/suite/base/test_func_keys_destinations.py
+++ b/integration_tests/suite/base/test_func_keys_destinations.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2020 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2021 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import assert_that, contains_inanyorder, has_entries
@@ -96,7 +96,7 @@ def test_get_destinations():
                     'parameters': [
                         {
                             'name': 'user_id',
-                            'collection': 'http://localhost:{}/1.1/users'.format(
+                            'collection': 'http://127.0.0.1:{}/1.1/users'.format(
                                 BaseIntegrationTest.service_port(9486, 'confd')
                             ),
                         }

--- a/integration_tests/suite/helpers/base.py
+++ b/integration_tests/suite/helpers/base.py
@@ -38,7 +38,7 @@ class IntegrationTest(AssetLaunchingTestCase):
 
     @classmethod
     def setup_token(cls):
-        cls.mock_auth = MockAuthClient('localhost', cls.service_port(9497, 'auth'))
+        cls.mock_auth = MockAuthClient('127.0.0.1', cls.service_port(9497, 'auth'))
         token = MockUserToken(
             TOKEN,
             'user_uuid',
@@ -164,20 +164,20 @@ class IntegrationTest(AssetLaunchingTestCase):
 
     @classmethod
     def create_sysconfd(cls):
-        url = 'http://localhost:{port}'.format(port=cls.service_port(8668, 'sysconfd'))
+        url = 'http://127.0.0.1:{port}'.format(port=cls.service_port(8668, 'sysconfd'))
         return SysconfdMock(url)
 
     @classmethod
     def setup_helpers(cls):
-        setup_confd_helpers(host='localhost', port=cls.service_port('9486', 'confd'))
+        setup_confd_helpers(host='127.0.0.1', port=cls.service_port('9486', 'confd'))
         setup_new_client_helpers(
-            host='localhost', port=cls.service_port('9486', 'confd')
+            host='127.0.0.1', port=cls.service_port('9486', 'confd')
         )
         setup_database_helpers(
-            host='localhost', port=cls.service_port(5432, 'postgres')
+            host='127.0.0.1', port=cls.service_port(5432, 'postgres')
         )
-        setup_provd_helpers(host='localhost', port=cls.service_port(8666, 'provd'))
-        setup_bus_helpers(host='localhost', port=cls.service_port(5672, 'rabbitmq'))
+        setup_provd_helpers(host='127.0.0.1', port=cls.service_port(8666, 'provd'))
+        setup_bus_helpers(host='127.0.0.1', port=cls.service_port(5672, 'rabbitmq'))
 
     @classmethod
     def create_confd(cls, headers=None, encoder=None):
@@ -187,7 +187,7 @@ class IntegrationTest(AssetLaunchingTestCase):
     @classmethod
     def new_client(cls, headers=None, encoder=None):
         client = ConfdClient.from_options(
-            host='localhost',
+            host='127.0.0.1',
             port=cls.service_port('9486', 'confd'),
             headers=headers,
             encoder=encoder,
@@ -197,13 +197,13 @@ class IntegrationTest(AssetLaunchingTestCase):
     @classmethod
     def create_bus(cls):
         port = cls.service_port(5672, 'rabbitmq')
-        client = BusClient.from_connection_fields(host='localhost', port=port)
+        client = BusClient.from_connection_fields(host='127.0.0.1', port=port)
         return client
 
     @classmethod
     def create_auth(cls):
         return AuthClient(
-            host='localhost',
+            host='127.0.0.1',
             port=cls.service_port(9497, 'auth'),
             prefix=None,
             https=False,
@@ -211,7 +211,7 @@ class IntegrationTest(AssetLaunchingTestCase):
 
     @classmethod
     def create_ari(cls):
-        return ARIClient(host='localhost', port=cls.service_port(5039, 'ari'))
+        return ARIClient(host='127.0.0.1', port=cls.service_port(5039, 'ari'))
 
     @classmethod
     def create_filesystem(cls, base_path):

--- a/integration_tests/suite/helpers/database.py
+++ b/integration_tests/suite/helpers/database.py
@@ -549,7 +549,7 @@ class DatabaseQueries:
 def create_helper(
     user='asterisk',
     password='proformatique',
-    host='localhost',
+    host='127.0.0.1',
     port=5432,
     db='asterisk',
 ):

--- a/integration_tests/suite/helpers/provd.py
+++ b/integration_tests/suite/helpers/provd.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2020 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2021 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import docker
@@ -166,6 +166,6 @@ class ProvdHelper:
                 return client.logs(container['Id'], since=timestamp).decode('utf-8')
 
 
-def create_helper(host='localhost', port='8666', token=TOKEN):
+def create_helper(host='127.0.0.1', port='8666', token=TOKEN):
     client = ProvdClient(host=host, port=port, prefix='', https=False, token=token)
     return ProvdHelper(client)


### PR DESCRIPTION
reason: service_port() returns only port bound to ipv4. Some host can
resolve localhost to ipv6 address and docker doesn't necessarily bind
the same port number on ipv4 and ipv6