### PR TITLE
Restore the /users with lines, extensions and SIP endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 * `/wizard` endpoint updates now the configuration file for autoprovisionning `/etc/asterisk/pjsip.d/05-autoprov-wizard.conf` with the `language` value it receives in the request body. However, if the user wants to change the language used for audio provisionning; they will have to do it manually for now.
 
+* The `/1.1/users` resource can now create the user's line during the user's creation
+* The `/1.1/lines` resource can now create the underlying custom, SIP or SCCP endpoint during its creation
+* The `/1.1/lines` resource can now create the underlying extensions during its creation
+
 ## 22.13
 
 * `/status` endpoint has now been included into `wazo-confd`, and it returns the current status (`ok` or `fail`) of the following:

--- a/integration_tests/suite/base/__init__.py
+++ b/integration_tests/suite/base/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2021 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from ..helpers.base import IntegrationTest

--- a/integration_tests/suite/base/test_line_endpoint_custom.py
+++ b/integration_tests/suite/base/test_line_endpoint_custom.py
@@ -1,7 +1,7 @@
 # Copyright 2016-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from hamcrest import assert_that, has_entries
+from hamcrest import assert_that, has_entries, greater_than, none
 
 from . import confd
 from ..helpers import (
@@ -10,7 +10,61 @@ from ..helpers import (
     fixtures,
     scenarios as s,
 )
-from ..helpers.config import MAIN_TENANT, SUB_TENANT
+from ..helpers.config import CONTEXT, MAIN_TENANT, SUB_TENANT
+
+
+@fixtures.registrar()
+def test_create_line_with_endpoint_custom_with_all_parameters(registrar):
+    response = confd.lines.post(
+        context=CONTEXT,
+        position=2,
+        registrar=registrar['id'],
+        provisioning_code='887865',
+        endpoint_custom={
+            'interface': 'custom/createall',
+            'enabled': False,
+        },
+    )
+
+    try:
+        assert_that(
+            response.item,
+            has_entries(
+                context=CONTEXT,
+                position=2,
+                device_slot=2,
+                name=none(),
+                protocol=none(),
+                device_id=none(),
+                caller_id_name=none(),
+                caller_id_num=none(),
+                registrar=registrar['id'],
+                provisioning_code="887865",
+                provisioning_extension="887865",
+                tenant_uuid=MAIN_TENANT,
+                endpoint_custom=has_entries(
+                    id=greater_than(0),
+                    tenant_uuid=MAIN_TENANT,
+                    interface='custom/createall',
+                    enabled=False,
+                ),
+            ),
+        )
+
+        assert_that(
+            confd.lines(response.item['id']).get().item,
+            has_entries(
+                endpoint_custom=has_entries(
+                    id=response.item['endpoint_custom']['id'],
+                    interface='custom/createall',
+                    enabled=False,
+                    line=has_entries(id=response.item['id']),
+                ),
+            ),
+        )
+
+    finally:
+        confd.lines(response.item['id']).delete().assert_deleted()
 
 
 @fixtures.line()

--- a/integration_tests/suite/base/test_line_endpoint_sip.py
+++ b/integration_tests/suite/base/test_line_endpoint_sip.py
@@ -1,7 +1,16 @@
 # Copyright 2015-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from hamcrest import assert_that, contains, contains_inanyorder, has_entries
+from hamcrest import (
+    assert_that,
+    contains,
+    contains_inanyorder,
+    has_entries,
+    has_items,
+    none,
+)
+
+from wazo_test_helpers.hamcrest.uuid_ import uuid_
 
 from . import confd
 from ..helpers import (
@@ -10,10 +19,126 @@ from ..helpers import (
     fixtures,
     scenarios as s,
 )
-from ..helpers.config import MAIN_TENANT, SUB_TENANT
+from ..helpers.config import CONTEXT, MAIN_TENANT, SUB_TENANT
 
 FAKE_UUID = '99999999-9999-4999-9999-999999999999'
 FAKE_ID = 999999999
+
+
+@fixtures.transport()
+@fixtures.sip_template()
+@fixtures.sip_template()
+@fixtures.registrar()
+def test_create_line_with_endpoint_sip_with_all_parameters(
+    transport, template_1, template_2, registrar
+):
+    aor_section_options = [
+        ['@custom_variable', 'custom'],
+        ['qualify_frequency', '60'],
+        ['maximum_expiration', '3600'],
+        ['remove_existing', 'yes'],
+        ['max_contacts', '1'],
+    ]
+    auth_section_options = [['username', 'yiq8yej0'], ['password', 'yagq7x0w']]
+    endpoint_section_options = [
+        ['@custom_variable', 'custom'],
+        ['force_rport', 'yes'],
+        ['rewrite_contact', 'yes'],
+        ['callerid', '"Firstname Lastname" <100>'],
+    ]
+    identify_section_options = [
+        ['match', '54.172.60.0'],
+        ['match', '54.172.60.1'],
+        ['match', '54.172.60.2'],
+    ]
+    registration_section_options = [
+        ['client_uri', 'sip:peer@proxy.example.com'],
+        ['server_uri', 'sip:proxy.example.com'],
+        ['expiration', '120'],
+    ]
+    registration_outbound_auth_section_options = [
+        ['username', 'outbound-registration-username'],
+        ['password', 'outbound-registration-password'],
+    ]
+    outbound_auth_section_options = [
+        ['username', 'outbound-auth'],
+        ['password', 'outbound-password'],
+    ]
+
+    response = confd.lines.post(
+        context=CONTEXT,
+        position=2,
+        registrar=registrar['id'],
+        provisioning_code='887865',
+        endpoint_sip={
+            'name': "name",
+            'label': "label",
+            'aor_section_options': aor_section_options,
+            'auth_section_options': auth_section_options,
+            'endpoint_section_options': endpoint_section_options,
+            'identify_section_options': identify_section_options,
+            'registration_section_options': registration_section_options,
+            'registration_outbound_auth_section_options': registration_outbound_auth_section_options,
+            'outbound_auth_section_options': outbound_auth_section_options,
+            'transport': transport,
+            'templates': [template_1, template_2],
+            'asterisk_id': 'asterisk_id',
+        },
+    )
+    line_id = response.item['id']
+
+    try:
+        assert_that(
+            response.item,
+            has_entries(
+                context=CONTEXT,
+                position=2,
+                device_slot=2,
+                name=none(),
+                protocol=none(),
+                device_id=none(),
+                caller_id_name=none(),
+                caller_id_num=none(),
+                registrar=registrar['id'],
+                provisioning_code="887865",
+                provisioning_extension="887865",
+                tenant_uuid=MAIN_TENANT,
+                endpoint_sip=has_entries(
+                    tenant_uuid=MAIN_TENANT,
+                    name='name',
+                    label='label',
+                    aor_section_options=aor_section_options,
+                    auth_section_options=auth_section_options,
+                    endpoint_section_options=endpoint_section_options,
+                    identify_section_options=identify_section_options,
+                    registration_section_options=registration_section_options,
+                    registration_outbound_auth_section_options=registration_outbound_auth_section_options,
+                    outbound_auth_section_options=outbound_auth_section_options,
+                    transport=has_entries(uuid=transport['uuid']),
+                    templates=contains(
+                        has_entries(uuid=template_1['uuid'], label=template_1['label']),
+                        has_entries(uuid=template_2['uuid'], label=template_2['label']),
+                    ),
+                    asterisk_id='asterisk_id',
+                ),
+            ),
+        )
+
+        line = confd.lines(line_id).get().item
+        assert_that(
+            line,
+            has_entries(
+                endpoint_sip=has_entries(
+                    uuid=uuid_(),
+                    name='name',
+                ),
+            ),
+        )
+
+        response = confd.lines(line_id).put(**line)
+        response.assert_updated()
+    finally:
+        confd.lines(line_id).delete().assert_deleted()
 
 
 @fixtures.line()
@@ -187,8 +312,26 @@ def test_get_endpoint_sip_relation(line, sip):
                     name='my-endpoint',
                     auth_section_options=contains_inanyorder(
                         contains('username', 'my-username'),
+                        contains('password', 'my-password'),
                     ),
                 )
+            ),
+        )
+
+        response = confd.lines.get()
+        assert_that(
+            response.items,
+            has_items(
+                has_entries(
+                    endpoint_sip=has_entries(
+                        uuid=sip['uuid'],
+                        label='my-endpoint',
+                        name='my-endpoint',
+                        auth_section_options=contains_inanyorder(
+                            contains('username', 'my-username'),
+                        ),
+                    )
+                ),
             ),
         )
 

