### PR TITLE
nginx: add the "base" rules for confd to a separate file

### DIFF
--- a/etc/nginx/locations/https-available/wazo-confd
+++ b/etc/nginx/locations/https-available/wazo-confd
@@ -1,15 +1,13 @@
+location ^~ /api/confd/1.1/guests {
+    include /etc/nginx/wazo-confd-shared.conf;
+    include /etc/nginx/wazo-no-auth-shared.conf;
+}
+
+location ^~ /api/confd/1.1/wizard {
+    include /etc/nginx/wazo-confd-shared.conf;
+    include /etc/nginx/wazo-no-auth-shared.conf;
+}
+
 location ^~ /api/confd/ {
-    proxy_pass http://127.0.0.1:9486/;
-
-    # Mostly used for /users/import and /ha but can be useful for other
-    # endpoints on slow host (e.i. /devices)
-    proxy_read_timeout 180s;
-
-    # Mostly used for /moh and /sounds
-    client_max_body_size 16m;
-
-    proxy_set_header    Host                $http_host;
-    proxy_set_header    X-Script-Name       /api/confd;
-    proxy_set_header    X-Forwarded-For     $proxy_add_x_forwarded_for;
-    proxy_set_header    X-Forwarded-Proto   $scheme;
+    include /etc/nginx/wazo-confd-shared.conf;
 }

--- a/etc/nginx/wazo-confd-shared.conf
+++ b/etc/nginx/wazo-confd-shared.conf
@@ -1,0 +1,13 @@
+proxy_pass http://127.0.0.1:9486/;
+
+# Mostly used for /users/import and /ha but can be useful for other
+# endpoints on slow host (e.i. /devices)
+proxy_read_timeout 180s;
+
+# Mostly used for /moh and /sounds
+client_max_body_size 16m;
+
+proxy_set_header    Host                $http_host;
+proxy_set_header    X-Script-Name       /api/confd;
+proxy_set_header    X-Forwarded-For     $proxy_add_x_forwarded_for;
+proxy_set_header    X-Forwarded-Proto   $scheme;


### PR DESCRIPTION
Add a file with the rules for wazo-confd that needs to be included in all confd
resources.

create new location paths for no authentication resources.