### PR TITLE
WAZO-2708 Remove 'agentbus' param when sysconfd called

### DIFF
--- a/wazo_confd/plugins/agent/notifier.py
+++ b/wazo_confd/plugins/agent/notifier.py
@@ -16,7 +16,7 @@ class AgentNotifier:
         self.sysconfd = sysconfd
 
     def send_sysconfd_handlers(self, ipbx_command=None):
-        handlers = {'ipbx': [ipbx_command] if ipbx_command else [], 'agentbus': []}
+        handlers = {'ipbx': [ipbx_command] if ipbx_command else []}
         self.sysconfd.exec_request_handlers(handlers)
 
     def created(self, agent):

--- a/wazo_confd/plugins/agent/tests/test_notifier.py
+++ b/wazo_confd/plugins/agent/tests/test_notifier.py
@@ -24,7 +24,7 @@ class TestAgentNotifier(unittest.TestCase):
         self.notifier = AgentNotifier(self.bus, self.sysconfd)
 
     def _expected_handlers(self, ipbx_command=None):
-        return {'ipbx': [ipbx_command] if ipbx_command else [], 'agentbus': []}
+        return {'ipbx': [ipbx_command] if ipbx_command else []}
 
     def test_when_agent_created_then_call_expected_handlers(self):
         self.notifier.created(self.agent)

--- a/wazo_confd/plugins/agent_skill/notifier.py
+++ b/wazo_confd/plugins/agent_skill/notifier.py
@@ -15,7 +15,7 @@ class AgentSkillNotifier:
         self.sysconfd = sysconfd
 
     def send_sysconfd_handlers(self):
-        handlers = {'ipbx': ['module reload app_queue.so'], 'agentbus': []}
+        handlers = {'ipbx': ['module reload app_queue.so']}
         self.sysconfd.exec_request_handlers(handlers)
 
     def skill_associated(self, skill, agent_skill):