--- a/integration_tests/suite/base/test_line_extension.py
+++ b/integration_tests/suite/base/test_line_extension.py
@@ -95,6 +95,51 @@ def test_create_line_with_all_parameters_and_extension(registrar):
         confd.lines(response.item['id']).delete().assert_deleted()
 
 
+@fixtures.registrar()
+def test_create_line_with_missing_context_for_extension(registrar):
+    exten = h.extension.find_available_exten(CONTEXT)
+    response = confd.lines.post(
+        context=CONTEXT,
+        extensions=[
+            {
+                'exten': exten,
+            }
+        ],
+        endpoint_sip={
+            'name': 'test',
+        },
+    )
+
+    try:
+        assert_that(
+            confd.lines(response.item['id']).get().item,
+            has_entries(
+                context=CONTEXT,
+                extensions=contains(
+                    has_entries(
+                        context=CONTEXT,
+                        exten=exten,
+                    )
+                ),
+            ),
+        )
+
+        assert_that(
+            confd.lines(response.item['id']).get().item,
+            has_entries(
+                extensions=contains(
+                    has_entries(
+                        context=CONTEXT,
+                        exten=exten,
+                    )
+                ),
+            ),
+        )
+
+    finally:
+        confd.lines(response.item['id']).delete().assert_deleted()
+
+
 @fixtures.line()
 @fixtures.extension()
 def test_associate_errors(line, extension):

--- a/integration_tests/suite/base/test_lines.py
+++ b/integration_tests/suite/base/test_lines.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2020 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import re
@@ -218,6 +218,16 @@ def test_create_line_with_all_parameters(registrar):
 def test_create_line_with_caller_id_raises_error():
     response = confd.lines.post(
         context=config.CONTEXT, caller_id_name="Jôhn Smîth", caller_id_num="1000"
+    )
+
+    response.assert_status(400)
+
+
+def test_create_line_with_multiple_endpoints_raises_error():
+    response = confd.lines.post(
+        context=config.CONTEXT,
+        endpoint_sip={'name': 'sip'},
+        endpoint_sccp={'options': [['allow', 'all']]},
     )
 
     response.assert_status(400)

--- a/integration_tests/suite/base/test_user_import.py
+++ b/integration_tests/suite/base/test_user_import.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2021 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import unittest
@@ -76,8 +76,11 @@ def test_given_csv_has_minimal_fields_for_a_user_then_user_imported():
     user_id = get_import_field(response, 'user_id')
     user_uuid = get_import_field(response, 'user_uuid')
 
-    user = confd.users(user_id).get().item
-    assert_that(user, has_entries(firstname="Rîchard", uuid=user_uuid))
+    try:
+        user = confd.users(user_id).get().item
+        assert_that(user, has_entries(firstname="Rîchard", uuid=user_uuid))
+    finally:
+        confd.users(user_id).delete()
 
 
 def test_given_csv_has_all_fields_for_a_user_then_user_imported():
@@ -112,35 +115,38 @@ def test_given_csv_has_all_fields_for_a_user_then_user_imported():
     user_id = get_import_field(response, 'user_id')
     user_uuid = get_import_field(response, 'user_uuid')
 
