### PR TITLE
Pull request for WAZO-2750-purge-meeting-authorization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 22.06
+
+* Meeting authorizations are now only valid for 24 hours. They are automatically
+  deleted after 24 hours.
+
 ## 22.05
 
 * The following resources have been added:

--- a/debian/cron.d
+++ b/debian/cron.d
@@ -2,5 +2,5 @@
 # cron jobs for wazo-confd
 #
 
-42 3 * * * root /usr/bin/wazo-confd-sync-db --quiet
 24 3 * * * root /usr/bin/wazo-confd-purge-meetings --quiet
+42 3 * * * root /usr/bin/wazo-confd-sync-db --quiet

--- a/integration_tests/suite/helpers/base.py
+++ b/integration_tests/suite/helpers/base.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2021 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import os
@@ -61,6 +61,12 @@ class IntegrationTest(AssetLaunchingTestCase):
     @classmethod
     def purge_meetings(cls):
         cls.docker_exec(['wazo-confd-purge-meetings', '--debug'])
+
+    @classmethod
+    def purge_meeting_authorizations(cls):
+        return cls.docker_exec(
+            ['wazo-confd-purge-meetings', '--debug', '--authorizations-only'],
+        )
 
     @classmethod
     def _create_auth_tenant(cls):

--- a/integration_tests/suite/helpers/database.py
+++ b/integration_tests/suite/helpers/database.py
@@ -591,6 +591,14 @@ class DatabaseQueries:
         query = text("UPDATE meeting SET created_at = :date WHERE uuid = :meeting_uuid")
         self.connection.execute(query, date=date, meeting_uuid=meeting_uuid)
 
+    def set_meeting_authorization_creation_date(self, meeting_authorization_uuid, date):
+        query = text(
+            "UPDATE meeting_authorization SET created_at = :date WHERE uuid = :meeting_authorization_uuid"
+        )
+        self.connection.execute(
+            query, date=date, meeting_authorization_uuid=meeting_authorization_uuid
+        )
+
     @contextmanager
     def insert_max_meeting_authorizations(self, guest_uuid, meeting_uuid):
         query = text(

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright 2012-2021 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2012-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from setuptools import setup

--- a/wazo_confd/plugins/meeting_authorization/api.yml
+++ b/wazo_confd/plugins/meeting_authorization/api.yml
@@ -3,7 +3,7 @@ paths:
     post:
       operationId: create_guest_meeting_authorization
       summary: Request guest authorization to enter a meeting
-      description: '**Required ACL:** none. A single meeting only accepts a maximum amount of 128 authorizations.'
+      description: '**Required ACL:** none. A single meeting only accepts a maximum amount of 128 authorizations. Authorizations are valid for 24h.'
       tags:
       - meeting_authorizations
       - meetings

--- a/wazo_confd/purge_meetings.py
+++ b/wazo_confd/purge_meetings.py
@@ -4,7 +4,7 @@
 import argparse
 import logging
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from xivo import xivo_logging
 from xivo.chain_map import ChainMap
@@ -144,13 +144,13 @@ def main():
             ),
         )
 
-        meeting_date_limit = datetime.utcnow() - timedelta(hours=24)
+        meeting_date_limit = datetime.now(timezone.utc) - timedelta(hours=24)
         remove_meetings_older_than(meeting_date_limit, meeting_service)
 
     authorization_notifier = MeetingAuthorizationNotifier(bus)
     meeting_authorization_service = build_authorization_service(authorization_notifier)
 
-    meeting_authorization_date_limit = datetime.now() - timedelta(hours=24)
+    meeting_authorization_date_limit = datetime.now(timezone.utc) - timedelta(hours=24)
     remove_meeting_authorizations_older_than(
         meeting_authorization_date_limit, meeting_authorization_service
     )

--- a/wazo_confd/purge_meetings.py
+++ b/wazo_confd/purge_meetings.py
@@ -77,12 +77,13 @@ def load_config():
 
 
 def remove_meetings_older_than(date, meeting_service):
-    logger.debug('Removing meetings older than %s', date)
+    logger.info('Removing meetings older than %s...', date)
 
     with session_scope() as session:
         meetings = meeting_dao.find_all_by(created_before=date, persistent=False)
+        logger.info('Found %s meeting.', len(meetings))
         for meeting in meetings:
-            logger.info('Removing meeting %s: %s', meeting.uuid, meeting.name)
+            logger.debug('Removing meeting %s: %s', meeting.uuid, meeting.name)
             meeting_service.delete(meeting)
         session.flush()
 


### PR DESCRIPTION
Depends-On: https://github.com/wazo-platform/xivo-dao/pull/172

## meeting authorizations: purge items older than 24h


## meeting purge: fix timezone

Why:

* datetime.utcnow() returns UTC time WITHOUT a timezone
* when comparing the database date with a timestamp without a
timezone, PGSQL does the comparison in the local time zone
* when comparing with both timezones, PGSQL applies the corresponding
offset before comparing