### PR TITLE
Fix dissociation on line extension delete

### DIFF
--- a/wazo_confd/plugins/extension/plugin.py
+++ b/wazo_confd/plugins/extension/plugin.py
@@ -1,7 +1,14 @@
-# Copyright 2016-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from wazo_provd_client import Client as ProvdClient
+
+from xivo_dao.resources.line import dao as line_dao
+from xivo_dao.resources.extension import dao as extension_dao
+
+from wazo_confd.plugins.line_extension.service import (
+    build_service as build_line_extension_service,
+)
 
 from .resource import ExtensionItem, ExtensionList
 from .service import build_service
@@ -17,11 +24,17 @@ class Plugin:
         token_changed_subscribe(provd_client.set_token)
 
         service = build_service(provd_client)
+        line_extension_service = build_line_extension_service()
 
         api.add_resource(
             ExtensionItem,
             '/extensions/<int:id>',
             endpoint='extensions',
-            resource_class_args=(service,),
+            resource_class_args=(
+                service,
+                line_extension_service,
+                line_dao,
+                extension_dao,
+            ),
         )
         api.add_resource(ExtensionList, '/extensions', resource_class_args=(service,))

--- a/wazo_confd/plugins/line/plugin.py
+++ b/wazo_confd/plugins/line/plugin.py
@@ -1,7 +1,14 @@
-# Copyright 2015-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from wazo_provd_client import Client as ProvdClient
+
+from xivo_dao.resources.line import dao as line_dao
+from xivo_dao.resources.extension import dao as extension_dao
+
+from wazo_confd.plugins.line_extension.service import (
+    build_service as build_line_extension_service,
+)
 
 from .resource import LineItem, LineList
 from .service import build_service
@@ -17,11 +24,17 @@ class Plugin:
         token_changed_subscribe(provd_client.set_token)
 
         service = build_service(provd_client)
+        line_extension_service = build_line_extension_service()
 
         api.add_resource(
             LineItem,
             '/lines/<int:id>',
             endpoint='lines',
-            resource_class_args=(service,),
+            resource_class_args=(
+                service,
+                line_extension_service,
+                line_dao,
+                extension_dao,
+            ),
         )
         api.add_resource(LineList, '/lines', resource_class_args=(service,))

--- a/wazo_confd/plugins/line/resource.py
+++ b/wazo_confd/plugins/line/resource.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2020 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from flask import url_for, request
@@ -50,4 +50,7 @@ class LineItem(ItemResource):
 
     @required_acl('confd.lines.{id}.delete')
     def delete(self, id):
-        return super().delete(id)
+        kwargs = self._add_tenant_uuid()
+        model = self.service.get(id, **kwargs)
+        self.service.delete(model)
+        return '', 204


### PR DESCRIPTION
This is a followup to https://github.com/wazo-platform/xivo-manage-db/pull/170/files
Since the CASCADE does not execute the line_extension fixes this dissociate the line/extension explicitly when deleting a line or extension that are associated.

I have not been able to spot a bug to would result from not executing the fixes