-    user = confd.users(user_id).get().item
-    assert_that(
-        user,
-        has_entries(
-            firstname="Rîchard",
-            lastname="Lâpointe",
-            email="richard@lapointe.org",
-            language="fr_FR",
-            outgoing_caller_id='"Rîchy Cool" <4185551234>',
-            mobile_phone_number="4181234567",
-            supervision_enabled=True,
-            call_transfer_enabled=False,
-            dtmf_hangup_enabled=True,
-            call_record_outgoing_external_enabled=True,
-            call_record_outgoing_internal_enabled=True,
-            call_record_incoming_internal_enabled=True,
-            call_record_incoming_external_enabled=True,
-            online_call_record_enabled=False,
-            simultaneous_calls=5,
-            ring_seconds=10,
-            userfield="userfield",
-            call_permission_password='1234',
-            enabled=True,
-            uuid=user_uuid,
-            username=None,
-            password=None,
-            subscription_type=2,
-        ),
-    )
+    try:
+        user = confd.users(user_id).get().item
+        assert_that(
+            user,
+            has_entries(
+                firstname="Rîchard",
+                lastname="Lâpointe",
+                email="richard@lapointe.org",
+                language="fr_FR",
+                outgoing_caller_id='"Rîchy Cool" <4185551234>',
+                mobile_phone_number="4181234567",
+                supervision_enabled=True,
+                call_transfer_enabled=False,
+                dtmf_hangup_enabled=True,
+                call_record_outgoing_external_enabled=True,
+                call_record_outgoing_internal_enabled=True,
+                call_record_incoming_internal_enabled=True,
+                call_record_incoming_external_enabled=True,
+                online_call_record_enabled=False,
+                simultaneous_calls=5,
+                ring_seconds=10,
+                userfield="userfield",
+                call_permission_password='1234',
+                enabled=True,
+                uuid=user_uuid,
+                username=None,
+                password=None,
+                subscription_type=2,
+            ),
+        )
+    finally:
+        confd.users(user_id).delete()
 
 
 @fixtures.call_permission()

--- a/integration_tests/suite/base/test_users.py
+++ b/integration_tests/suite/base/test_users.py
@@ -797,6 +797,8 @@ def test_post_full_user_no_error(transport, template, registrar):
         "userfield": "userfield",
         "call_permission_password": "1234",
         "enabled": True,
+    }
+    auth = {
         "username": "richardlapointe",
         "password": "secret",
     }
