### PR TITLE
doc: use wazo-platform.org instead of wazo.community url

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,14 +5,14 @@ wazo-confd
 
 Wazo CONFD is a web server that provides a [RESTful](http://en.wikipedia.org/wiki/Representational_state_transfer)
 service for configuring and managing a Wazo server. Further details on how to use the API can be found on
-the [Wazo API web site](http://api.wazo.community)
+the [Wazo API web site](https://wazo-platform.org/documentation)
 
 
 Installing wazo-confd
 ---------------------
 
-The server is already provided as a part of [Wazo](http://documentation.wazo.community).
-Please refer to [the documentation](http://documentation.wazo.community/en/stable/installation/installsystem.html) for
+The server is already provided as a part of [Wazo](https://wazo-platform.org/uc-doc/).
+Please refer to [the documentation](https://wazo-platform.org/uc-doc/installation/install-system) for
 further details on installing one.
 
 

--- a/wazo_confd/plugins/api/api.yml
+++ b/wazo_confd/plugins/api/api.yml
@@ -20,7 +20,7 @@ info:
     url: http://www.gnu.org/licenses/gpl.txt
   contact:
     name: Dev Team
-    url: http://wazo.community
+    url: https://wazo-platform.org/
     email: dev@wazo.community
 schemes:
 - http
@@ -34,7 +34,7 @@ x-xivo-name: confd
 tags:
 - name: funckeys
   externalDocs:
-    url: http://documentation.wazo.community/en/stable/api_sdk/rest_api/confd/func_keys.html
+    url: https://wazo-platform.org/uc-doc/api_sdk/rest_api/confd/func_keys
     description: Documentation on function key models
 securityDefinitions:
   wazo_auth_token:

--- a/wazo_confd/plugins/func_key/api.yml
+++ b/wazo_confd/plugins/func_key/api.yml
@@ -348,7 +348,7 @@ parameters:
 definitions:
   FuncKey:
     title: FuncKey
-    description: Further documentation at http://documentation.wazo.community/en/stable/api_sdk/rest_api/confd/func_keys.html
+    description: Further documentation at https://wazo-platform.org/uc-doc/api_sdk/rest_api/confd/func_keys
     properties:
       blf:
         type: boolean
@@ -388,7 +388,7 @@ definitions:
     type: array
   FuncKeyTemplate:
     title: FuncKeyTemplate
-    description: Further documentation at http://documentation.wazo.community/en/stable/api_sdk/rest_api/confd/func_keys.html
+    description: Further documentation at https://wazo-platform.org/uc-doc/administration/users/csv_import
     properties:
       id:
         type: integer

--- a/wazo_confd/plugins/user_import/api.yml
+++ b/wazo_confd/plugins/user_import/api.yml
@@ -6,10 +6,10 @@ paths:
       description: '**Required ACL:** `confd.users.export.read`
 
 
-        CSV field list available at http://documentation.wazo.community/en/stable/administration/users/csv_import.html'
+        CSV field list available at https://wazo-platform.org/uc-doc/administration/users/csv_import'
       externalDocs:
         description: Complete documentation on the CSV data format and fields
-        url: http://documentation.wazo.community/en/stable/administration/users/csv_import.html
+        url: https://wazo-platform.org/uc-doc/administration/users/csv_import
       tags:
       - users
       produces:
@@ -28,10 +28,10 @@ paths:
       description: '**Required ACL:** `confd.users.import.create`
 
 
-        CSV field list available at http://documentation.wazo.community/en/stable/administration/users/csv_import.html'
+        CSV field list available at https://wazo-platform.org/uc-doc/administration/users/csv_import'
       externalDocs:
         description: Complete documentation on the CSV data format and fields
-        url: http://documentation.wazo.community/en/stable/administration/users/csv_import.html
+        url: https://wazo-platform.org/uc-doc/administration/users/csv_import
       consumes:
       - text/csv; charset=utf-8
       tags:
@@ -56,12 +56,12 @@ paths:
       **Required ACL:** `confd.users.import.update`
 
 
-        CSV field list available at http://documentation.wazo.community/en/stable/administration/users/csv_import.html
+        CSV field list available at https://wazo-platform.org/uc-doc/administration/users/csv_import
 
         This resource has been disabled since it creates invalid configurations'
       externalDocs:
         description: Complete documentation on the CSV data format and fields
-        url: http://documentation.wazo.community/en/stable/administration/users/csv_import.html
+        url: https://wazo-platform.org/uc-doc/administration/users/csv_import
       consumes:
       - text/csv; charset=utf-8
       tags:
@@ -86,7 +86,7 @@ parameters:
     name: body
     in: body
     required: true
-    description: CSV field list available at http://documentation.wazo.community/en/stable/administration/users/csv_import.html
+    description: CSV field list available at https://wazo-platform.org/uc-doc/administration/users/csv_import
     schema:
       type: string
 


### PR DESCRIPTION
why: avoid redirection