### PR TITLE
nginx: ignore missing files on reload

### DIFF
--- a/etc/nginx/locations/https-available/wazo-confd
+++ b/etc/nginx/locations/https-available/wazo-confd
@@ -1,11 +1,11 @@
 location ^~ /api/confd/1.1/guests {
     include /etc/nginx/wazo-confd-shared.conf;
-    include /etc/nginx/wazo-no-auth-shared.conf;
+    include /etc/nginx/wazo-no-auth-shared[.]conf;
 }
 
 location ^~ /api/confd/1.1/wizard {
     include /etc/nginx/wazo-confd-shared.conf;
-    include /etc/nginx/wazo-no-auth-shared.conf;
+    include /etc/nginx/wazo-no-auth-shared[.]conf;
 }
 
 location ^~ /api/confd/ {

--- a/etc/nginx/locations/https-available/wazo-confd
+++ b/etc/nginx/locations/https-available/wazo-confd
@@ -1,13 +1,16 @@
 location ^~ /api/confd/1.1/guests {
+    proxy_pass http://127.0.0.1:9486/1.1/guests;
     include /etc/nginx/wazo-confd-shared.conf;
     include /etc/nginx/wazo-no-auth-shared[.]conf;
 }
 
 location ^~ /api/confd/1.1/wizard {
+    proxy_pass http://127.0.0.1:9486/1.1/wizard;
     include /etc/nginx/wazo-confd-shared.conf;
     include /etc/nginx/wazo-no-auth-shared[.]conf;
 }
 
 location ^~ /api/confd/ {
+    proxy_pass http://127.0.0.1:9486/;
     include /etc/nginx/wazo-confd-shared.conf;
 }

--- a/etc/nginx/wazo-confd-shared.conf
+++ b/etc/nginx/wazo-confd-shared.conf
@@ -1,5 +1,3 @@
-proxy_pass http://127.0.0.1:9486/;
-
 # Mostly used for /users/import and /ha but can be useful for other
 # endpoints on slow host (e.i. /devices)
 proxy_read_timeout 180s;


### PR DESCRIPTION
will prevent the reload from failing if wazo-nginx is not installed