--- a/wazo_confd/plugins/agent_skill/tests/test_notifier.py
+++ b/wazo_confd/plugins/agent_skill/tests/test_notifier.py
@@ -13,7 +13,7 @@ from xivo_bus.resources.agent_skill.event import (
 
 from ..notifier import AgentSkillNotifier
 
-EXPECTED_HANDLERS = {'ipbx': ['module reload app_queue.so'], 'agentbus': []}
+EXPECTED_HANDLERS = {'ipbx': ['module reload app_queue.so']}
 
 
 class TestAgentMemberNotifier(unittest.TestCase):

--- a/wazo_confd/plugins/call_pickup/notifier.py
+++ b/wazo_confd/plugins/call_pickup/notifier.py
@@ -17,8 +17,7 @@ class CallPickupNotifier:
 
     def send_sysconfd_handlers(self):
         handlers = {
-            'ipbx': ['module reload res_pjsip.so', 'module reload chan_sccp.so'],
-            'agentbus': [],
+            'ipbx': ['module reload res_pjsip.so', 'module reload chan_sccp.so']
         }
         self.sysconfd.exec_request_handlers(handlers)
 

--- a/wazo_confd/plugins/call_pickup/tests/test_notifier.py
+++ b/wazo_confd/plugins/call_pickup/tests/test_notifier.py
@@ -16,8 +16,7 @@ from xivo_dao.alchemy.pickup import Pickup as CallPickup
 from ..notifier import CallPickupNotifier
 
 SYSCONFD_HANDLERS = {
-    'ipbx': ['module reload res_pjsip.so', 'module reload chan_sccp.so'],
-    'agentbus': [],
+    'ipbx': ['module reload res_pjsip.so', 'module reload chan_sccp.so']
 }
 
 

--- a/wazo_confd/plugins/call_pickup_member/notifier.py
+++ b/wazo_confd/plugins/call_pickup_member/notifier.py
@@ -18,8 +18,7 @@ class CallPickupMemberNotifier:
 
     def send_sysconfd_handlers(self):
         handlers = {
-            'ipbx': ['module reload res_pjsip.so', 'module reload chan_sccp.so'],
-            'agentbus': [],
+            'ipbx': ['module reload res_pjsip.so', 'module reload chan_sccp.so']
         }
         self.sysconfd.exec_request_handlers(handlers)
 

--- a/wazo_confd/plugins/call_pickup_member/tests/test_notifier.py
+++ b/wazo_confd/plugins/call_pickup_member/tests/test_notifier.py
@@ -19,8 +19,7 @@ from xivo_dao.alchemy.groupfeatures import GroupFeatures as Group
 from ..notifier import CallPickupMemberNotifier
 
 SYSCONFD_HANDLERS = {
-    'ipbx': ['module reload res_pjsip.so', 'module reload chan_sccp.so'],
-    'agentbus': [],
+    'ipbx': ['module reload res_pjsip.so', 'module reload chan_sccp.so']
 }
 
 

--- a/wazo_confd/plugins/confbridge/notifier.py
+++ b/wazo_confd/plugins/confbridge/notifier.py
@@ -15,7 +15,7 @@ class ConfBridgeConfigurationNotifier:
         self.sysconfd = sysconfd
 
     def send_sysconfd_handlers(self, ipbx):
-        handlers = {'ipbx': ipbx, 'agentbus': []}
+        handlers = {'ipbx': ipbx}
         self.sysconfd.exec_request_handlers(handlers)
 
     def edited(self, section_name, confbridge):

--- a/wazo_confd/plugins/confbridge/tests/test_notifier.py
+++ b/wazo_confd/plugins/confbridge/tests/test_notifier.py
@@ -12,7 +12,7 @@ from xivo_bus.resources.confbridge.event import (
 from ..notifier import ConfBridgeConfigurationNotifier
 
 
-SYSCONFD_HANDLERS = {'ipbx': ['module reload app_confbridge.so'], 'agentbus': []}
+SYSCONFD_HANDLERS = {'ipbx': ['module reload app_confbridge.so']}
 
 
 class TestConfBridgeConfigurationNotifier(unittest.TestCase):

--- a/wazo_confd/plugins/conference/notifier.py
+++ b/wazo_confd/plugins/conference/notifier.py
@@ -16,7 +16,7 @@ class ConferenceNotifier:
         self.sysconfd = sysconfd
 
     def send_sysconfd_handlers(self):
-        handlers = {'ipbx': ['module reload app_confbridge.so'], 'agentbus': []}
+        handlers = {'ipbx': ['module reload app_confbridge.so']}
         self.sysconfd.exec_request_handlers(handlers)
 
     def created(self, conference):

--- a/wazo_confd/plugins/conference/tests/test_notifier.py
+++ b/wazo_confd/plugins/conference/tests/test_notifier.py
@@ -14,7 +14,7 @@ from xivo_bus.resources.conference.event import (
 
 from ..notifier import ConferenceNotifier
 
-EXPECTED_HANDLERS = {'ipbx': ['module reload app_confbridge.so'], 'agentbus': []}
+EXPECTED_HANDLERS = {'ipbx': ['module reload app_confbridge.so']}
 
 
 class TestConferenceNotifier(unittest.TestCase):

--- a/wazo_confd/plugins/conference_extension/notifier.py
+++ b/wazo_confd/plugins/conference_extension/notifier.py
@@ -15,7 +15,7 @@ class ConferenceExtensionNotifier:
         self.sysconfd = sysconfd
 
     def send_sysconfd_handlers(self):
-        handlers = {'ipbx': ['dialplan reload'], 'agentbus': []}
+        handlers = {'ipbx': ['dialplan reload']}
         self.sysconfd.exec_request_handlers(handlers)
 
     def associated(self, conference, extension):

--- a/wazo_confd/plugins/conference_extension/tests/test_notifier.py
+++ b/wazo_confd/plugins/conference_extension/tests/test_notifier.py
@@ -15,7 +15,7 @@ from xivo_dao.alchemy.conference import Conference
 
 from ..notifier import ConferenceExtensionNotifier
 
-SYSCONFD_HANDLERS = {'ipbx': ['dialplan reload'], 'agentbus': []}
+SYSCONFD_HANDLERS = {'ipbx': ['dialplan reload']}
 
 
 class TestConferenceExtensionNotifier(unittest.TestCase):

--- a/wazo_confd/plugins/context/notifier.py
+++ b/wazo_confd/plugins/context/notifier.py
@@ -20,7 +20,7 @@ class ContextNotifier:
         self.sysconfd = sysconfd
 
     def send_sysconfd_handlers(self):
-        handlers = {'ipbx': ['dialplan reload'], 'agentbus': []}
+        handlers = {'ipbx': ['dialplan reload']}
         self.sysconfd.exec_request_handlers(handlers)
 
     def created(self, context):

--- a/wazo_confd/plugins/context/tests/test_notifier.py
+++ b/wazo_confd/plugins/context/tests/test_notifier.py
@@ -13,7 +13,7 @@ from xivo_bus.resources.context.event import (
 
 from ..notifier import ContextNotifier
 
-EXPECTED_HANDLERS = {'ipbx': ['dialplan reload'], 'agentbus': []}
+EXPECTED_HANDLERS = {'ipbx': ['dialplan reload']}
 
 
 class TestContextNotifier(unittest.TestCase):

--- a/wazo_confd/plugins/context_context/notifier.py
+++ b/wazo_confd/plugins/context_context/notifier.py
@@ -12,7 +12,7 @@ class ContextContextNotifier:
         self.sysconfd = sysconfd
 
     def send_sysconfd_handlers(self):
-        handlers = {'ipbx': ['dialplan reload'], 'agentbus': []}
+        handlers = {'ipbx': ['dialplan reload']}
         self.sysconfd.exec_request_handlers(handlers)
 
     def associated_contexts(self, context, contexts):

--- a/wazo_confd/plugins/context_context/tests/test_notifier.py
+++ b/wazo_confd/plugins/context_context/tests/test_notifier.py
@@ -11,7 +11,7 @@ from xivo_dao.alchemy.context import Context
 
 from ..notifier import ContextContextNotifier
 
-EXPECTED_HANDLERS = {'ipbx': ['dialplan reload'], 'agentbus': []}
+EXPECTED_HANDLERS = {'ipbx': ['dialplan reload']}
 
 
 class TestContextContextNotifier(unittest.TestCase):

--- a/wazo_confd/plugins/endpoint_iax/notifier.py
+++ b/wazo_confd/plugins/endpoint_iax/notifier.py
@@ -25,7 +25,7 @@ class IAXEndpointNotifier:
         self.bus = bus
 
     def send_sysconfd_handlers(self):
-        handlers = {'ipbx': ['iax2 reload'], 'agentbus': []}
+        handlers = {'ipbx': ['iax2 reload']}
         self.sysconfd.exec_request_handlers(handlers)
 
     def created(self, iax):

--- a/wazo_confd/plugins/endpoint_iax/tests/test_notifier.py
+++ b/wazo_confd/plugins/endpoint_iax/tests/test_notifier.py
@@ -16,7 +16,7 @@ from xivo_dao.alchemy.useriax import UserIAX as IAX
 from ..notifier import IAXEndpointNotifier
 
 
-SYSCONFD_HANDLERS = {'ipbx': ['iax2 reload'], 'agentbus': []}
+SYSCONFD_HANDLERS = {'ipbx': ['iax2 reload']}
 
 
 class TestIAXEndpointNotifier(unittest.TestCase):

--- a/wazo_confd/plugins/endpoint_sccp/notifier.py
+++ b/wazo_confd/plugins/endpoint_sccp/notifier.py
@@ -25,8 +25,7 @@ class SccpEndpointNotifier:
 
     def send_sysconfd_handlers(self):
         handlers = {
-            'ipbx': ['module reload chan_sccp.so', 'dialplan reload'],
-            'agentbus': [],
+            'ipbx': ['module reload chan_sccp.so', 'dialplan reload']
         }
         self.sysconfd.exec_request_handlers(handlers)
 

--- a/wazo_confd/plugins/endpoint_sccp/notifier.py
+++ b/wazo_confd/plugins/endpoint_sccp/notifier.py
@@ -24,9 +24,7 @@ class SccpEndpointNotifier:
         self.bus = bus
 
     def send_sysconfd_handlers(self):
-        handlers = {
-            'ipbx': ['module reload chan_sccp.so', 'dialplan reload']
-        }
+        handlers = {'ipbx': ['module reload chan_sccp.so', 'dialplan reload']}
         self.sysconfd.exec_request_handlers(handlers)
 
     def created(self, sccp):

--- a/wazo_confd/plugins/endpoint_sccp/tests/test_notifier.py
+++ b/wazo_confd/plugins/endpoint_sccp/tests/test_notifier.py
@@ -15,9 +15,7 @@ from xivo_dao.alchemy.sccpline import SCCPLine as SCCP
 
 from ..notifier import SccpEndpointNotifier
 
-SYSCONFD_HANDLERS = {
-    'ipbx': ['module reload chan_sccp.so', 'dialplan reload']
-}
+SYSCONFD_HANDLERS = {'ipbx': ['module reload chan_sccp.so', 'dialplan reload']}
 
 
 class TestSccpEndpointNotifier(unittest.TestCase):

--- a/wazo_confd/plugins/endpoint_sccp/tests/test_notifier.py
+++ b/wazo_confd/plugins/endpoint_sccp/tests/test_notifier.py
@@ -16,8 +16,7 @@ from xivo_dao.alchemy.sccpline import SCCPLine as SCCP
 from ..notifier import SccpEndpointNotifier
 
 SYSCONFD_HANDLERS = {
-    'ipbx': ['module reload chan_sccp.so', 'dialplan reload'],
-    'agentbus': [],
+    'ipbx': ['module reload chan_sccp.so', 'dialplan reload']
 }
 
 

--- a/wazo_confd/plugins/endpoint_sip/notifier.py
+++ b/wazo_confd/plugins/endpoint_sip/notifier.py
@@ -33,8 +33,7 @@ class SipEndpointNotifier:
 
     def send_sysconfd_handlers(self):
         handlers = {
-            'ipbx': ['module reload res_pjsip.so', 'dialplan reload'],
-            'agentbus': [],
+            'ipbx': ['module reload res_pjsip.so', 'dialplan reload']
         }
         self.sysconfd.exec_request_handlers(handlers)
 
@@ -69,8 +68,7 @@ class SipTemplateNotifier:
 
     def send_sysconfd_handlers(self):
         handlers = {
-            'ipbx': ['module reload res_pjsip.so', 'dialplan reload'],
-            'agentbus': [],
+            'ipbx': ['module reload res_pjsip.so', 'dialplan reload']
         }
         self.sysconfd.exec_request_handlers(handlers)
 

--- a/wazo_confd/plugins/endpoint_sip/notifier.py
+++ b/wazo_confd/plugins/endpoint_sip/notifier.py
@@ -32,9 +32,7 @@ class SipEndpointNotifier:
         self.bus = bus
 
     def send_sysconfd_handlers(self):
-        handlers = {
-            'ipbx': ['module reload res_pjsip.so', 'dialplan reload']
-        }
+        handlers = {'ipbx': ['module reload res_pjsip.so', 'dialplan reload']}
         self.sysconfd.exec_request_handlers(handlers)
 
     def created(self, sip):
@@ -67,9 +65,7 @@ class SipTemplateNotifier:
         self.bus = bus
 
     def send_sysconfd_handlers(self):
-        handlers = {
-            'ipbx': ['module reload res_pjsip.so', 'dialplan reload']
-        }
+        handlers = {'ipbx': ['module reload res_pjsip.so', 'dialplan reload']}
         self.sysconfd.exec_request_handlers(handlers)
 
     def created(self, sip):

--- a/wazo_confd/plugins/endpoint_sip/tests/test_notifier.py
+++ b/wazo_confd/plugins/endpoint_sip/tests/test_notifier.py
@@ -18,8 +18,7 @@ from ..notifier import SipEndpointNotifier, SipTemplateNotifier
 
 
 SYSCONFD_HANDLERS = {
-    'ipbx': ['module reload res_pjsip.so', 'dialplan reload'],
-    'agentbus': [],
+    'ipbx': ['module reload res_pjsip.so', 'dialplan reload']
 }
 
 

--- a/wazo_confd/plugins/endpoint_sip/tests/test_notifier.py
+++ b/wazo_confd/plugins/endpoint_sip/tests/test_notifier.py
@@ -17,9 +17,7 @@ from xivo_bus.resources.endpoint_sip.event import (
 from ..notifier import SipEndpointNotifier, SipTemplateNotifier
 
 
-SYSCONFD_HANDLERS = {
-    'ipbx': ['module reload res_pjsip.so', 'dialplan reload']
-}
+SYSCONFD_HANDLERS = {'ipbx': ['module reload res_pjsip.so', 'dialplan reload']}
 
 
 class TestSipEndpointNotifier(unittest.TestCase):

--- a/wazo_confd/plugins/extension/notifier.py
+++ b/wazo_confd/plugins/extension/notifier.py
@@ -16,7 +16,7 @@ class ExtensionNotifier:
         self.bus = bus
 
     def send_sysconfd_handlers(self, ipbx):
-        handlers = {'ipbx': ipbx, 'agentbus': []}
+        handlers = {'ipbx': ipbx}
         self.sysconfd.exec_request_handlers(handlers)
 
     def created(self, extension):

--- a/wazo_confd/plugins/extension/tests/test_notifier.py
+++ b/wazo_confd/plugins/extension/tests/test_notifier.py
@@ -43,7 +43,7 @@ class TestExtensionNotifier(unittest.TestCase):
         )
 
     def test_when_extension_created_then_dialplan_reloaded(self):
-        expected_handlers = {'ipbx': ['dialplan reload'], 'agentbus': []}
+        expected_handlers = {'ipbx': ['dialplan reload']}
         self.notifier.created(self.extension)
 
         self.sysconfd.exec_request_handlers.assert_called_once_with(expected_handlers)
@@ -55,8 +55,7 @@ class TestExtensionNotifier(unittest.TestCase):
                 'module reload res_pjsip.so',
                 'module reload chan_sccp.so',
                 'module reload app_queue.so',
-            ],
-            'agentbus': [],
+            ]
         }
         updated_fields = ['exten']
         self.notifier.edited(self.extension, updated_fields)
@@ -70,8 +69,7 @@ class TestExtensionNotifier(unittest.TestCase):
                 'module reload res_pjsip.so',
                 'module reload chan_sccp.so',
                 'module reload app_queue.so',
-            ],
-            'agentbus': [],
+            ]
         }
         self.notifier.edited(self.extension, None)
 
