### PR TITLE
test: use mock from unittest library

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,3 @@
 https://github.com/wazo-platform/wazo-test-helpers/archive/master.zip
 nose
-mock>=1.3.0
 pyhamcrest

--- a/wazo_confd/helpers/tests/test_resource.py
+++ b/wazo_confd/helpers/tests/test_resource.py
@@ -1,9 +1,9 @@
-# Copyright 2013-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2013-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import unittest
 
-from mock import Mock, sentinel
+from unittest.mock import Mock, sentinel
 from hamcrest import assert_that, equal_to
 
 from wazo_confd.helpers.resource import CRUDService

--- a/wazo_confd/helpers/tests/test_validator.py
+++ b/wazo_confd/helpers/tests/test_validator.py
@@ -1,9 +1,9 @@
-# Copyright 2015-2020 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import unittest
 from hamcrest import assert_that, raises, calling, equal_to
-from mock import Mock, sentinel
+from unittest.mock import Mock, sentinel
 
 from xivo_dao.helpers.exception import InputError, NotFoundError, ResourceError
 

--- a/wazo_confd/plugins/access_feature/tests/test_notifier.py
+++ b/wazo_confd/plugins/access_feature/tests/test_notifier.py
@@ -1,8 +1,8 @@
-# Copyright 2018-2020 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import unittest
-from mock import Mock
+from unittest.mock import Mock
 
 from xivo_bus.resources.access_feature.event import (
     CreateAccessFeatureEvent,

--- a/wazo_confd/plugins/agent/tests/test_notifier.py
+++ b/wazo_confd/plugins/agent/tests/test_notifier.py
@@ -3,7 +3,7 @@
 
 import unittest
 import uuid
-from mock import Mock
+from unittest.mock import Mock
 
 from xivo_bus.resources.agent.event import (
     CreateAgentEvent,

--- a/wazo_confd/plugins/agent_skill/tests/test_notifier.py
+++ b/wazo_confd/plugins/agent_skill/tests/test_notifier.py
@@ -3,7 +3,7 @@
 
 import unittest
 
-from mock import Mock
+from unittest.mock import Mock
 import uuid
 
 from xivo_bus.resources.agent_skill.event import (

--- a/wazo_confd/plugins/application/tests/test_notifier.py
+++ b/wazo_confd/plugins/application/tests/test_notifier.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import unittest
-from mock import Mock
+from unittest.mock import Mock
 
 from xivo_bus.resources.application.event import (
     CreateApplicationEvent,

--- a/wazo_confd/plugins/call_filter/tests/test_notifier.py
+++ b/wazo_confd/plugins/call_filter/tests/test_notifier.py
@@ -3,7 +3,7 @@
 
 import unittest
 import uuid
-from mock import Mock
+from unittest.mock import Mock
 
 from xivo_bus.resources.call_filter.event import (
     CreateCallFilterEvent,

--- a/wazo_confd/plugins/call_filter_fallback/tests/test_notifier.py
+++ b/wazo_confd/plugins/call_filter_fallback/tests/test_notifier.py
@@ -3,7 +3,7 @@
 
 import unittest
 from uuid import uuid4
-from mock import Mock
+from unittest.mock import Mock
 
 from xivo_bus.resources.call_filter.event import EditCallFilterFallbackEvent
 from xivo_dao.alchemy.callfilter import Callfilter as CallFilter

--- a/wazo_confd/plugins/call_filter_user/tests/test_notifier.py
+++ b/wazo_confd/plugins/call_filter_user/tests/test_notifier.py
@@ -4,7 +4,7 @@
 import unittest
 
 from uuid import uuid4
-from mock import Mock
+from unittest.mock import Mock
 
 from xivo_bus.resources.call_filter_user.event import (
     CallFilterRecipientUsersAssociatedEvent,

--- a/wazo_confd/plugins/call_permission/tests/test_notifier.py
+++ b/wazo_confd/plugins/call_permission/tests/test_notifier.py
@@ -4,7 +4,7 @@
 import unittest
 
 from uuid import uuid4
-from mock import Mock
+from unittest.mock import Mock
 
 from xivo_bus.resources.call_permission.event import (
     CreateCallPermissionEvent,

--- a/wazo_confd/plugins/call_pickup/tests/test_notifier.py
+++ b/wazo_confd/plugins/call_pickup/tests/test_notifier.py
@@ -4,7 +4,7 @@
 import unittest
 
 from uuid import uuid4
-from mock import Mock
+from unittest.mock import Mock
 
 from xivo_bus.resources.call_pickup.event import (
     CreateCallPickupEvent,

--- a/wazo_confd/plugins/call_pickup_member/tests/test_notifier.py
+++ b/wazo_confd/plugins/call_pickup_member/tests/test_notifier.py
@@ -4,7 +4,7 @@
 import unittest
 
 from uuid import uuid4
-from mock import Mock
+from unittest.mock import Mock
 
 from xivo_bus.resources.call_pickup_member.event import (
     CallPickupInterceptorGroupsAssociatedEvent,

--- a/wazo_confd/plugins/confbridge/tests/test_notifier.py
+++ b/wazo_confd/plugins/confbridge/tests/test_notifier.py
@@ -1,8 +1,8 @@
-# Copyright 2017-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import unittest
-from mock import Mock
+from unittest.mock import Mock
 
 from xivo_bus.resources.confbridge.event import (
     EditConfBridgeWazoDefaultBridgeEvent,

--- a/wazo_confd/plugins/conference/tests/test_notifier.py
+++ b/wazo_confd/plugins/conference/tests/test_notifier.py
@@ -4,7 +4,7 @@
 import unittest
 
 from uuid import uuid4
-from mock import Mock
+from unittest.mock import Mock
 
 from xivo_bus.resources.conference.event import (
     CreateConferenceEvent,

--- a/wazo_confd/plugins/conference_extension/tests/test_notifier.py
+++ b/wazo_confd/plugins/conference_extension/tests/test_notifier.py
@@ -4,7 +4,7 @@
 import unittest
 
 from uuid import uuid4
-from mock import Mock
+from unittest.mock import Mock
 
 from xivo_bus.resources.conference_extension.event import (
     ConferenceExtensionAssociatedEvent,

--- a/wazo_confd/plugins/configuration/tests/test_notifier.py
+++ b/wazo_confd/plugins/configuration/tests/test_notifier.py
@@ -1,8 +1,8 @@
-# Copyright 2013-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2013-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import unittest
-from mock import Mock
+from unittest.mock import Mock
 
 from xivo_bus.resources.configuration.event import LiveReloadEditedEvent
 

--- a/wazo_confd/plugins/context/tests/test_notifier.py
+++ b/wazo_confd/plugins/context/tests/test_notifier.py
@@ -3,7 +3,7 @@
 
 import unittest
 
-from mock import Mock
+from unittest.mock import Mock
 
 from xivo_bus.resources.context.event import (
     CreateContextEvent,

--- a/wazo_confd/plugins/context_context/tests/test_notifier.py
+++ b/wazo_confd/plugins/context_context/tests/test_notifier.py
@@ -4,7 +4,7 @@
 import unittest
 
 from uuid import uuid4
-from mock import Mock
+from unittest.mock import Mock
 
 from xivo_bus.resources.context_context.event import ContextContextsAssociatedEvent
 from xivo_dao.alchemy.context import Context

--- a/wazo_confd/plugins/device/tests/test_funckey.py
+++ b/wazo_confd/plugins/device/tests/test_funckey.py
@@ -1,9 +1,9 @@
-# Copyright 2016-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import unittest
 
-from mock import Mock
+from unittest.mock import Mock
 from hamcrest import assert_that, has_entries
 
 from xivo_dao.alchemy.func_key_mapping import FuncKeyMapping as FuncKey

--- a/wazo_confd/plugins/device/tests/test_notifier.py
+++ b/wazo_confd/plugins/device/tests/test_notifier.py
@@ -4,7 +4,7 @@
 import unittest
 
 from uuid import uuid4
-from mock import Mock
+from unittest.mock import Mock
 
 from xivo_bus.resources.device.event import (
     CreateDeviceEvent,

--- a/wazo_confd/plugins/dhcp/tests/test_notifier.py
+++ b/wazo_confd/plugins/dhcp/tests/test_notifier.py
@@ -1,9 +1,9 @@
-# Copyright 2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import unittest
 
-from mock import Mock
+from unittest.mock import Mock
 from xivo_bus.resources.dhcp.event import EditDHCPEvent
 from xivo_dao.alchemy.dhcp import Dhcp
 

--- a/wazo_confd/plugins/email/tests/test_notifier.py
+++ b/wazo_confd/plugins/email/tests/test_notifier.py
@@ -1,8 +1,8 @@
-# Copyright 2021 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2021-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import unittest
-from mock import Mock
+from unittest.mock import Mock
 
 from xivo_bus.resources.email.event import EmailConfigUpdatedEvent
 

--- a/wazo_confd/plugins/email/tests/test_schema.py
+++ b/wazo_confd/plugins/email/tests/test_schema.py
@@ -1,4 +1,4 @@
-# Copyright 2021 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2021-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import unittest
@@ -12,7 +12,7 @@ from hamcrest import (
     has_property,
 )
 from marshmallow import ValidationError
-from mock import Mock
+from unittest.mock import Mock
 from wazo_test_helpers.hamcrest.raises import raises
 
 from ..schema import EmailConfigSchema

--- a/wazo_confd/plugins/endpoint_custom/tests/test_notifier.py
+++ b/wazo_confd/plugins/endpoint_custom/tests/test_notifier.py
@@ -4,7 +4,7 @@
 import unittest
 import uuid
 
-from mock import Mock
+from unittest.mock import Mock
 
 from xivo_bus.resources.endpoint_custom.event import (
     CreateCustomEndpointEvent,

--- a/wazo_confd/plugins/endpoint_iax/tests/test_notifier.py
+++ b/wazo_confd/plugins/endpoint_iax/tests/test_notifier.py
@@ -4,7 +4,7 @@
 import unittest
 import uuid
 
-from mock import Mock
+from unittest.mock import Mock
 
 from xivo_bus.resources.endpoint_iax.event import (
     CreateIAXEndpointEvent,

--- a/wazo_confd/plugins/endpoint_sccp/tests/test_notifier.py
+++ b/wazo_confd/plugins/endpoint_sccp/tests/test_notifier.py
@@ -4,7 +4,7 @@
 import unittest
 import uuid
 
-from mock import Mock
+from unittest.mock import Mock
 
 from xivo_bus.resources.endpoint_sccp.event import (
     CreateSccpEndpointEvent,

--- a/wazo_confd/plugins/endpoint_sip/tests/test_notifier.py
+++ b/wazo_confd/plugins/endpoint_sip/tests/test_notifier.py
@@ -3,7 +3,7 @@
 
 import unittest
 import uuid
-from mock import Mock
+from unittest.mock import Mock
 
 from xivo_bus.resources.endpoint_sip.event import (
     CreateSipEndpointEvent,

--- a/wazo_confd/plugins/extension/tests/test_notifier.py
+++ b/wazo_confd/plugins/extension/tests/test_notifier.py
@@ -4,7 +4,7 @@
 import unittest
 
 from uuid import uuid4
-from mock import Mock
+from unittest.mock import Mock
 
 from xivo_bus.resources.extension.event import (
     CreateExtensionEvent,

--- a/wazo_confd/plugins/extension_feature/tests/test_notifier.py
+++ b/wazo_confd/plugins/extension_feature/tests/test_notifier.py
@@ -4,7 +4,7 @@
 import unittest
 
 from uuid import uuid4
-from mock import Mock
+from unittest.mock import Mock
 
 from xivo_bus.resources.extension_feature.event import EditExtensionFeatureEvent
 from xivo_dao.alchemy.extension import Extension

--- a/wazo_confd/plugins/external_app/tests/test_notifier.py
+++ b/wazo_confd/plugins/external_app/tests/test_notifier.py
@@ -4,7 +4,7 @@
 import unittest
 
 from uuid import uuid4
-from mock import Mock
+from unittest.mock import Mock
 
 from xivo_bus.resources.external_app.event import (
     CreateExternalAppEvent,

--- a/wazo_confd/plugins/features/tests/test_notifier.py
+++ b/wazo_confd/plugins/features/tests/test_notifier.py
@@ -1,8 +1,8 @@
-# Copyright 2017-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import unittest
-from mock import Mock
+from unittest.mock import Mock
 
 from xivo_bus.resources.features.event import (
     EditFeaturesApplicationmapEvent,

--- a/wazo_confd/plugins/func_key/tests/test_notifier.py
+++ b/wazo_confd/plugins/func_key/tests/test_notifier.py
@@ -4,7 +4,7 @@
 import unittest
 
 from uuid import uuid4
-from mock import Mock, call
+from unittest.mock import Mock, call
 
 from xivo_bus.resources.func_key.event import (
     CreateFuncKeyTemplateEvent,

--- a/wazo_confd/plugins/func_key/tests/test_service.py
+++ b/wazo_confd/plugins/func_key/tests/test_service.py
@@ -1,9 +1,9 @@
-# Copyright 2016-2020 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import unittest
 
-from mock import Mock, sentinel, patch
+from unittest.mock import Mock, sentinel, patch
 from hamcrest import assert_that, equal_to
 
 from xivo_dao.alchemy.userfeatures import UserFeatures as User

--- a/wazo_confd/plugins/func_key/tests/test_validator.py
+++ b/wazo_confd/plugins/func_key/tests/test_validator.py
@@ -1,9 +1,9 @@
-# Copyright 2016-2020 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import unittest
 
-from mock import Mock, sentinel
+from unittest.mock import Mock, sentinel
 
 from hamcrest import assert_that, calling, raises
 

--- a/wazo_confd/plugins/group/tests/test_notifier.py
+++ b/wazo_confd/plugins/group/tests/test_notifier.py
@@ -3,7 +3,7 @@
 
 import unittest
 from uuid import uuid4
-from mock import Mock
+from unittest.mock import Mock
 
 from xivo_bus.resources.group.event import (
     CreateGroupEvent,

--- a/wazo_confd/plugins/group_call_permission/tests/test_notifier.py
+++ b/wazo_confd/plugins/group_call_permission/tests/test_notifier.py
@@ -3,7 +3,7 @@
 
 import unittest
 
-from mock import Mock
+from unittest.mock import Mock
 from uuid import uuid4
 
 from xivo_bus.resources.group_call_permission.event import (

--- a/wazo_confd/plugins/group_extension/tests/test_notifier.py
+++ b/wazo_confd/plugins/group_extension/tests/test_notifier.py
@@ -4,7 +4,7 @@
 import unittest
 
 from uuid import uuid4
-from mock import Mock
+from unittest.mock import Mock
 
 from xivo_bus.resources.group_extension.event import (
     GroupExtensionAssociatedEvent,

--- a/wazo_confd/plugins/group_fallback/tests/test_notifier.py
+++ b/wazo_confd/plugins/group_fallback/tests/test_notifier.py
@@ -3,7 +3,7 @@
 
 import unittest
 from uuid import uuid4
-from mock import Mock
+from unittest.mock import Mock
 
 from xivo_bus.resources.group.event import EditGroupFallbackEvent
 from xivo_dao.alchemy.groupfeatures import GroupFeatures as Group

--- a/wazo_confd/plugins/group_member/tests/test_notifier.py
+++ b/wazo_confd/plugins/group_member/tests/test_notifier.py
@@ -4,7 +4,7 @@
 import unittest
 
 from uuid import uuid4
-from mock import Mock
+from unittest.mock import Mock
 
 from xivo_bus.resources.group_member.event import (
     GroupMemberUsersAssociatedEvent,

--- a/wazo_confd/plugins/group_schedule/tests/test_notifier.py
+++ b/wazo_confd/plugins/group_schedule/tests/test_notifier.py
@@ -4,7 +4,7 @@
 import unittest
 
 from uuid import uuid4
-from mock import Mock
+from unittest.mock import Mock
 
 from xivo_bus.resources.group_schedule.event import (
     GroupScheduleAssociatedEvent,

--- a/wazo_confd/plugins/ha/tests/test_notifier.py
+++ b/wazo_confd/plugins/ha/tests/test_notifier.py
@@ -1,9 +1,9 @@
-# Copyright 2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import unittest
 
-from mock import Mock
+from unittest.mock import Mock
 from xivo_bus.resources.ha.event import EditHAEvent
 
 from ..notifier import HANotifier

--- a/wazo_confd/plugins/hep/tests/test_notifier.py
+++ b/wazo_confd/plugins/hep/tests/test_notifier.py
@@ -1,8 +1,8 @@
-# Copyright 2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import unittest
-from mock import Mock
+from unittest.mock import Mock
 
 from xivo_bus.resources.hep.event import HEPGeneralUpdatedEvent
 

--- a/wazo_confd/plugins/iax_callnumberlimits/tests/test_notifier.py
+++ b/wazo_confd/plugins/iax_callnumberlimits/tests/test_notifier.py
@@ -1,8 +1,8 @@
-# Copyright 2017-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import unittest
-from mock import Mock
+from unittest.mock import Mock
 
 from xivo_bus.resources.iax_callnumberlimits.event import EditIAXCallNumberLimitsEvent
 from xivo_dao.alchemy.iaxcallnumberlimits import IAXCallNumberLimits

--- a/wazo_confd/plugins/iax_general/tests/test_notifier.py
+++ b/wazo_confd/plugins/iax_general/tests/test_notifier.py
@@ -1,8 +1,8 @@
-# Copyright 2017-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import unittest
-from mock import Mock
+from unittest.mock import Mock
 
 from xivo_bus.resources.iax_general.event import EditIAXGeneralEvent
 from xivo_dao.alchemy.staticiax import StaticIAX

--- a/wazo_confd/plugins/incall/tests/test_notifier.py
+++ b/wazo_confd/plugins/incall/tests/test_notifier.py
@@ -4,7 +4,7 @@
 import unittest
 
 from uuid import uuid4
-from mock import Mock
+from unittest.mock import Mock
 
 from xivo_bus.resources.incall.event import (
     CreateIncallEvent,

--- a/wazo_confd/plugins/incall_extension/tests/test_notifier.py
+++ b/wazo_confd/plugins/incall_extension/tests/test_notifier.py
@@ -4,7 +4,7 @@
 import unittest
 
 from uuid import uuid4
-from mock import Mock
+from unittest.mock import Mock
 
 from xivo_bus.resources.incall_extension.event import (
     IncallExtensionAssociatedEvent,

--- a/wazo_confd/plugins/incall_schedule/tests/test_notifier.py
+++ b/wazo_confd/plugins/incall_schedule/tests/test_notifier.py
@@ -4,7 +4,7 @@
 import unittest
 
 from uuid import uuid4
-from mock import Mock
+from unittest.mock import Mock
 
 from xivo_bus.resources.incall_schedule.event import (
     IncallScheduleAssociatedEvent,

--- a/wazo_confd/plugins/ivr/tests/test_notifier.py
+++ b/wazo_confd/plugins/ivr/tests/test_notifier.py
@@ -4,7 +4,7 @@
 import unittest
 
 from uuid import uuid4
-from mock import Mock
+from unittest.mock import Mock
 from xivo_bus.resources.ivr.event import CreateIvrEvent, DeleteIvrEvent, EditIvrEvent
 from xivo_dao.alchemy.ivr import IVR
 

--- a/wazo_confd/plugins/line/tests/test_notifier.py
+++ b/wazo_confd/plugins/line/tests/test_notifier.py
@@ -4,7 +4,7 @@
 import unittest
 
 from uuid import uuid4
-from mock import Mock
+from unittest.mock import Mock
 
 from xivo_bus.resources.line.event import (
     CreateLineEvent,

--- a/wazo_confd/plugins/line/tests/test_validator.py
+++ b/wazo_confd/plugins/line/tests/test_validator.py
@@ -1,8 +1,8 @@
-# Copyright 2015-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import unittest
-from mock import Mock
+from unittest.mock import Mock
 
 from xivo_dao.alchemy.linefeatures import LineFeatures as Line
 from xivo_dao.helpers.exception import ResourceError

--- a/wazo_confd/plugins/line_application/tests/test_notifier.py
+++ b/wazo_confd/plugins/line_application/tests/test_notifier.py
@@ -4,7 +4,7 @@
 import unittest
 import uuid
 
-from mock import Mock
+from unittest.mock import Mock
 
 from xivo_bus.resources.line_application.event import (
     LineApplicationAssociatedEvent,

--- a/wazo_confd/plugins/line_device/tests/test_notifier.py
+++ b/wazo_confd/plugins/line_device/tests/test_notifier.py
@@ -4,7 +4,7 @@
 import unittest
 import uuid
 
-from mock import Mock
+from unittest.mock import Mock
 
 from hamcrest import assert_that, equal_to
 

--- a/wazo_confd/plugins/line_extension/tests/test_notifier.py
+++ b/wazo_confd/plugins/line_extension/tests/test_notifier.py
@@ -4,7 +4,7 @@
 import unittest
 
 from uuid import uuid4
-from mock import Mock
+from unittest.mock import Mock
 
 from xivo_bus.resources.line_extension.event import (
     LineExtensionAssociatedEvent,

--- a/wazo_confd/plugins/outcall/tests/test_notifier.py
+++ b/wazo_confd/plugins/outcall/tests/test_notifier.py
@@ -4,7 +4,7 @@
 import unittest
 
 from uuid import uuid4
-from mock import Mock
+from unittest.mock import Mock
 
 from xivo_bus.resources.outcall.event import (
     CreateOutcallEvent,

--- a/wazo_confd/plugins/outcall_call_permission/tests/test_notifier.py
+++ b/wazo_confd/plugins/outcall_call_permission/tests/test_notifier.py
@@ -4,7 +4,7 @@
 import unittest
 
 from uuid import uuid4
-from mock import Mock
+from unittest.mock import Mock
 
 from xivo_bus.resources.outcall_call_permission.event import (
     OutcallCallPermissionAssociatedEvent,

--- a/wazo_confd/plugins/outcall_extension/tests/test_notifier.py
+++ b/wazo_confd/plugins/outcall_extension/tests/test_notifier.py
@@ -4,7 +4,7 @@
 import unittest
 
 from uuid import uuid4
-from mock import Mock
+from unittest.mock import Mock
 
 from xivo_bus.resources.outcall_extension.event import (
     OutcallExtensionAssociatedEvent,

--- a/wazo_confd/plugins/outcall_schedule/tests/test_notifier.py
+++ b/wazo_confd/plugins/outcall_schedule/tests/test_notifier.py
@@ -4,7 +4,7 @@
 import unittest
 
 from uuid import uuid4
-from mock import Mock
+from unittest.mock import Mock
 
 from xivo_bus.resources.outcall_schedule.event import (
     OutcallScheduleAssociatedEvent,

--- a/wazo_confd/plugins/outcall_trunk/tests/test_notifier.py
+++ b/wazo_confd/plugins/outcall_trunk/tests/test_notifier.py
@@ -4,7 +4,7 @@
 import unittest
 
 from uuid import uuid4
-from mock import Mock
+from unittest.mock import Mock
 
 from xivo_bus.resources.outcall_trunk.event import OutcallTrunksAssociatedEvent
 from xivo_dao.alchemy.outcall import Outcall

--- a/wazo_confd/plugins/paging/tests/test_notifier.py
+++ b/wazo_confd/plugins/paging/tests/test_notifier.py
@@ -4,7 +4,7 @@
 import unittest
 
 from uuid import uuid4
-from mock import Mock
+from unittest.mock import Mock
 
 from xivo_bus.resources.paging.event import (
     CreatePagingEvent,

--- a/wazo_confd/plugins/paging_user/tests/test_notifier.py
+++ b/wazo_confd/plugins/paging_user/tests/test_notifier.py
@@ -4,7 +4,7 @@
 import unittest
 
 from uuid import uuid4
-from mock import Mock
+from unittest.mock import Mock
 
 from xivo_bus.resources.paging_user.event import (
     PagingMemberUsersAssociatedEvent,

--- a/wazo_confd/plugins/parking_lot/tests/test_notifier.py
+++ b/wazo_confd/plugins/parking_lot/tests/test_notifier.py
@@ -4,7 +4,7 @@
 import unittest
 
 from uuid import uuid4
-from mock import Mock
+from unittest.mock import Mock
 
 from xivo_bus.resources.parking_lot.event import (
     CreateParkingLotEvent,

--- a/wazo_confd/plugins/parking_lot_extension/tests/test_notifier.py
+++ b/wazo_confd/plugins/parking_lot_extension/tests/test_notifier.py
@@ -4,7 +4,7 @@
 import unittest
 
 from uuid import uuid4
-from mock import Mock
+from unittest.mock import Mock
 
 from xivo_bus.resources.parking_lot_extension.event import (
     ParkingLotExtensionAssociatedEvent,

--- a/wazo_confd/plugins/provisioning_networking/tests/test_notifier.py
+++ b/wazo_confd/plugins/provisioning_networking/tests/test_notifier.py
@@ -1,9 +1,9 @@
-# Copyright 2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import unittest
 
-from mock import Mock
+from unittest.mock import Mock
 from xivo_bus.resources.provisioning_networking.event import (
     EditProvisioningNetworkingEvent,
 )

--- a/wazo_confd/plugins/queue/tests/test_notifier.py
+++ b/wazo_confd/plugins/queue/tests/test_notifier.py
@@ -4,7 +4,7 @@
 import unittest
 
 from uuid import uuid4
-from mock import Mock
+from unittest.mock import Mock
 
 from xivo_bus.resources.queue.event import (
     CreateQueueEvent,

--- a/wazo_confd/plugins/queue_extension/tests/test_notifier.py
+++ b/wazo_confd/plugins/queue_extension/tests/test_notifier.py
@@ -4,7 +4,7 @@
 import unittest
 
 from uuid import uuid4
-from mock import Mock
+from unittest.mock import Mock
 
 from xivo_bus.resources.queue_extension.event import (
     QueueExtensionAssociatedEvent,

--- a/wazo_confd/plugins/queue_fallback/tests/test_notifier.py
+++ b/wazo_confd/plugins/queue_fallback/tests/test_notifier.py
@@ -4,7 +4,7 @@
 import unittest
 
 from uuid import uuid4
-from mock import Mock
+from unittest.mock import Mock
 
 from xivo_bus.resources.queue.event import EditQueueFallbackEvent
 from xivo_dao.alchemy.queuefeatures import QueueFeatures as Queue

--- a/wazo_confd/plugins/queue_general/tests/test_notifier.py
+++ b/wazo_confd/plugins/queue_general/tests/test_notifier.py
@@ -1,8 +1,8 @@
-# Copyright 2018-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import unittest
-from mock import Mock
+from unittest.mock import Mock
 
 from xivo_bus.resources.queue_general.event import EditQueueGeneralEvent
 

--- a/wazo_confd/plugins/queue_member/tests/test_notifier.py
+++ b/wazo_confd/plugins/queue_member/tests/test_notifier.py
@@ -4,7 +4,7 @@
 import unittest
 
 from uuid import uuid4
-from mock import Mock, call
+from unittest.mock import Mock, call
 
 from xivo_bus.resources.queue_member.event import (
     QueueMemberAgentAssociatedEvent,

--- a/wazo_confd/plugins/queue_schedule/tests/test_notifier.py
+++ b/wazo_confd/plugins/queue_schedule/tests/test_notifier.py
@@ -4,7 +4,7 @@
 import unittest
 
 from uuid import uuid4
-from mock import Mock
+from unittest.mock import Mock
 
 from xivo_bus.resources.queue_schedule.event import (
     QueueScheduleAssociatedEvent,

--- a/wazo_confd/plugins/register_iax/tests/test_notifier.py
+++ b/wazo_confd/plugins/register_iax/tests/test_notifier.py
@@ -1,8 +1,8 @@
-# Copyright 2017-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import unittest
-from mock import Mock
+from unittest.mock import Mock
 
 from xivo_bus.resources.register.event import (
     CreateRegisterIAXEvent,

--- a/wazo_confd/plugins/register_iax/tests/test_schema.py
+++ b/wazo_confd/plugins/register_iax/tests/test_schema.py
@@ -1,8 +1,8 @@
-# Copyright 2017-2021 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import unittest
-from mock import Mock
+from unittest.mock import Mock
 from hamcrest import calling, assert_that, equal_to, has_entries, has_key, has_property
 from marshmallow import ValidationError
 from wazo_test_helpers.hamcrest.raises import raises

--- a/wazo_confd/plugins/registrar/tests/test_notifier.py
+++ b/wazo_confd/plugins/registrar/tests/test_notifier.py
@@ -1,8 +1,8 @@
-# Copyright 2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import unittest
-from mock import Mock
+from unittest.mock import Mock
 
 from xivo_bus.resources.registrar.event import (
     CreateRegistrarEvent,

--- a/wazo_confd/plugins/rtp/tests/test_notifier.py
+++ b/wazo_confd/plugins/rtp/tests/test_notifier.py
@@ -1,8 +1,8 @@
-# Copyright 2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import unittest
-from mock import Mock
+from unittest.mock import Mock
 
 from xivo_bus.resources.rtp.event import (
     EditRTPGeneralEvent,

--- a/wazo_confd/plugins/sccp_general/tests/test_notifier.py
+++ b/wazo_confd/plugins/sccp_general/tests/test_notifier.py
@@ -1,9 +1,9 @@
-# Copyright 2017-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import unittest
 
-from mock import Mock
+from unittest.mock import Mock
 
 from xivo_bus.resources.sccp_general.event import EditSCCPGeneralEvent
 from xivo_dao.alchemy.sccpgeneralsettings import SCCPGeneralSettings

--- a/wazo_confd/plugins/schedule/tests/test_notifier.py
+++ b/wazo_confd/plugins/schedule/tests/test_notifier.py
@@ -4,7 +4,7 @@
 import unittest
 
 from uuid import uuid4
-from mock import Mock
+from unittest.mock import Mock
 
 from xivo_bus.resources.schedule.event import (
     CreateScheduleEvent,

--- a/wazo_confd/plugins/skill/tests/test_notifier.py
+++ b/wazo_confd/plugins/skill/tests/test_notifier.py
@@ -4,7 +4,7 @@
 import unittest
 
 from uuid import uuid4
-from mock import Mock
+from unittest.mock import Mock
 
 from xivo_bus.resources.skill.event import (
     CreateSkillEvent,

--- a/wazo_confd/plugins/skill_rule/tests/test_notifier.py
+++ b/wazo_confd/plugins/skill_rule/tests/test_notifier.py
@@ -4,7 +4,7 @@
 import unittest
 
 from uuid import uuid4
-from mock import Mock
+from unittest.mock import Mock
 
 from xivo_bus.resources.skill_rule.event import (
     CreateSkillRuleEvent,

--- a/wazo_confd/plugins/switchboard_fallback/tests/test_notifier.py
+++ b/wazo_confd/plugins/switchboard_fallback/tests/test_notifier.py
@@ -4,7 +4,7 @@
 import unittest
 
 from uuid import uuid4
-from mock import Mock
+from unittest.mock import Mock
 
 from xivo_bus.resources.switchboard.event import EditSwitchboardFallbackEvent
 from xivo_dao.alchemy.switchboard import Switchboard

--- a/wazo_confd/plugins/trunk/tests/test_notifier.py
+++ b/wazo_confd/plugins/trunk/tests/test_notifier.py
@@ -4,7 +4,7 @@
 import unittest
 
 from uuid import uuid4
-from mock import Mock
+from unittest.mock import Mock
 
 from xivo_bus.resources.trunk.event import (
     CreateTrunkEvent,

--- a/wazo_confd/plugins/trunk_endpoint/tests/test_notifier.py
+++ b/wazo_confd/plugins/trunk_endpoint/tests/test_notifier.py
@@ -4,7 +4,7 @@
 import unittest
 import uuid
 
-from mock import Mock
+from unittest.mock import Mock
 
 from xivo_bus.resources.trunk_endpoint.event import (
     TrunkEndpointCustomAssociatedEvent,

--- a/wazo_confd/plugins/trunk_register/tests/test_notifier.py
+++ b/wazo_confd/plugins/trunk_register/tests/test_notifier.py
@@ -4,7 +4,7 @@
 import unittest
 
 from uuid import uuid4
-from mock import Mock
+from unittest.mock import Mock
 from xivo_bus.resources.trunk_register.event import (
     TrunkRegisterIAXAssociatedEvent,
     TrunkRegisterIAXDissociatedEvent,

--- a/wazo_confd/plugins/user/tests/test_notifier.py
+++ b/wazo_confd/plugins/user/tests/test_notifier.py
@@ -4,7 +4,7 @@
 import datetime
 import unittest
 import uuid
-from mock import Mock, call
+from unittest.mock import Mock, call
 
 from xivo_bus.resources.user.event import (
     CreateUserEvent,

--- a/wazo_confd/plugins/user/tests/test_schema.py
+++ b/wazo_confd/plugins/user/tests/test_schema.py
@@ -1,8 +1,8 @@
-# Copyright 2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import unittest
-from mock import Mock
+from unittest.mock import Mock
 
 from hamcrest import assert_that, equal_to
 

--- a/wazo_confd/plugins/user/tests/test_validator.py
+++ b/wazo_confd/plugins/user/tests/test_validator.py
@@ -1,9 +1,9 @@
-# Copyright 2013-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2013-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import unittest
 
-from mock import Mock, sentinel
+from unittest.mock import Mock, sentinel
 
 from xivo_dao.alchemy.user_line import UserLine
 from xivo_dao.alchemy.userfeatures import UserFeatures as User

--- a/wazo_confd/plugins/user_agent/tests/test_notifier.py
+++ b/wazo_confd/plugins/user_agent/tests/test_notifier.py
@@ -4,7 +4,7 @@
 import unittest
 
 from uuid import uuid4
-from mock import Mock
+from unittest.mock import Mock
 
 from xivo_bus.resources.user_agent.event import (
     UserAgentAssociatedEvent,

--- a/wazo_confd/plugins/user_call_permission/tests/test_notifier.py
+++ b/wazo_confd/plugins/user_call_permission/tests/test_notifier.py
@@ -4,7 +4,7 @@
 import unittest
 
 from uuid import uuid4
-from mock import Mock
+from unittest.mock import Mock
 
 from xivo_bus.resources.user_call_permission.event import (
     UserCallPermissionAssociatedEvent,

--- a/wazo_confd/plugins/user_external_app/tests/test_notifier.py
+++ b/wazo_confd/plugins/user_external_app/tests/test_notifier.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import unittest
-from mock import Mock
+from unittest.mock import Mock
 from uuid import uuid4
 
 from xivo_bus.resources.user_external_app.event import (

--- a/wazo_confd/plugins/user_fallback/tests/test_notifier.py
+++ b/wazo_confd/plugins/user_fallback/tests/test_notifier.py
@@ -4,7 +4,7 @@
 import unittest
 
 from uuid import uuid4
-from mock import Mock
+from unittest.mock import Mock
 
 from xivo_bus.resources.user.event import EditUserFallbackEvent
 from xivo_dao.alchemy.userfeatures import UserFeatures as User

--- a/wazo_confd/plugins/user_group/tests/test_notifier.py
+++ b/wazo_confd/plugins/user_group/tests/test_notifier.py
@@ -4,7 +4,7 @@
 import unittest
 
 from uuid import uuid4
-from mock import Mock
+from unittest.mock import Mock
 
 from xivo_bus.resources.user_group.event import UserGroupsAssociatedEvent
 from xivo_dao.alchemy.userfeatures import UserFeatures as User

--- a/wazo_confd/plugins/user_import/tests/test_wazo_user_service.py
+++ b/wazo_confd/plugins/user_import/tests/test_wazo_user_service.py
@@ -1,10 +1,10 @@
-# Copyright 2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import unittest
 
 from hamcrest import assert_that, contains, has_entries, has_items
-from mock import Mock, sentinel as s
+from unittest.mock import Mock, sentinel as s
 
 from ..wazo_user_service import WazoUserService
 

--- a/wazo_confd/plugins/user_line/tests/test_notifier.py
+++ b/wazo_confd/plugins/user_line/tests/test_notifier.py
@@ -4,8 +4,8 @@
 import unittest
 import uuid
 
-from mock import Mock
-from mock import patch
+from unittest.mock import Mock
+from unittest.mock import patch
 from xivo_bus.resources.user_line.event import (
     UserLineAssociatedEvent,
     UserLineDissociatedEvent,

--- a/wazo_confd/plugins/user_schedule/tests/test_notifier.py
+++ b/wazo_confd/plugins/user_schedule/tests/test_notifier.py
@@ -4,7 +4,7 @@
 import unittest
 
 from uuid import uuid4
-from mock import Mock
+from unittest.mock import Mock
 
 from xivo_bus.resources.user_schedule.event import (
     UserScheduleAssociatedEvent,

--- a/wazo_confd/plugins/user_voicemail/tests/test_notifier.py
+++ b/wazo_confd/plugins/user_voicemail/tests/test_notifier.py
@@ -4,7 +4,7 @@
 import unittest
 
 from uuid import uuid4
-from mock import Mock
+from unittest.mock import Mock
 from xivo_bus.resources.user_voicemail.event import (
     UserVoicemailAssociatedEvent,
     UserVoicemailDissociatedEvent,

--- a/wazo_confd/plugins/voicemail/tests/test_notifier.py
+++ b/wazo_confd/plugins/voicemail/tests/test_notifier.py
@@ -5,7 +5,7 @@ import unittest
 
 from hamcrest import assert_that, contains
 from uuid import uuid4
-from mock import call, Mock
+from unittest.mock import call, Mock
 
 from xivo_dao.alchemy.voicemail import Voicemail
 

--- a/wazo_confd/plugins/voicemail/tests/test_validator.py
+++ b/wazo_confd/plugins/voicemail/tests/test_validator.py
@@ -1,9 +1,9 @@
-# Copyright 2013-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2013-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import unittest
 
-from mock import Mock, sentinel
+from unittest.mock import Mock, sentinel
 from hamcrest import assert_that, calling, raises
 
 from xivo_dao.alchemy.voicemail import Voicemail

--- a/wazo_confd/plugins/voicemail_general/tests/test_notifier.py
+++ b/wazo_confd/plugins/voicemail_general/tests/test_notifier.py
@@ -1,8 +1,8 @@
-# Copyright 2017-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import unittest
-from mock import Mock
+from unittest.mock import Mock
 
 from xivo_bus.resources.voicemail_general.event import EditVoicemailGeneralEvent
 from xivo_dao.alchemy.staticvoicemail import StaticVoicemail

--- a/wazo_confd/plugins/voicemail_zonemessages/tests/test_notifier.py
+++ b/wazo_confd/plugins/voicemail_zonemessages/tests/test_notifier.py
@@ -1,8 +1,8 @@
-# Copyright 2017-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import unittest
-from mock import Mock
+from unittest.mock import Mock
 
 from xivo_bus.resources.voicemail_zonemessages.event import (
     EditVoicemailZoneMessagesEvent,

--- a/wazo_confd/plugins/wizard/tests/test_notifier.py
+++ b/wazo_confd/plugins/wizard/tests/test_notifier.py
@@ -1,8 +1,8 @@
-# Copyright 2016-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import unittest
-from mock import Mock
+from unittest.mock import Mock
 
 from xivo_bus.resources.wizard.event import CreateWizardEvent
 

--- a/wazo_confd/plugins/wizard/tests/test_service.py
+++ b/wazo_confd/plugins/wizard/tests/test_service.py
@@ -1,11 +1,11 @@
-# Copyright 2016-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import unittest
 
 from textwrap import dedent
 
-from mock import Mock, patch, mock_open
+from unittest.mock import Mock, patch, mock_open
 from hamcrest import assert_that, equal_to, empty, none
 
 from ..service import WizardService

--- a/wazo_confd/tests/test_service_discovery.py
+++ b/wazo_confd/tests/test_service_discovery.py
@@ -1,10 +1,10 @@
-# Copyright 2016-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import unittest
 
 from hamcrest import assert_that, equal_to
-from mock import ANY, Mock, patch
+from unittest.mock import ANY, Mock, patch
 
 from ..service_discovery import self_check
 

--- a/wazo_confd/tests/test_sysconfd.py
+++ b/wazo_confd/tests/test_sysconfd.py
@@ -1,9 +1,9 @@
-# Copyright 2013-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2013-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from unittest import TestCase
 
-from mock import patch, Mock
+from unittest.mock import patch, Mock
 from hamcrest import assert_that, equal_to, has_entries, has_items
 
 from .._sysconfd import SysconfdPublisher


### PR DESCRIPTION
why: pypi version is a backport if the python3 builtin package