### PR TITLE
meeting authorizations: always accepted if not required

### DIFF
--- a/wazo_confd/plugins/meeting_authorization/resource.py
+++ b/wazo_confd/plugins/meeting_authorization/resource.py
@@ -40,12 +40,6 @@ class GuestMeetingAuthorizationList(ListResource):
         body['guest_uuid'] = guest_uuid
         body['meeting_uuid'] = meeting_uuid
         form = self.schema().load(body)
-        form['status'] = 'pending'
-
-        try:
-            self._meeting_dao.get(meeting_uuid)
-        except NotFoundError as e:
-            raise errors.not_found('meetings', 'Meeting', **e.metadata)
 
         model = self.model(**form)
         self._service.create(model)

--- a/wazo_confd/plugins/meeting_authorization/service.py
+++ b/wazo_confd/plugins/meeting_authorization/service.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from xivo_dao.resources.meeting_authorization import dao
+from xivo_dao.resources.meeting import dao as meeting_dao
 
 from wazo_confd.helpers.resource import CRUDService
 
@@ -11,6 +12,16 @@ from .validator import build_validator
 class MeetingAuthorizationService(CRUDService):
     def search(self, parameters, meeting_uuid):
         return self.dao.search(meeting_uuid, **parameters)
+
+    def create(self, meeting_authorization):
+        self._set_status(meeting_authorization)
+        return super().create(meeting_authorization)
+
+    def _set_status(self, meeting_authorization):
+        meeting = meeting_dao.get(meeting_authorization.meeting_uuid)
+        meeting_authorization.status = (
+            'pending' if meeting.require_authorization else 'accepted'
+        )
 
     def get(self, meeting_uuid, authorization_uuid, **kwargs):
         return self.dao.get(meeting_uuid, authorization_uuid, **kwargs)


### PR DESCRIPTION
Why:

* It eases the workflow from client apps to be able to always request
authorizations, even if they are not required.