@@ -95,7 +93,7 @@ class TestExtensionNotifier(unittest.TestCase):
         )
 
     def test_when_extension_deleted_then_dialplan_reloaded(self):
-        expected_handlers = {'ipbx': ['dialplan reload'], 'agentbus': []}
+        expected_handlers = {'ipbx': ['dialplan reload']}
         self.notifier.deleted(self.extension)
 
         self.sysconfd.exec_request_handlers.assert_called_once_with(expected_handlers)

--- a/wazo_confd/plugins/extension_feature/notifier.py
+++ b/wazo_confd/plugins/extension_feature/notifier.py
@@ -12,7 +12,7 @@ class ExtensionFeatureNotifier:
         self.bus = bus
 
     def send_sysconfd_handlers(self, ipbx):
-        handlers = {'ipbx': ipbx, 'agentbus': []}
+        handlers = {'ipbx': ipbx}
         self.sysconfd.exec_request_handlers(handlers)
 
     def edited(self, extension, updated_fields):

--- a/wazo_confd/plugins/extension_feature/tests/test_notifier.py
+++ b/wazo_confd/plugins/extension_feature/tests/test_notifier.py
@@ -20,7 +20,7 @@ class TestExtensionFeatureNotifier(unittest.TestCase):
         self.notifier = ExtensionFeatureNotifier(self.sysconfd, self.bus)
 
     def test_when_extension_edited_then_handlers_sent(self):
-        expected_handlers = {'ipbx': ['dialplan reload'], 'agentbus': []}
+        expected_handlers = {'ipbx': ['dialplan reload']}
         updated_fields = ['exten']
         self.notifier.edited(self.extension, updated_fields)
 

--- a/wazo_confd/plugins/features/notifier.py
+++ b/wazo_confd/plugins/features/notifier.py
@@ -16,7 +16,7 @@ class FeaturesConfigurationNotifier:
         self.sysconfd = sysconfd
 
     def send_sysconfd_handlers(self, ipbx):
-        handlers = {'ipbx': ipbx, 'agentbus': []}
+        handlers = {'ipbx': ipbx}
         self.sysconfd.exec_request_handlers(handlers)
 
     def edited(self, section_name, features):

