### PR TITLE
debian: depends on wazo-nginx

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -28,6 +28,7 @@ Depends:
   python3-tz,
   rename,
   wazo-auth-client-python3,
+  wazo-nginx,
   wazo-provd-client-python3,
   xivo-bus-python3,
   xivo-lib-python-python3,


### PR DESCRIPTION
Why: we added an include in the nginx configuration that depends on a
configuration file installed by wazo-nginx.