### PR TITLE
API spec: add voicemail number example

### DIFF
--- a/wazo_confd/plugins/voicemail/api.yml
+++ b/wazo_confd/plugins/voicemail/api.yml
@@ -115,7 +115,7 @@ definitions:
     - properties:
         number:
           type: string
-          description: Mailbox number
+          description: Mailbox number, for example `0001`
         context:
           type: string
           description: Voicemail context


### PR DESCRIPTION
## Summary of the changes
- api spec: adds an example for `number` in /voicemails POST

motivated by #253