--- a/wazo_confd/plugins/features/tests/test_notifier.py
+++ b/wazo_confd/plugins/features/tests/test_notifier.py
@@ -13,7 +13,7 @@ from xivo_bus.resources.features.event import (
 from ..notifier import FeaturesConfigurationNotifier
 
 
-SYSCONFD_HANDLERS = {'ipbx': ['module reload features'], 'agentbus': []}
+SYSCONFD_HANDLERS = {'ipbx': ['module reload features']}
 
 
 class TestFeaturesConfigurationNotifier(unittest.TestCase):

--- a/wazo_confd/plugins/func_key/notifier.py
+++ b/wazo_confd/plugins/func_key/notifier.py
@@ -18,7 +18,7 @@ class FuncKeyTemplateNotifier:
         self.device_db = device_db
 
     def send_sysconfd_handlers(self, ipbx):
-        handlers = {'ipbx': ipbx, 'agentbus': []}
+        handlers = {'ipbx': ipbx}
         self.sysconfd.exec_request_handlers(handlers)
 
     def created(self, template):

--- a/wazo_confd/plugins/func_key/tests/test_notifier.py
+++ b/wazo_confd/plugins/func_key/tests/test_notifier.py
@@ -15,8 +15,8 @@ from xivo_dao.alchemy.func_key_template import FuncKeyTemplate
 
 from ..notifier import FuncKeyTemplateNotifier
 
-SYSCONFD_HANDLERS = {'ipbx': ['dialplan reload'], 'agentbus': []}
-SYSCONFD_HANDLERS_SCCP = {'ipbx': ['module reload chan_sccp.so'], 'agentbus': []}
+SYSCONFD_HANDLERS = {'ipbx': ['dialplan reload']}
+SYSCONFD_HANDLERS_SCCP = {'ipbx': ['module reload chan_sccp.so']}
 
 
 class TestFuncKeyTemplateNotifier(unittest.TestCase):

--- a/wazo_confd/plugins/group/notifier.py
+++ b/wazo_confd/plugins/group/notifier.py
@@ -20,7 +20,7 @@ class GroupNotifier:
         self.sysconfd = sysconfd
 
     def send_sysconfd_handlers(self):
-        handlers = {'ipbx': ['module reload app_queue.so'], 'agentbus': []}
+        handlers = {'ipbx': ['module reload app_queue.so']}
         self.sysconfd.exec_request_handlers(handlers)
 
     def created(self, group):

--- a/wazo_confd/plugins/group/tests/test_notifier.py
+++ b/wazo_confd/plugins/group/tests/test_notifier.py
@@ -13,7 +13,7 @@ from xivo_bus.resources.group.event import (
 
 from ..notifier import GroupNotifier
 
-EXPECTED_HANDLERS = {'ipbx': ['module reload app_queue.so'], 'agentbus': []}
+EXPECTED_HANDLERS = {'ipbx': ['module reload app_queue.so']}
 
 
 class TestGroupNotifier(unittest.TestCase):

--- a/wazo_confd/plugins/group_extension/notifier.py
+++ b/wazo_confd/plugins/group_extension/notifier.py
@@ -15,7 +15,7 @@ class GroupExtensionNotifier:
         self.sysconfd = sysconfd
 
     def send_sysconfd_handlers(self):
-        handlers = {'ipbx': ['dialplan reload'], 'agentbus': []}
+        handlers = {'ipbx': ['dialplan reload']}
         self.sysconfd.exec_request_handlers(handlers)
 
     def associated(self, group, extension):

--- a/wazo_confd/plugins/group_extension/tests/test_notifier.py
+++ b/wazo_confd/plugins/group_extension/tests/test_notifier.py
@@ -15,7 +15,7 @@ from xivo_dao.alchemy.groupfeatures import GroupFeatures as Group
 
 from ..notifier import GroupExtensionNotifier
 
-SYSCONFD_HANDLERS = {'ipbx': ['dialplan reload'], 'agentbus': []}
+SYSCONFD_HANDLERS = {'ipbx': ['dialplan reload']}
 
 
 class TestGroupExtensionNotifier(unittest.TestCase):

--- a/wazo_confd/plugins/group_member/notifier.py
+++ b/wazo_confd/plugins/group_member/notifier.py
@@ -20,8 +20,7 @@ class GroupMemberNotifier:
                 'module reload res_pjsip.so',
                 'module reload app_queue.so',
                 'module reload chan_sccp.so',
-            ],
-            'agentbus': [],
+            ]
         }
         self.sysconfd.exec_request_handlers(handlers)
 

--- a/wazo_confd/plugins/group_member/tests/test_notifier.py
+++ b/wazo_confd/plugins/group_member/tests/test_notifier.py
@@ -18,8 +18,7 @@ SYSCONFD_HANDLERS = {
         'module reload res_pjsip.so',
         'module reload app_queue.so',
         'module reload chan_sccp.so',
-    ],
-    'agentbus': [],
+    ]
 }
 
 

--- a/wazo_confd/plugins/hep/notifier.py
+++ b/wazo_confd/plugins/hep/notifier.py
@@ -12,7 +12,7 @@ class HEPConfigurationNotifier:
         self.sysconfd = sysconfd
 
     def send_sysconfd_handlers(self, ipbx):
-        handlers = {'ipbx': ipbx, 'agentbus': []}
+        handlers = {'ipbx': ipbx}
         self.sysconfd.exec_request_handlers(handlers)
 
     def edited(self, section_name, hep):

--- a/wazo_confd/plugins/hep/tests/test_notifier.py
+++ b/wazo_confd/plugins/hep/tests/test_notifier.py
@@ -9,7 +9,7 @@ from xivo_bus.resources.hep.event import HEPGeneralUpdatedEvent
 from ..notifier import HEPConfigurationNotifier
 
 
-SYSCONFD_HANDLERS = {'ipbx': ['module reload res_hep.so'], 'agentbus': []}
+SYSCONFD_HANDLERS = {'ipbx': ['module reload res_hep.so']}
 
 
 class TestHEPConfigurationNotifier(unittest.TestCase):

--- a/wazo_confd/plugins/iax_callnumberlimits/notifier.py
+++ b/wazo_confd/plugins/iax_callnumberlimits/notifier.py
@@ -12,7 +12,7 @@ class IAXCallNumberLimitsNotifier:
         self.sysconfd = sysconfd
 
     def send_sysconfd_handlers(self, ipbx):
-        handlers = {'ipbx': ipbx, 'agentbus': []}
+        handlers = {'ipbx': ipbx}
         self.sysconfd.exec_request_handlers(handlers)
 
     def edited(self, iax_callnumberlimits):

--- a/wazo_confd/plugins/iax_callnumberlimits/tests/test_notifier.py
+++ b/wazo_confd/plugins/iax_callnumberlimits/tests/test_notifier.py
@@ -9,7 +9,7 @@ from xivo_dao.alchemy.iaxcallnumberlimits import IAXCallNumberLimits
 
 from ..notifier import IAXCallNumberLimitsNotifier
 
-SYSCONFD_HANDLERS = {'ipbx': ['iax2 reload'], 'agentbus': []}
+SYSCONFD_HANDLERS = {'ipbx': ['iax2 reload']}
 
 
 class TestIAXCallNumberLimitsNotifier(unittest.TestCase):

--- a/wazo_confd/plugins/iax_general/notifier.py
+++ b/wazo_confd/plugins/iax_general/notifier.py
@@ -12,7 +12,7 @@ class IAXGeneralNotifier:
         self.sysconfd = sysconfd
 
     def send_sysconfd_handlers(self, ipbx):
-        handlers = {'ipbx': ipbx, 'agentbus': []}
+        handlers = {'ipbx': ipbx}
         self.sysconfd.exec_request_handlers(handlers)
 
     def edited(self, iax_general):

--- a/wazo_confd/plugins/iax_general/tests/test_notifier.py
+++ b/wazo_confd/plugins/iax_general/tests/test_notifier.py
@@ -9,7 +9,7 @@ from xivo_dao.alchemy.staticiax import StaticIAX
 
 from ..notifier import IAXGeneralNotifier
 
-SYSCONFD_HANDLERS = {'ipbx': ['iax2 reload'], 'agentbus': []}
+SYSCONFD_HANDLERS = {'ipbx': ['iax2 reload']}
 
 
 class TestIAXGeneralNotifier(unittest.TestCase):

--- a/wazo_confd/plugins/incall_extension/notifier.py
+++ b/wazo_confd/plugins/incall_extension/notifier.py
@@ -15,7 +15,7 @@ class IncallExtensionNotifier:
         self.sysconfd = sysconfd
 
     def send_sysconfd_handlers(self):
-        handlers = {'ipbx': ['dialplan reload'], 'agentbus': []}
+        handlers = {'ipbx': ['dialplan reload']}
         self.sysconfd.exec_request_handlers(handlers)
 
     def associated(self, incall, extension):

--- a/wazo_confd/plugins/incall_extension/tests/test_notifier.py
+++ b/wazo_confd/plugins/incall_extension/tests/test_notifier.py
@@ -15,7 +15,7 @@ from xivo_dao.alchemy.incall import Incall
 
 from ..notifier import IncallExtensionNotifier
 
