### PR TITLE
integration tests: always update db image

### DIFF
--- a/integration_tests/Makefile
+++ b/integration_tests/Makefile
@@ -1,15 +1,26 @@
 PROVD_DIR ?= ../../provd/
-MANAGE_DB_DIR ?= ../../manage-db/
-POSTGRES_DOCKER=$(MANAGE_DB_DIR)/contribs/docker/wazo-confd-db-test/Dockerfile
 
-test-setup: egg-info build-confd
+ifeq ($(MANAGE_DB_DIR),)
+	UPDATE_DB_TARGET=update-db-pull
+else
+	UPDATE_DB_TARGET=update-db-build
+	POSTGRES_DOCKER=$(MANAGE_DB_DIR)/contribs/docker/wazo-confd-db-test/Dockerfile
+endif
+
+test-setup: egg-info build-confd update-db
 
 build-confd:
 	docker build -t wazoplatform/wazo-confd ..
 	docker build --no-cache -t wazo-confd-test -f Dockerfile ..
 
-update-db:
-	docker build --no-cache -t wazoplatform/wazo-confd-db-test -f $(POSTGRES_DOCKER) $(MANAGE_DB_DIR)
+update-db: $(UPDATE_DB_TARGET)
+
+update-db-pull:
+	docker pull wazoplatform/wazo-confd-db-test
+	docker tag wazoplatform/wazo-confd-db-test:latest wazoplatform/wazo-confd-db-test:local
+
+update-db-build:
+	docker build --no-cache -t wazoplatform/wazo-confd-db-test:local -f $(POSTGRES_DOCKER) $(MANAGE_DB_DIR)
 
 build-provd:
 	docker build -t wazoplatform/wazo-provd $(PROVD_DIR)
@@ -20,4 +31,4 @@ test:
 egg-info:
 	cd .. && python setup.py egg_info
 
-.PHONY: test-setup test egg-info update-db build-provd build-confd
+.PHONY: test-setup test egg-info update-db update-db-build update-db-pull build-provd build-confd

--- a/integration_tests/assets/docker-compose.yml
+++ b/integration_tests/assets/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - "./provd/zero:/var/lib/wazo-provd/plugins/zero"
 
   postgres:
-    image: wazoplatform/wazo-confd-db-test
+    image: wazoplatform/wazo-confd-db-test:local
     ports:
       - "5432"
 

--- a/tox.ini
+++ b/tox.ini
@@ -46,11 +46,12 @@ deps = -rintegration_tests/test-requirements.txt
 changedir = integration_tests
 passenv =
     WAZO_TEST_DOCKER_OVERRIDE_EXTRA
+    MANAGE_DB_DIR
 commands =
     make test-setup
     nosetests -v {posargs}
 whitelist_externals =
-    sh
+    make
 
 [testenv:pylint]
 skip_install = true
@@ -60,8 +61,6 @@ deps =
     -rrequirements.txt
     -rtest-requirements.txt
     pylint
-whitelist_externals =
-    sh
 
 [flake8]
 # E501: line too long (80 chars)


### PR DESCRIPTION
Why:

* Useful for CI handling of siblings
* Probably less hassle when developing due to autopulling, thanks to :local