@@ -824,6 +826,7 @@ def test_post_full_user_no_error(transport, template, registrar):
 
     response = confd.users.post(
         {
+            'auth': auth,
             'lines': [line],
             **user,
         }

--- a/integration_tests/suite/base/test_users.py
+++ b/integration_tests/suite/base/test_users.py
@@ -8,6 +8,7 @@ from hamcrest import (
     contains_inanyorder,
     empty,
     equal_to,
+    greater_than,
     has_entries,
     has_entry,
     has_item,
@@ -16,15 +17,17 @@ from hamcrest import (
     none,
     not_,
 )
+from wazo_test_helpers.hamcrest.uuid_ import uuid_
 
 from . import confd
 from ..helpers import (
     associations as a,
     errors as e,
     fixtures,
+    helpers as h,
     scenarios as s,
 )
-from ..helpers.config import MAIN_TENANT, SUB_TENANT
+from ..helpers.config import CONTEXT, MAIN_TENANT, SUB_TENANT
 
 FULL_USER = {
     "firstname": "Jôhn",
@@ -766,6 +769,106 @@ def test_create_multi_tenant_moh(main_moh, sub_moh):
 
     response = confd.users.post(**parameters)
     response.assert_match(400, e.not_found(resource='MOH'))
+
+
+@fixtures.transport()
+@fixtures.sip_template()
+@fixtures.registrar()
+def test_post_full_user_no_error(transport, template, registrar):
+    exten = h.extension.find_available_exten(CONTEXT)
+    user = {
+        "subscription_type": 2,
+        "firstname": "Rîchard",
+        "lastname": "Lâpointe",
+        "email": "richard@lapointe.org",
+        "language": "fr_FR",
+        "outgoing_caller_id": '"Rîchy Cool" <4185551234>',
+        "mobile_phone_number": "4181234567",
+        "supervision_enabled": True,
+        "call_transfer_enabled": False,
+        "dtmf_hangup_enabled": True,
+        "call_record_outgoing_external_enabled": True,
+        "call_record_outgoing_internal_enabled": True,
+        "call_record_incoming_internal_enabled": True,
+        "call_record_incoming_external_enabled": True,
+        "online_call_record_enabled": False,
+        "simultaneous_calls": 5,
+        "ring_seconds": 30,
+        "userfield": "userfield",
+        "call_permission_password": "1234",
+        "enabled": True,
+        "username": "richardlapointe",
+        "password": "secret",
+    }
+    extension = {'context': CONTEXT, 'exten': exten}
+    line = {
+        'context': CONTEXT,
+        'position': 2,
+        'registrar': registrar['id'],
+        'provisioning_code': "887865",
+        'extensions': [extension],
+        'endpoint_sip': {
+            'name': 'iddqd',
+            'label': 'Richard\'s line',
+            'auth_section_options': [
+                ['username', 'iddqd'],
+                ['password', 'secret'],
+            ],
+            'endpoint_section_options': [
+                ['callerid', f'"Rîchard Lâpointe" <{exten}>'],
+            ],
+            'transport': transport,
+            'templates': [template],
+        },
+    }
+
+    response = confd.users.post(
+        {
+            'lines': [line],
+            **user,
+        }
+    ).response
+
+    assert response.status_code == 201
+    payload = response.json()
+    try:
+        assert_that(
+            payload,
+            has_entries(
+                uuid=uuid_(),
+                lines=contains(
+                    has_entries(
+                        id=greater_than(0),
+                        endpoint_sip=has_entries(uuid=uuid_()),
+                        extensions=contains(has_entries(id=greater_than(0))),
+                    )
+                ),
+                **user,
+            ),
+        )
+
+        assert_that(
+            confd.users(payload['uuid']).get().item,
+            has_entries(lines=contains(has_entries(id=payload['lines'][0]['id']))),
+        )
+
+        assert_that(
+            confd.lines(payload['lines'][0]['id']).get().item,
+            has_entries(
+                extensions=contains(has_entries(**extension)),
+                endpoint_sip=has_entries(name='iddqd'),
+            ),
+        )
+
+        user = confd.users(payload['uuid']).get().item
+        user.pop('call_record_enabled', None)  # Deprecated field
+        confd.users(payload['uuid']).put(**user).assert_updated()
+    finally:
+        confd.users(payload['uuid']).delete().assert_deleted()
+        confd.lines(payload['lines'][0]['id']).delete().assert_deleted()
+        confd.extensions(
+            payload['lines'][0]['extensions'][0]['id']
+        ).delete().assert_deleted()
 
 
 @fixtures.user(

--- a/wazo_confd/plugins/endpoint_sip/resource.py
+++ b/wazo_confd/plugins/endpoint_sip/resource.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2020 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from flask import url_for, request
@@ -35,7 +35,10 @@ class _BaseSipList(ListResource):
         return super().get()
 
     def post(self):
-        form = self.schema().load(request.get_json())
+        return super().post()
+
+    def _post(self, body):
+        form = self.schema().load(body)
         form = self.add_tenant_to_form(form)
 
         templates = []

--- a/wazo_confd/plugins/endpoint_sip/tests/test_schema.py
+++ b/wazo_confd/plugins/endpoint_sip/tests/test_schema.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2021 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import uuid
@@ -20,7 +20,7 @@ from werkzeug.exceptions import BadRequest
 
 # Adding schemas to the marshmallow registry
 from wazo_confd.plugins.trunk.resource import TrunkSchema  # noqa
-from wazo_confd.plugins.line.resource import LineSchema  # noqa
+from wazo_confd.plugins.line.resource import LineListSchema  # noqa
 
 from ..schema import (
     EndpointSIPSchema,

--- a/wazo_confd/plugins/extension/resource.py
+++ b/wazo_confd/plugins/extension/resource.py
@@ -1,7 +1,7 @@
-# Copyright 2016-2020 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from flask import request, url_for
+from flask import url_for
 
 from xivo_dao.alchemy.extension import Extension
 
@@ -25,7 +25,10 @@ class ExtensionList(ListResource):
 
     @required_acl('confd.extensions.create')
     def post(self):
-        form = self.schema().load(request.get_json())
+        return super().post()
+
+    def _post(self, body):
+        form = self.schema().load(body)
         model = self.model(**form)
         tenant_uuids = self._build_tenant_list({'recurse': True})
         model = self.service.create(model, tenant_uuids)

--- a/wazo_confd/plugins/line/api.yml
+++ b/wazo_confd/plugins/line/api.yml
@@ -179,19 +179,15 @@ definitions:
   LineRelationEndpoints:
     properties:
       endpoint_sip:
-        readOnly: true
         $ref: '#/definitions/EndpointSipRelationBase'
       endpoint_sccp:
-        readOnly: true
         $ref: '#/definitions/EndpointSccpRelationBase'
       endpoint_custom:
-        readOnly: true
         $ref: '#/definitions/EndpointCustomRelationBase'
   LineRelationExtensions:
     properties:
       extensions:
         type: array
-        readOnly: true
         items:
           $ref: '#/definitions/ExtensionRelationBase'
   LineRelationUsers:

--- a/wazo_confd/plugins/line/plugin.py
+++ b/wazo_confd/plugins/line/plugin.py
@@ -1,7 +1,32 @@
-# Copyright 2015-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from wazo_provd_client import Client as ProvdClient
+
+from xivo_dao.resources.endpoint_custom import dao as endpoint_custom_dao
+from xivo_dao.resources.endpoint_sccp import dao as endpoint_sccp_dao
+from xivo_dao.resources.line import dao as line_dao
+from xivo_dao.resources.endpoint_sip import dao as sip_dao
+from xivo_dao.resources.pjsip_transport import dao as transport_dao
+
+from wazo_confd.plugins.extension.service import (
+    build_service as build_extension_service,
+)
+from wazo_confd.plugins.line_extension.service import (
+    build_service as build_extension_line_service,
+)
+from wazo_confd.plugins.endpoint_sip.service import (
+    build_endpoint_service as build_endpoint_sip_service,
+)
+from wazo_confd.plugins.line_endpoint.service import build_service_custom
+from wazo_confd.plugins.line_endpoint.service import build_service_sip
+from wazo_confd.plugins.line_endpoint.service import build_service_sccp
+from wazo_confd.plugins.endpoint_sccp.service import (
+    build_service as build_endpoint_sccp_service,
+)
+from wazo_confd.plugins.endpoint_custom.service import (
+    build_service as build_endpoint_custom_service,
+)
 
 from .resource import LineItem, LineList
 from .service import build_service
@@ -12,11 +37,20 @@ class Plugin:
         api = dependencies['api']
         config = dependencies['config']
         token_changed_subscribe = dependencies['token_changed_subscribe']
+        pjsip_doc = dependencies['pjsip_doc']
 
         provd_client = ProvdClient(**config['provd'])
         token_changed_subscribe(provd_client.set_token)
 
         service = build_service(provd_client)
+        extension_line_service = build_extension_line_service()
+        extension_service = build_extension_service(provd_client)
+        endpoint_custom_service = build_endpoint_custom_service()
+        endpoint_sccp_service = build_endpoint_sccp_service()
+        endpoint_sip_service = build_endpoint_sip_service(provd_client, pjsip_doc)
+        line_endpoint_custom_association_service = build_service_custom(provd_client)
+        line_endpoint_sip_association_service = build_service_sip(provd_client)
+        line_endpoint_sccp_association_service = build_service_sccp(provd_client)
 
         api.add_resource(
             LineItem,
@@ -24,4 +58,23 @@ class Plugin:
             endpoint='lines',
             resource_class_args=(service,),
         )
-        api.add_resource(LineList, '/lines', resource_class_args=(service,))
+        api.add_resource(
+            LineList,
+            '/lines',
+            resource_class_args=(
+                service,
+                endpoint_custom_service,
+                endpoint_sip_service,
+                extension_line_service,
+                extension_service,
+                line_endpoint_custom_association_service,
+                line_endpoint_sip_association_service,
+                line_endpoint_sccp_association_service,
+                endpoint_sccp_service,
+                endpoint_custom_dao,
+                endpoint_sccp_dao,
+                line_dao,
+                sip_dao,
+                transport_dao,
+            ),
+        )

--- a/wazo_confd/plugins/line/resource.py
+++ b/wazo_confd/plugins/line/resource.py
@@ -1,20 +1,81 @@
-# Copyright 2015-2020 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from flask import url_for, request
+from flask import url_for
 
 from xivo_dao.alchemy.linefeatures import LineFeatures as Line
 
 from wazo_confd.auth import required_acl
 from wazo_confd.helpers.restful import ListResource, ItemResource
-from wazo_confd.plugins.line.schema import LineSchema, LineSchemaNullable
+from wazo_confd.plugins.line.schema import (
+    LineSchemaNullable,
+    LineListSchema,
+    LinePutSchema,
+)
+
+from wazo_confd.plugins.endpoint_custom.resource import CustomList
+from wazo_confd.plugins.endpoint_sccp.resource import SccpList
+from wazo_confd.plugins.endpoint_sip.resource import SipList
+from wazo_confd.plugins.line_endpoint.resource import (
+    LineEndpointAssociationCustom,
+    LineEndpointAssociationSccp,
+    LineEndpointAssociationSip,
+)
+from wazo_confd.plugins.line_extension.resource import LineExtensionList
 
 
 class LineList(ListResource):
 
     model = Line
     schema = LineSchemaNullable
+    _list_schema = LineListSchema
     has_tenant_uuid = True
+
+    def __init__(
+        self,
+        line_service,
+        endpoint_custom_service,
+        endpoint_sip_service,
+        extension_line_service,
+        extension_service,
+        line_endpoint_custom_association_service,
+        line_endpoint_sip_association_service,
+        line_endpoint_sccp_association_service,
+        endpoint_sccp_service,
+        endpoint_custom_dao,
+        endpoint_sccp_dao,
+        line_dao,
+        sip_dao,
+        transport_dao,
+    ):
+        super().__init__(line_service)
+        self._endpoint_sip_list_resource = SipList(
+            endpoint_sip_service, sip_dao, transport_dao
+        )
+        self._endpoint_sccp_list_resource = SccpList(
+            endpoint_sccp_service,
+        )
+        self._endpoint_custom_list_resource = CustomList(
+            endpoint_custom_service,
+        )
+        self._line_endpoint_custom_association_resource = LineEndpointAssociationCustom(
+            line_endpoint_custom_association_service,
+            line_dao,
+            endpoint_custom_dao,
+        )
+        self._line_endpoint_sip_association_resource = LineEndpointAssociationSip(
+            line_endpoint_sip_association_service, line_dao, sip_dao
+        )
+        self._line_endpoint_sccp_association_resource = LineEndpointAssociationSccp(
+            line_endpoint_sccp_association_service,
+            line_dao,
+            endpoint_sccp_dao,
+        )
+        self._extension_line_list_resource = LineExtensionList(
+            extension_line_service,
+            extension_service,
+            line_dao,
+        )
 
     def build_headers(self, line):
         return {'Location': url_for('lines', id=line.id, _external=True)}
@@ -25,16 +86,64 @@ class LineList(ListResource):
 
     @required_acl('confd.lines.create')
     def post(self):
-        form = self.schema().load(request.get_json())
+        return super().post()
+
+    def _post(self, item):
+        form = self.schema().load(item)
+
+        endpoint_sip_body = form.pop('endpoint_sip', None)
+        endpoint_sccp_body = form.pop('endpoint_sccp', None)
+        endpoint_custom_body = form.pop('endpoint_custom', None)
+        extensions = form.pop('extensions', None) or []
+
         model = self.model(**form)
         tenant_uuids = self._build_tenant_list({'recurse': True})
         model = self.service.create(model, tenant_uuids)
-        return self.schema().dump(model), 201, self.build_headers(model)
+
+        payload = self.schema().dump(model)
+        payload['extensions'] = []
+
+        if endpoint_sip_body:
+            endpoint_sip, _, _ = self._endpoint_sip_list_resource._post(
+                endpoint_sip_body
+            )
+            self._line_endpoint_sip_association_resource.put(
+                model.id,
+                endpoint_sip['uuid'],
+            )
+            payload['endpoint_sip'] = endpoint_sip
+        elif endpoint_sccp_body:
+            endpoint_sccp, _, _ = self._endpoint_sccp_list_resource._post(
+                endpoint_sccp_body
+            )
+            self._line_endpoint_sccp_association_resource.put(
+                model.id,
+                endpoint_sccp['id'],
+            )
+            payload['endpoint_sccp'] = endpoint_sccp
+        elif endpoint_custom_body:
+            endpoint_custom, _, _ = self._endpoint_custom_list_resource._post(
+                endpoint_custom_body
+            )
+            self._line_endpoint_custom_association_resource.put(
+                model.id,
+                endpoint_custom['id'],
+            )
+            payload['endpoint_custom'] = endpoint_custom
+
+        for extension_body in extensions:
+            extension, _, _ = self._extension_line_list_resource._post(
+                model.id, extension_body
+            )
+            payload['extensions'].append(extension)
+
+        return payload, 201, self.build_headers(model)
 
 
 class LineItem(ItemResource):
 
-    schema = LineSchema
+    # The schema should be the same as the POST once the PUT handle sub-resource updates
+    schema = LinePutSchema
     has_tenant_uuid = True
 
     @required_acl('confd.lines.{id}.read')

--- a/wazo_confd/plugins/line/schema.py
+++ b/wazo_confd/plugins/line/schema.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 
-from marshmallow import fields, validates_schema
+from marshmallow import fields, validates_schema, pre_load
 from marshmallow.validate import Length, Predicate, Range
 from marshmallow.exceptions import ValidationError
 
@@ -54,6 +54,14 @@ class LineSchema(BaseSchema):
 
         if nb_endpoint > 1:
             raise ValidationError('Only one endpoint should be configured')
+
+    @pre_load
+    def populate_missing_context(self, data, **kwargs):
+        extensions = data.get('extensions', [])
+        for ext in extensions:
+            if 'context' not in ext:
+                ext['context'] = data.get('context')
+        return data
 
 
 class LineSchemaNullable(LineSchema):

--- a/wazo_confd/plugins/line_extension/resource.py
+++ b/wazo_confd/plugins/line_extension/resource.py
@@ -56,11 +56,14 @@ class LineExtensionList(ListResource):
 
     @required_acl('confd.lines.{line_id}.extensions.create')
     def post(self, line_id):
+        return self._post(line_id, request.get_json())
+
+    def _post(self, line_id, body):
         tenant_uuids = self._build_tenant_list({'recurse': True})
 
         line = self.line_dao.get(line_id, tenant_uuids=tenant_uuids)
 
-        form = self.schema().load(request.get_json())
+        form = self.schema().load(body)
         model = self.model(**form)
         extension = self.extension_service.create(model, tenant_uuids)
 

--- a/wazo_confd/plugins/pjsip/resource.py
+++ b/wazo_confd/plugins/pjsip/resource.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2020-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from flask import url_for, request
@@ -53,9 +53,6 @@ class PJSIPTransportList(ListResource):
 
     schema = PJSIPTransportSchema
     model = PJSIPTransport
-
-    def __init__(self, service):
-        self.service = service
 
     def build_headers(self, transport):
         return {

--- a/wazo_confd/plugins/user/api.yml
+++ b/wazo_confd/plugins/user/api.yml
@@ -33,7 +33,7 @@ paths:
         description: User to create
         required: true
         schema:
-          $ref: '#/definitions/User'
+          $ref: '#/definitions/UserCreate'
       responses:
         '201':
           description: User created
@@ -288,7 +288,30 @@ parameters:
     description: the user's ID or UUID
 
 definitions:
-  User:
+  UserCreate:
+    title: User Create
+    allOf:
+    - $ref: '#/definitions/BaseUser'
+    - $ref: '#/definitions/UserRelationVoicemail'
+    - $ref: '#/definitions/UserRelationAgent'
+    - $ref: '#/definitions/UserRelationFallbacks'
+    - $ref: '#/definitions/UserRelationForwards'
+    - $ref: '#/definitions/UserRelationGroups'
+    - $ref: '#/definitions/UserRelationIncalls'
+    - $ref: '#/definitions/UserRelationLinesCreate'
+    - $ref: '#/definitions/UserRelationServices'
+    - $ref: '#/definitions/UserRelationSwitchboards'
+    - $ref: '#/definitions/UserRelationQueues'
+    - $ref: '#/definitions/UserRelationCallPickupTargets'
+
+  UserRelationLinesCreate:
+    properties:
+      lines:
+        type: array
+        items:
+          $ref: '#/definitions/UserRelationLine'
+
+  BaseUser:
     title: User
     allOf:
     - $ref: '#/definitions/UserRelationBase'
@@ -405,6 +428,11 @@ definitions:
           type: string
           description: The UUID of the tenant
           readOnly: true
+
+  User:
+    title: User
+    allOf:
+    - $ref: '#/definitions/BaseUser'
     - $ref: '#/definitions/UserRelationAgent'
     - $ref: '#/definitions/UserRelationFallbacks'
     - $ref: '#/definitions/UserRelationForwards'

--- a/wazo_confd/plugins/user/plugin.py
+++ b/wazo_confd/plugins/user/plugin.py
@@ -1,8 +1,22 @@
-# Copyright 2015-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
+
+from xivo_dao.resources.user import dao as user_dao
+from xivo_dao.resources.endpoint_custom import dao as endpoint_custom_dao
+from xivo_dao.resources.endpoint_sccp import dao as endpoint_sccp_dao
+from xivo_dao.resources.line import dao as line_dao
+from xivo_dao.resources.endpoint_sip import dao as sip_dao
+from xivo_dao.resources.pjsip_transport import dao as transport_dao
 
 from wazo_provd_client import Client as ProvdClient
 
+from wazo_confd.plugins.extension.service import (
+    build_service as build_extension_service,
+)
+from wazo_confd.plugins.line.service import build_service as build_line_service
+from wazo_confd.plugins.user_line.service import (
+    build_service as build_user_line_service,
+)
 from .resource import UserItem, UserList
 from .resource_sub import (
     UserForwardBusy,
@@ -13,7 +27,24 @@ from .resource_sub import (
     UserServiceIncallFilter,
     UserServiceList,
 )
+from wazo_confd.plugins.line_extension.service import (
+    build_service as build_extension_line_service,
+)
+from wazo_confd.plugins.endpoint_sip.service import (
+    build_endpoint_service as build_endpoint_sip_service,
+)
+from wazo_confd.plugins.line_endpoint.service import build_service_custom
+from wazo_confd.plugins.line_endpoint.service import build_service_sip
+from wazo_confd.plugins.line_endpoint.service import build_service_sccp
+from wazo_confd.plugins.endpoint_sccp.service import (
+    build_service as build_endpoint_sccp_service,
+)
+from wazo_confd.plugins.endpoint_custom.service import (
+    build_service as build_endpoint_custom_service,
+)
+
 from .service import build_service, build_service_callservice, build_service_forward
+from ..user_import.wazo_user_service import build_service as build_wazo_user_service
 
 
 class Plugin:
@@ -21,24 +52,58 @@ class Plugin:
         api = dependencies['api']
         config = dependencies['config']
         token_changed_subscribe = dependencies['token_changed_subscribe']
+        pjsip_doc = dependencies['pjsip_doc']
 
         provd_client = ProvdClient(**config['provd'])
         token_changed_subscribe(provd_client.set_token)
 
-        service = build_service(provd_client)
+        user_service = build_service(provd_client)
+        wazo_user_service = build_wazo_user_service()
         service_callservice = build_service_callservice()
         service_forward = build_service_forward()
+        line_service = build_line_service(provd_client)
+        extension_service = build_extension_service(provd_client)
+        user_line_service = build_user_line_service()
+        endpoint_custom_service = build_endpoint_custom_service()
+        endpoint_sip_service = build_endpoint_sip_service(provd_client, pjsip_doc)
+        endpoint_sccp_service = build_endpoint_sccp_service()
+        extension_line_service = build_extension_line_service()
+        line_endpoint_custom_association_service = build_service_custom(provd_client)
+        line_endpoint_sip_association_service = build_service_sip(provd_client)
+        line_endpoint_sccp_association_service = build_service_sccp(provd_client)
 
         api.add_resource(
             UserItem,
             '/users/<uuid:id>',
             '/users/<int:id>',
             endpoint='users',
-            resource_class_args=(service,),
+            resource_class_args=(user_service,),
         )
 
         api.add_resource(
-            UserList, '/users', endpoint='users_list', resource_class_args=(service,)
+            UserList,
+            '/users',
+            endpoint='users_list',
+            resource_class_args=(
+                user_service,
+                line_service,
+                user_line_service,
+                endpoint_custom_service,
+                endpoint_sip_service,
+                extension_line_service,
+                extension_service,
+                line_endpoint_custom_association_service,
+                line_endpoint_sip_association_service,
+                line_endpoint_sccp_association_service,
+                endpoint_sccp_service,
+                wazo_user_service,
+                endpoint_custom_dao,
+                endpoint_sccp_dao,
+                line_dao,
+                user_dao,
+                sip_dao,
+                transport_dao,
+            ),
         )
 
         api.add_resource(

--- a/wazo_confd/plugins/user/resource.py
+++ b/wazo_confd/plugins/user/resource.py
@@ -83,6 +83,7 @@ class UserList(ListResource):
     def _post(self, body):
         body = self.schema().load(body)
         lines = body.pop('lines', None) or []
+        auth = body.pop('auth', None)
 
         user_dict, _, headers = super()._post(body)
         user_dict['lines'] = []
@@ -92,11 +93,9 @@ class UserList(ListResource):
             self._user_line_item_resource.put(user_dict['uuid'], line['id'])
             user_dict['lines'].append(line)
 
-        # FIX: create(...) takes a user dict containing an 'email_address' key, not an 'email' key
-        if user_dict.get('username'):
-            fixed_user_dict = user_dict.copy()
-            fixed_user_dict['email_address'] = fixed_user_dict['email']
-            self._wazo_user_service.create(fixed_user_dict)
+        if auth:
+            user_dict['auth'] = self._wazo_user_service.create(auth)
+
         return user_dict, 201, headers
 
     @required_acl('confd.users.read')

--- a/wazo_confd/plugins/user/resource.py
+++ b/wazo_confd/plugins/user/resource.py
@@ -1,5 +1,7 @@
-# Copyright 2015-2020 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
+
+import logging
 
 from flask import url_for
 
@@ -7,20 +9,69 @@ from xivo_dao.alchemy.userfeatures import UserFeatures as User
 
 from wazo_confd.auth import required_acl
 from wazo_confd.helpers.restful import ListResource, ItemResource
+from wazo_confd.plugins.line.resource import LineList
+from wazo_confd.plugins.user_line.resource import UserLineItem
 
 from .schema import (
     UserDirectorySchema,
-    UserSchema,
+    UserListSchema,
     UserSchemaNullable,
     UserSummarySchema,
+    UserPutSchema,
 )
+
+logger = logging.getLogger(__name__)
 
 
 class UserList(ListResource):
 
     model = User
     schema = UserSchemaNullable
+    _list_schema = UserListSchema
     view_schemas = {'directory': UserDirectorySchema, 'summary': UserSummarySchema}
+
+    def __init__(
+        self,
+        user_service,
+        line_service,
+        user_line_service,
+        endpoint_custom_service,
+        endpoint_sip_service,
+        extension_line_service,
+        extension_service,
+        line_endpoint_custom_association_service,
+        line_endpoint_sip_association_service,
+        line_endpoint_sccp_association_service,
+        endpoint_sccp_service,
+        wazo_user_service,
+        endpoint_custom_dao,
+        endpoint_sccp_dao,
+        line_dao,
+        user_dao,
+        sip_dao,
+        transport_dao,
+    ):
+        super().__init__(user_service)
+        self._line_list_resource = LineList(
+            line_service,
+            endpoint_custom_service,
+            endpoint_sip_service,
+            extension_line_service,
+            extension_service,
+            line_endpoint_custom_association_service,
+            line_endpoint_sip_association_service,
+            line_endpoint_sccp_association_service,
+            endpoint_sccp_service,
+            endpoint_custom_dao,
+            endpoint_sccp_dao,
+            line_dao,
+            sip_dao,
+            transport_dao,
+        )
+        self._user_line_item_resource = UserLineItem(
+            user_line_service, user_dao, line_dao
+        )
+        self._wazo_user_service = wazo_user_service
 
     def build_headers(self, user):
         return {'Location': url_for('users', id=user.id, _external=True)}
@@ -28,6 +79,25 @@ class UserList(ListResource):
     @required_acl('confd.users.create')
     def post(self):
         return super().post()
+
+    def _post(self, body):
+        body = self.schema().load(body)
+        lines = body.pop('lines', None) or []
+
+        user_dict, _, headers = super()._post(body)
+        user_dict['lines'] = []
+
+        for line_body in lines:
+            line, _, _ = self._line_list_resource._post(line_body)
+            self._user_line_item_resource.put(user_dict['uuid'], line['id'])
+            user_dict['lines'].append(line)
+
+        # FIX: create(...) takes a user dict containing an 'email_address' key, not an 'email' key
+        if user_dict.get('username'):
+            fixed_user_dict = user_dict.copy()
+            fixed_user_dict['email_address'] = fixed_user_dict['email']
+            self._wazo_user_service.create(fixed_user_dict)
+        return user_dict, 201, headers
 
     @required_acl('confd.users.read')
     def get(self):
@@ -41,7 +111,7 @@ class UserList(ListResource):
 
 class UserItem(ItemResource):
 
-    schema = UserSchema
+    schema = UserPutSchema
     has_tenant_uuid = True
 
     @required_acl('confd.users.{id}.read')

--- a/wazo_confd/plugins/user/resource.py
+++ b/wazo_confd/plugins/user/resource.py
@@ -94,6 +94,8 @@ class UserList(ListResource):
             user_dict['lines'].append(line)
 
         if auth:
+            auth['uuid'] = user_dict['uuid']
+            auth['tenant_uuid'] = user_dict['tenant_uuid']
             user_dict['auth'] = self._wazo_user_service.create(auth)
 
         return user_dict, 201, headers

--- a/wazo_confd/plugins/user/schema.py
+++ b/wazo_confd/plugins/user/schema.py
@@ -1,7 +1,14 @@
 # Copyright 2016-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from marshmallow import fields, post_dump, pre_dump, post_load, pre_load, validates_schema
+from marshmallow import (
+    fields,
+    post_dump,
+    pre_dump,
+    post_load,
+    pre_load,
+    validates_schema,
+)
 from marshmallow.exceptions import ValidationError
 from marshmallow.validate import Length, Range, Regexp
 
@@ -23,7 +30,9 @@ CALL_PERMISSION_PASSWORD_REGEX = r"^[0-9#\*]{1,16}$"
 
 class WazoAuthUserSchema(BaseSchema):
     uuid = fields.UUID(dump_only=True)
-    username = fields.String(validate=Length(min=1, max=256), missing=None, allow_none=True)
+    username = fields.String(
+        validate=Length(min=1, max=256), missing=None, allow_none=True
+    )
     password = fields.String(validate=Length(min=1), allow_none=True)
     firstname = fields.String(missing=None, allow_none=True)
     lastname = fields.String(missing=None, allow_none=True)

--- a/wazo_confd/plugins/user/schema.py
+++ b/wazo_confd/plugins/user/schema.py
@@ -5,7 +5,13 @@ from marshmallow import fields, post_dump, pre_dump, post_load, validates_schema
 from marshmallow.exceptions import ValidationError
 from marshmallow.validate import Length, Range, Regexp
 
-from wazo_confd.helpers.mallow import BaseSchema, Link, ListLink, StrictBoolean, Nested
+from wazo_confd.helpers.mallow import (
+    BaseSchema,
+    Link,
+    ListLink,
+    StrictBoolean,
+    Nested,
+)
 from wazo_confd.helpers.validator import LANGUAGE_REGEX
 
 MOBILE_PHONE_NUMBER_REGEX = r"^\+?[0-9\*#]+$"
@@ -72,20 +78,7 @@ class UserSchema(BaseSchema):
     incalls = Nested(
         'IncallSchema', only=['id', 'extensions', 'links'], many=True, dump_only=True
     )
-    lines = Nested(
-        'LineSchema',
-        only=[
-            'id',
-            'name',
-            'endpoint_sip',
-            'endpoint_sccp',
-            'endpoint_custom',
-            'extensions',
-            'links',
-        ],
-        many=True,
-        dump_only=True,
-    )
+    lines = Nested('LineSchema', many=True)
     forwards = Nested('ForwardsSchema', dump_only=True)
     schedules = Nested(
         'ScheduleSchema', only=['id', 'name', 'links'], many=True, dump_only=True
@@ -229,3 +222,24 @@ class UserSchemaNullable(UserSchema):
         ]
         if field_name in nullable_fields:
             field_obj.allow_none = True
+
+
+class UserListSchema(UserSchemaNullable):
+    lines = Nested(
+        'LineSchema',
+        only=[
+            'id',
+            'name',
+            'endpoint_sip',
+            'endpoint_sccp',
+            'endpoint_custom',
+            'extensions',
+            'links',
+        ],
+        many=True,
+        dump_only=True,
+    )
+
+
+class UserPutSchema(UserSchema):
+    lines = Nested('LineSchema', many=True, dump_only=True)


### PR DESCRIPTION
This PR restores the new user API branch that was reverted because it created a wazo-auth user given body that used to work in previous version and did NOT create one.

This new version will do the following.

1. If a line is created and its body includes an endpoint (SIP, SCCP or custom) the endpoint will be created and associated to the line at the same time.
2. If the line has an extension in its body when it gets created, then the extension will be created and associated while creating the line.
3. If the user has a line in its body when it gets created, then the line will be created and associated while creating the user.
4. If an `auth` section is in the user's body when creating the user, then the wazo-auth user for that user will be created at the same time as the wazo-confd user.

When an error occurs nothing should happen. I did not write a test for a stopped wazo-auth since that would have returned a 503 from the token checking mechanism and not from the implementation of this resource anyway.