-SYSCONFD_HANDLERS = {'ipbx': ['dialplan reload'], 'agentbus': []}
+SYSCONFD_HANDLERS = {'ipbx': ['dialplan reload']}
 
 
 class TestIncallExtensionNotifier(unittest.TestCase):

--- a/wazo_confd/plugins/ivr/notifier.py
+++ b/wazo_confd/plugins/ivr/notifier.py
@@ -12,7 +12,7 @@ class IvrNotifier:
         self.sysconfd = sysconfd
 
     def send_sysconfd_handlers(self):
-        handlers = {'ipbx': ['dialplan reload'], 'agentbus': []}
+        handlers = {'ipbx': ['dialplan reload']}
         self.sysconfd.exec_request_handlers(handlers)
 
     def created(self, ivr):

--- a/wazo_confd/plugins/ivr/tests/test_notifier.py
+++ b/wazo_confd/plugins/ivr/tests/test_notifier.py
@@ -11,7 +11,7 @@ from xivo_dao.alchemy.ivr import IVR
 from ..notifier import IvrNotifier
 
 
-SYSCONFD_HANDLERS = {'ipbx': ['dialplan reload'], 'agentbus': []}
+SYSCONFD_HANDLERS = {'ipbx': ['dialplan reload']}
 
 
 class TestIvrNotifier(unittest.TestCase):

--- a/wazo_confd/plugins/line/notifier.py
+++ b/wazo_confd/plugins/line/notifier.py
@@ -30,7 +30,6 @@ class LineNotifier:
                 'dialplan reload',
                 'module reload chan_sccp.so',
             ],
-            'agentbus': [],
         }
         self.sysconfd.exec_request_handlers(handlers)
 

--- a/wazo_confd/plugins/line/tests/test_notifier.py
+++ b/wazo_confd/plugins/line/tests/test_notifier.py
@@ -20,8 +20,7 @@ SYSCONFD_HANDLERS = {
         'module reload res_pjsip.so',
         'dialplan reload',
         'module reload chan_sccp.so',
-    ],
-    'agentbus': [],
+    ]
 }
 
 

--- a/wazo_confd/plugins/line_application/notifier.py
+++ b/wazo_confd/plugins/line_application/notifier.py
@@ -23,7 +23,7 @@ APPLICATION_FIELDS = ['uuid']
 
 class LineApplicationNotifier:
 
-    REQUEST_HANDLERS = {'ipbx': ['module reload res_pjsip.so'], 'agentbus': []}
+    REQUEST_HANDLERS = {'ipbx': ['module reload res_pjsip.so']}
 
     def __init__(self, bus, sysconfd):
         self._bus = bus

--- a/wazo_confd/plugins/line_application/tests/test_notifier.py
+++ b/wazo_confd/plugins/line_application/tests/test_notifier.py
@@ -18,7 +18,7 @@ from ..notifier import LineApplicationNotifier
 
 class TestLineApplicationNotifier(unittest.TestCase):
 
-    REQUEST_HANDLERS = {'ipbx': ['module reload res_pjsip.so'], 'agentbus': []}
+    REQUEST_HANDLERS = {'ipbx': ['module reload res_pjsip.so']}
 
     def setUp(self):
         self.sysconfd = Mock()

--- a/wazo_confd/plugins/line_device/notifier.py
+++ b/wazo_confd/plugins/line_device/notifier.py
@@ -23,7 +23,7 @@ DEVICE_FIELDS = ['id']
 
 class LineDeviceNotifier:
 
-    REQUEST_HANDLERS = {'ipbx': ['module reload chan_sccp.so'], 'agentbus': []}
+    REQUEST_HANDLERS = {'ipbx': ['module reload chan_sccp.so']}
 
     def __init__(self, bus, sysconfd):
         self._bus = bus

--- a/wazo_confd/plugins/line_device/tests/test_notifier.py
+++ b/wazo_confd/plugins/line_device/tests/test_notifier.py
@@ -21,7 +21,7 @@ from ..notifier import LineDeviceNotifier
 
 class TestLineDeviceNotifier(unittest.TestCase):
 
-    REQUEST_HANDLERS = {'ipbx': ['module reload chan_sccp.so'], 'agentbus': []}
+    REQUEST_HANDLERS = {'ipbx': ['module reload chan_sccp.so']}
 
     def setUp(self):
         self.sysconfd = Mock()

--- a/wazo_confd/plugins/line_extension/notifier.py
+++ b/wazo_confd/plugins/line_extension/notifier.py
@@ -19,8 +19,7 @@ class LineExtensionNotifier:
                 'dialplan reload',
                 'module reload res_pjsip.so',
                 'module reload app_queue.so',
-            ],
-            'agentbus': [],
+            ]
         }
         self.sysconfd.exec_request_handlers(handlers)
 

--- a/wazo_confd/plugins/line_extension/tests/test_notifier.py
+++ b/wazo_confd/plugins/line_extension/tests/test_notifier.py
@@ -20,8 +20,7 @@ SYSCONFD_HANDLERS = {
         'dialplan reload',
         'module reload res_pjsip.so',
         'module reload app_queue.so',
-    ],
-    'agentbus': [],
+    ]
 }
 
 

--- a/wazo_confd/plugins/meeting/notifier.py
+++ b/wazo_confd/plugins/meeting/notifier.py
@@ -43,7 +43,6 @@ class Notifier:
     def send_sysconfd_handlers(self, meeting, action):
         handlers = {
             'ipbx': ['module reload res_pjsip.so'],
-            'agentbus': [],
             'context': [
                 {
                     'resource_type': 'meeting',

--- a/wazo_confd/plugins/moh/notifier.py
+++ b/wazo_confd/plugins/moh/notifier.py
@@ -15,7 +15,7 @@ class MohNotifier:
         self.sysconfd = sysconfd
 
     def send_sysconfd_handlers(self):
-        handlers = {'ipbx': ['moh reload'], 'agentbus': []}
+        handlers = {'ipbx': ['moh reload']}
         self.sysconfd.exec_request_handlers(handlers)
 
     def created(self, moh):

--- a/wazo_confd/plugins/outcall_extension/notifier.py
+++ b/wazo_confd/plugins/outcall_extension/notifier.py
@@ -15,7 +15,7 @@ class OutcallExtensionNotifier:
         self.sysconfd = sysconfd
 
     def send_sysconfd_handlers(self):
-        handlers = {'ipbx': ['dialplan reload'], 'agentbus': []}
+        handlers = {'ipbx': ['dialplan reload']}
         self.sysconfd.exec_request_handlers(handlers)
 
     def associated(self, outcall, extension):

--- a/wazo_confd/plugins/outcall_extension/tests/test_notifier.py
+++ b/wazo_confd/plugins/outcall_extension/tests/test_notifier.py
@@ -15,7 +15,7 @@ from xivo_dao.alchemy.outcall import Outcall
 
 from ..notifier import OutcallExtensionNotifier
 
-SYSCONFD_HANDLERS = {'ipbx': ['dialplan reload'], 'agentbus': []}
+SYSCONFD_HANDLERS = {'ipbx': ['dialplan reload']}
 
 
 class TestOutcallExtensionNotifier(unittest.TestCase):

--- a/wazo_confd/plugins/parking_lot/notifier.py
+++ b/wazo_confd/plugins/parking_lot/notifier.py
@@ -16,7 +16,7 @@ class ParkingLotNotifier:
         self.sysconfd = sysconfd
 
     def send_sysconfd_handlers(self):
-        handlers = {'ipbx': ['module reload res_parking.so'], 'agentbus': []}
+        handlers = {'ipbx': ['module reload res_parking.so']}
         self.sysconfd.exec_request_handlers(handlers)
 
     def created(self, parking_lot):

--- a/wazo_confd/plugins/parking_lot/tests/test_notifier.py
+++ b/wazo_confd/plugins/parking_lot/tests/test_notifier.py
@@ -14,7 +14,7 @@ from xivo_bus.resources.parking_lot.event import (
 
 from ..notifier import ParkingLotNotifier
 
-EXPECTED_HANDLERS = {'ipbx': ['module reload res_parking.so'], 'agentbus': []}
+EXPECTED_HANDLERS = {'ipbx': ['module reload res_parking.so']}
 
 
 class TestParkingLotNotifier(unittest.TestCase):

--- a/wazo_confd/plugins/parking_lot_extension/notifier.py
+++ b/wazo_confd/plugins/parking_lot_extension/notifier.py
@@ -15,7 +15,7 @@ class ParkingLotExtensionNotifier:
         self.sysconfd = sysconfd
 
     def send_sysconfd_handlers(self):
-        handlers = {'ipbx': ['module reload res_parking.so'], 'agentbus': []}
+        handlers = {'ipbx': ['module reload res_parking.so']}
         self.sysconfd.exec_request_handlers(handlers)
 
     def associated(self, parking_lot, extension):

--- a/wazo_confd/plugins/parking_lot_extension/tests/test_notifier.py
+++ b/wazo_confd/plugins/parking_lot_extension/tests/test_notifier.py
@@ -15,7 +15,7 @@ from xivo_dao.alchemy.parking_lot import ParkingLot
 
 from ..notifier import ParkingLotExtensionNotifier
 
-SYSCONFD_HANDLERS = {'ipbx': ['module reload res_parking.so'], 'agentbus': []}
+SYSCONFD_HANDLERS = {'ipbx': ['module reload res_parking.so']}
 
 
 class TestParkingLotExtensionNotifier(unittest.TestCase):

--- a/wazo_confd/plugins/pjsip/notifier.py
+++ b/wazo_confd/plugins/pjsip/notifier.py
@@ -18,7 +18,7 @@ class PJSIPConfigurationNotifier:
         self.sysconfd = sysconfd
 
     def send_sysconfd_handlers(self, ipbx):
-        handlers = {'ipbx': ipbx, 'agentbus': []}
+        handlers = {'ipbx': ipbx}
         self.sysconfd.exec_request_handlers(handlers)
 
     def edited(self, section_name, file_):

--- a/wazo_confd/plugins/queue/notifier.py
+++ b/wazo_confd/plugins/queue/notifier.py
@@ -16,7 +16,7 @@ class QueueNotifier:
         self.sysconfd = sysconfd
 
     def send_sysconfd_handlers(self):
-        handlers = {'ipbx': ['module reload app_queue.so'], 'agentbus': []}
+        handlers = {'ipbx': ['module reload app_queue.so']}
         self.sysconfd.exec_request_handlers(handlers)
 
     def created(self, queue):

--- a/wazo_confd/plugins/queue/tests/test_notifier.py
+++ b/wazo_confd/plugins/queue/tests/test_notifier.py
@@ -14,7 +14,7 @@ from xivo_bus.resources.queue.event import (
 
 from ..notifier import QueueNotifier
 
-EXPECTED_HANDLERS = {'ipbx': ['module reload app_queue.so'], 'agentbus': []}
+EXPECTED_HANDLERS = {'ipbx': ['module reload app_queue.so']}
 
 
 class TestQueueNotifier(unittest.TestCase):

--- a/wazo_confd/plugins/queue_extension/notifier.py
+++ b/wazo_confd/plugins/queue_extension/notifier.py
@@ -15,7 +15,7 @@ class QueueExtensionNotifier:
         self.sysconfd = sysconfd
 
     def send_sysconfd_handlers(self):
-        handlers = {'ipbx': ['dialplan reload'], 'agentbus': []}
+        handlers = {'ipbx': ['dialplan reload']}
         self.sysconfd.exec_request_handlers(handlers)
 
     def associated(self, queue, extension):

--- a/wazo_confd/plugins/queue_extension/tests/test_notifier.py
+++ b/wazo_confd/plugins/queue_extension/tests/test_notifier.py
@@ -15,7 +15,7 @@ from xivo_dao.alchemy.queuefeatures import QueueFeatures as Queue
 
 from ..notifier import QueueExtensionNotifier
 
-SYSCONFD_HANDLERS = {'ipbx': ['dialplan reload'], 'agentbus': []}
+SYSCONFD_HANDLERS = {'ipbx': ['dialplan reload']}
 
 
 class TestQueueExtensionNotifier(unittest.TestCase):

--- a/wazo_confd/plugins/queue_general/notifier.py
+++ b/wazo_confd/plugins/queue_general/notifier.py
@@ -12,7 +12,7 @@ class QueueGeneralNotifier:
         self.sysconfd = sysconfd
 
     def send_sysconfd_handlers(self, ipbx):
-        handlers = {'ipbx': ipbx, 'agentbus': []}
+        handlers = {'ipbx': ipbx}
         self.sysconfd.exec_request_handlers(handlers)
 
     def edited(self, queue_general):

--- a/wazo_confd/plugins/queue_general/tests/test_notifier.py
+++ b/wazo_confd/plugins/queue_general/tests/test_notifier.py
@@ -8,7 +8,7 @@ from xivo_bus.resources.queue_general.event import EditQueueGeneralEvent
 
 from ..notifier import QueueGeneralNotifier
 
-SYSCONFD_HANDLERS = {'ipbx': ['module reload app_queue.so'], 'agentbus': []}
+SYSCONFD_HANDLERS = {'ipbx': ['module reload app_queue.so']}
 
 
 class TestQueueGeneralNotifier(unittest.TestCase):

--- a/wazo_confd/plugins/register_iax/notifier.py
+++ b/wazo_confd/plugins/register_iax/notifier.py
@@ -16,7 +16,7 @@ class RegisterIAXNotifier:
         self.sysconfd = sysconfd
 
     def send_sysconfd_handlers(self):
-        handlers = {'ipbx': ['iax2 reload'], 'agentbus': []}
+        handlers = {'ipbx': ['iax2 reload']}
         self.sysconfd.exec_request_handlers(handlers)
 
     def created(self, register):

--- a/wazo_confd/plugins/register_iax/tests/test_notifier.py
+++ b/wazo_confd/plugins/register_iax/tests/test_notifier.py
@@ -13,7 +13,7 @@ from xivo_bus.resources.register.event import (
 from ..notifier import RegisterIAXNotifier
 
 
-EXPECTED_SYSCONFD_HANDLERS = {'ipbx': ['iax2 reload'], 'agentbus': []}
+EXPECTED_SYSCONFD_HANDLERS = {'ipbx': ['iax2 reload']}
 
 
 class TestRegisterIAXNotifier(unittest.TestCase):

--- a/wazo_confd/plugins/rtp/notifier.py
+++ b/wazo_confd/plugins/rtp/notifier.py
@@ -15,7 +15,7 @@ class RTPConfigurationNotifier:
         self.sysconfd = sysconfd
 
     def send_sysconfd_handlers(self, ipbx):
-        handlers = {'ipbx': ipbx, 'agentbus': []}
+        handlers = {'ipbx': ipbx}
         self.sysconfd.exec_request_handlers(handlers)
 
     def edited(self, section_name, rtp):

--- a/wazo_confd/plugins/rtp/tests/test_notifier.py
+++ b/wazo_confd/plugins/rtp/tests/test_notifier.py
@@ -12,7 +12,7 @@ from xivo_bus.resources.rtp.event import (
 from ..notifier import RTPConfigurationNotifier
 
 
-SYSCONFD_HANDLERS = {'ipbx': ['module reload res_rtp_asterisk.so'], 'agentbus': []}
+SYSCONFD_HANDLERS = {'ipbx': ['module reload res_rtp_asterisk.so']}
 
 
 class TestRTPConfigurationNotifier(unittest.TestCase):

--- a/wazo_confd/plugins/sccp_general/notifier.py
+++ b/wazo_confd/plugins/sccp_general/notifier.py
@@ -12,7 +12,7 @@ class SCCPGeneralNotifier:
         self.sysconfd = sysconfd
 
     def send_sysconfd_handlers(self, ipbx):
-        handlers = {'ipbx': ipbx, 'agentbus': []}
+        handlers = {'ipbx': ipbx}
         self.sysconfd.exec_request_handlers(handlers)
 
     def edited(self, sccp_general):

--- a/wazo_confd/plugins/sccp_general/tests/test_notifier.py
+++ b/wazo_confd/plugins/sccp_general/tests/test_notifier.py
@@ -10,7 +10,7 @@ from xivo_dao.alchemy.sccpgeneralsettings import SCCPGeneralSettings
 
 from ..notifier import SCCPGeneralNotifier
 
-SYSCONFD_HANDLERS = {'ipbx': ['module reload chan_sccp.so'], 'agentbus': []}
+SYSCONFD_HANDLERS = {'ipbx': ['module reload chan_sccp.so']}
 
 
 class TestSCCPGeneralNotifier(unittest.TestCase):

--- a/wazo_confd/plugins/skill_rule/notifier.py
+++ b/wazo_confd/plugins/skill_rule/notifier.py
@@ -16,7 +16,7 @@ class SkillRuleNotifier:
         self.sysconfd = sysconfd
 
     def send_sysconfd_handlers(self):
-        handlers = {'ipbx': ['module reload app_queue.so'], 'agentbus': []}
+        handlers = {'ipbx': ['module reload app_queue.so']}
         self.sysconfd.exec_request_handlers(handlers)
 
     def created(self, skill_rule):

--- a/wazo_confd/plugins/skill_rule/tests/test_notifier.py
+++ b/wazo_confd/plugins/skill_rule/tests/test_notifier.py
@@ -14,7 +14,7 @@ from xivo_bus.resources.skill_rule.event import (
 
 from ..notifier import SkillRuleNotifier
 
-EXPECTED_HANDLERS = {'ipbx': ['module reload app_queue.so'], 'agentbus': []}
+EXPECTED_HANDLERS = {'ipbx': ['module reload app_queue.so']}
 
 
 class TestSkillRuleNotifier(unittest.TestCase):

--- a/wazo_confd/plugins/trunk/notifier.py
+++ b/wazo_confd/plugins/trunk/notifier.py
@@ -20,7 +20,7 @@ class TrunkNotifier:
         self.sysconfd = sysconfd
 
     def send_sysconfd_handlers(self, ipbx_commands):
-        handlers = {'ipbx': ipbx_commands, 'agentbus': []}
+        handlers = {'ipbx': ipbx_commands}
         self.sysconfd.exec_request_handlers(handlers)
 
     def created(self, trunk):

--- a/wazo_confd/plugins/trunk/tests/test_notifier.py
+++ b/wazo_confd/plugins/trunk/tests/test_notifier.py
@@ -128,4 +128,4 @@ class TestTrunkNotifier(unittest.TestCase):
             raise AssertionError(
                 'no sysconfd handlers for endpoint {}'.format(self.trunk.endpoint)
             )
-        return {'ipbx': ipbx_commands, 'agentbus': []}
+        return {'ipbx': ipbx_commands}

--- a/wazo_confd/plugins/trunk_endpoint/notifier.py
+++ b/wazo_confd/plugins/trunk_endpoint/notifier.py
@@ -48,7 +48,7 @@ class TrunkEndpointNotifier:
         self.sysconfd = sysconfd
 
     def send_sysconfd_handlers(self, ipbx):
-        handlers = {'ipbx': ipbx, 'agentbus': []}
+        handlers = {'ipbx': ipbx}
         self.sysconfd.exec_request_handlers(handlers)
 
     def _build_headers(self, trunk):

--- a/wazo_confd/plugins/trunk_endpoint/tests/test_notifier.py
+++ b/wazo_confd/plugins/trunk_endpoint/tests/test_notifier.py
@@ -102,7 +102,7 @@ class TestTrunkEndpointNotifier(unittest.TestCase):
 
     def test_associate_sip_then_sysconfd_event(self):
         self.notifier_sip.associated(self.trunk, self.sip)
-        expected = {'ipbx': ['module reload res_pjsip.so'], 'agentbus': []}
+        expected = {'ipbx': ['module reload res_pjsip.so']}
 
         self.sysconfd.exec_request_handlers.assert_called_once_with(expected)
 
@@ -113,7 +113,7 @@ class TestTrunkEndpointNotifier(unittest.TestCase):
 
     def test_associate_iax_then_sysconfd_event(self):
         self.notifier_iax.associated(self.trunk, self.iax)
-        expected = {'ipbx': ['iax2 reload'], 'agentbus': []}
+        expected = {'ipbx': ['iax2 reload']}
 
         self.sysconfd.exec_request_handlers.assert_called_once_with(expected)
 

--- a/wazo_confd/plugins/user/notifier.py
+++ b/wazo_confd/plugins/user/notifier.py
@@ -25,7 +25,6 @@ class UserNotifier:
                 'module reload app_queue.so',
                 'module reload res_pjsip.so',
             ],
-            'agentbus': [],
         }
         self.sysconfd.exec_request_handlers(handlers)
 

--- a/wazo_confd/plugins/user/tests/test_notifier.py
+++ b/wazo_confd/plugins/user/tests/test_notifier.py
@@ -32,8 +32,7 @@ EXPECTED_HANDLERS = {
         'module reload chan_sccp.so',
         'module reload app_queue.so',
         'module reload res_pjsip.so',
-    ],
-    'agentbus': [],
+    ]
 }
 
 

--- a/wazo_confd/plugins/user_group/notifier.py
+++ b/wazo_confd/plugins/user_group/notifier.py
@@ -17,8 +17,7 @@ class UserGroupNotifier:
                 'module reload res_pjsip.so',
                 'module reload app_queue.so',
                 'module reload chan_sccp.so',
-            ],
-            'agentbus': [],
+            ]
         }
         self.sysconfd.exec_request_handlers(handlers)
 

--- a/wazo_confd/plugins/user_group/tests/test_notifier.py
+++ b/wazo_confd/plugins/user_group/tests/test_notifier.py
@@ -17,8 +17,7 @@ SYSCONFD_HANDLERS = {
         'module reload res_pjsip.so',
         'module reload app_queue.so',
         'module reload chan_sccp.so',
-    ],
-    'agentbus': [],
+    ]
 }
 
 

--- a/wazo_confd/plugins/user_line/notifier.py
+++ b/wazo_confd/plugins/user_line/notifier.py
@@ -28,8 +28,7 @@ class UserLineNotifier:
 
     def _send_sysconfd_handlers(self):
         handlers = {
-            'ipbx': ['dialplan reload', 'module reload res_pjsip.so'],
-            'agentbus': [],
+            'ipbx': ['dialplan reload', 'module reload res_pjsip.so']
         }
         self._sysconfd.exec_request_handlers(handlers)
 

--- a/wazo_confd/plugins/user_line/notifier.py
+++ b/wazo_confd/plugins/user_line/notifier.py
@@ -27,9 +27,7 @@ class UserLineNotifier:
         self._sysconfd = sysconfd
 
     def _send_sysconfd_handlers(self):
-        handlers = {
-            'ipbx': ['dialplan reload', 'module reload res_pjsip.so']
-        }
+        handlers = {'ipbx': ['dialplan reload', 'module reload res_pjsip.so']}
         self._sysconfd.exec_request_handlers(handlers)
 
     def associated(self, user_line):

--- a/wazo_confd/plugins/user_line/tests/test_notifier.py
+++ b/wazo_confd/plugins/user_line/tests/test_notifier.py
@@ -19,8 +19,7 @@ from wazo_confd.plugins.endpoint_sip.schema import EndpointSIPSchema  # noqa
 
 
 EXPECTED_SYSCONFD_HANDLERS = {
-    'ipbx': ['dialplan reload', 'module reload res_pjsip.so'],
-    'agentbus': [],
+    'ipbx': ['dialplan reload', 'module reload res_pjsip.so']
 }
 
 USER_UUID = str(uuid.uuid4())

--- a/wazo_confd/plugins/user_line/tests/test_notifier.py
+++ b/wazo_confd/plugins/user_line/tests/test_notifier.py
@@ -18,9 +18,7 @@ from wazo_confd.plugins.endpoint_sccp.resource import SccpSchema  # noqa
 from wazo_confd.plugins.endpoint_sip.schema import EndpointSIPSchema  # noqa
 
 
-EXPECTED_SYSCONFD_HANDLERS = {
-    'ipbx': ['dialplan reload', 'module reload res_pjsip.so']
-}
+EXPECTED_SYSCONFD_HANDLERS = {'ipbx': ['dialplan reload', 'module reload res_pjsip.so']}
 
 USER_UUID = str(uuid.uuid4())
 TENANT_UUID = str(uuid.uuid4())

--- a/wazo_confd/plugins/user_voicemail/notifier.py
+++ b/wazo_confd/plugins/user_voicemail/notifier.py
@@ -15,8 +15,7 @@ class UserVoicemailNotifier:
 
     def _send_sysconfd_handlers(self):
         handlers = {
-            'ipbx': ['module reload res_pjsip.so', 'module reload chan_sccp.so'],
-            'agentbus': [],
+            'ipbx': ['module reload res_pjsip.so', 'module reload chan_sccp.so']
         }
         self._sysconfd.exec_request_handlers(handlers)
 

--- a/wazo_confd/plugins/user_voicemail/tests/test_notifier.py
+++ b/wazo_confd/plugins/user_voicemail/tests/test_notifier.py
@@ -18,8 +18,7 @@ USER_LINE2_ID = 12
 TENANT_UUID = str(uuid4())
 
 EXPECTED_SYSCONFD_HANDLERS = {
-    'ipbx': ['module reload res_pjsip.so', 'module reload chan_sccp.so'],
-    'agentbus': [],
+    'ipbx': ['module reload res_pjsip.so', 'module reload chan_sccp.so']
 }
 
 

--- a/wazo_confd/plugins/voicemail/notifier.py
+++ b/wazo_confd/plugins/voicemail/notifier.py
@@ -17,7 +17,7 @@ class VoicemailNotifier:
         self.sysconfd = sysconfd
 
     def _send_sysconfd_handlers(self, ipbx_commands):
-        handlers = {'ipbx': ipbx_commands, 'agentbus': []}
+        handlers = {'ipbx': ipbx_commands}
         self.sysconfd.exec_request_handlers(handlers)
 
     def created(self, voicemail):

--- a/wazo_confd/plugins/voicemail/tests/test_notifier.py
+++ b/wazo_confd/plugins/voicemail/tests/test_notifier.py
@@ -38,7 +38,7 @@ class TestVoicemailNotifier(unittest.TestCase):
         )
 
     def test_when_voicemail_created_then_sysconfd_called(self):
-        expected_handlers = {'ipbx': ['voicemail reload'], 'agentbus': []}
+        expected_handlers = {'ipbx': ['voicemail reload']}
         self.notifier.created(self.voicemail)
 
         self.sysconfd.exec_request_handlers.assert_called_once_with(expected_handlers)
@@ -65,8 +65,7 @@ class TestVoicemailNotifier(unittest.TestCase):
                 'voicemail reload',
                 'module reload res_pjsip.so',
                 'module reload chan_sccp.so',
-            ],
-            'agentbus': [],
+            ]
         }
         self.notifier.edited(self.voicemail)
 
@@ -82,7 +81,7 @@ class TestVoicemailNotifier(unittest.TestCase):
         )
 
     def test_when_voicemail_deleted_then_sysconfd_called(self):
-        expected_handlers = {'ipbx': ['voicemail reload'], 'agentbus': []}
+        expected_handlers = {'ipbx': ['voicemail reload']}
         self.notifier.deleted(self.voicemail)
 
         self.sysconfd.exec_request_handlers.assert_called_once_with(expected_handlers)

--- a/wazo_confd/plugins/voicemail_general/notifier.py
+++ b/wazo_confd/plugins/voicemail_general/notifier.py
@@ -12,7 +12,7 @@ class VoicemailGeneralNotifier:
         self.sysconfd = sysconfd
 
     def send_sysconfd_handlers(self, ipbx):
-        handlers = {'ipbx': ipbx, 'agentbus': []}
+        handlers = {'ipbx': ipbx}
         self.sysconfd.exec_request_handlers(handlers)
 
     def edited(self, voicemail_general):

--- a/wazo_confd/plugins/voicemail_general/tests/test_notifier.py
+++ b/wazo_confd/plugins/voicemail_general/tests/test_notifier.py
@@ -9,7 +9,7 @@ from xivo_dao.alchemy.staticvoicemail import StaticVoicemail
 
 from ..notifier import VoicemailGeneralNotifier
 
-SYSCONFD_HANDLERS = {'ipbx': ['voicemail reload'], 'agentbus': []}
+SYSCONFD_HANDLERS = {'ipbx': ['voicemail reload']}
 
 
 class TestVoicemailGeneralNotifier(unittest.TestCase):

--- a/wazo_confd/plugins/voicemail_zonemessages/notifier.py
+++ b/wazo_confd/plugins/voicemail_zonemessages/notifier.py
@@ -14,7 +14,7 @@ class VoicemailZoneMessagesNotifier:
         self.sysconfd = sysconfd
 
     def send_sysconfd_handlers(self, ipbx):
-        handlers = {'ipbx': ipbx, 'agentbus': []}
+        handlers = {'ipbx': ipbx}
         self.sysconfd.exec_request_handlers(handlers)
 
     def edited(self, voicemail_zonemessages):

--- a/wazo_confd/plugins/voicemail_zonemessages/tests/test_notifier.py
+++ b/wazo_confd/plugins/voicemail_zonemessages/tests/test_notifier.py
@@ -11,7 +11,7 @@ from xivo_dao.alchemy.staticvoicemail import StaticVoicemail
 
 from ..notifier import VoicemailZoneMessagesNotifier
 
-SYSCONFD_HANDLERS = {'ipbx': ['voicemail reload'], 'agentbus': []}
+SYSCONFD_HANDLERS = {'ipbx': ['voicemail reload']}
 
 
 class TestVoicemailZoneMessagesNotifier(unittest.TestCase):


### PR DESCRIPTION
Sysconfd no longer uses agentbus. So the parameter 'agentbus' has been
removed from all the calls to sysconfd.