### PR TITLE
Fix uuid needed for schemas

### DIFF
--- a/integration_tests/suite/base/test_group_member_user.py
+++ b/integration_tests/suite/base/test_group_member_user.py
@@ -3,7 +3,14 @@
 
 import re
 
-from hamcrest import assert_that, contains, contains_inanyorder, empty, has_entries
+from hamcrest import (
+    assert_that,
+    contains,
+    contains_inanyorder,
+    empty,
+    has_entries,
+    has_items,
+)
 
 from . import confd
 from ..helpers import associations as a, errors as e, fixtures, scenarios as s
@@ -198,12 +205,13 @@ def test_get_groups_associated_to_user(group1, group2, user, line):
         response = confd.users.get()
         assert_that(
             response.items,
-            contains_inanyorder(
+            has_items(
                 has_entries(
+                    uuid=user['uuid'],
                     groups=contains_inanyorder(
                         has_entries(id=group2['id'], uuid=group2['uuid']),
                         has_entries(id=group1['id'], uuid=group1['uuid']),
-                    )
+                    ),
                 ),
             ),
         )

--- a/integration_tests/suite/base/test_group_member_user.py
+++ b/integration_tests/suite/base/test_group_member_user.py
@@ -194,6 +194,20 @@ def test_get_groups_associated_to_user(group1, group2, user, line):
             ),
         )
 
+        # Listing use different schema
+        response = confd.users.get()
+        assert_that(
+            response.items,
+            contains_inanyorder(
+                has_entries(
+                    groups=contains_inanyorder(
+                        has_entries(id=group2['id'], uuid=group2['uuid']),
+                        has_entries(id=group1['id'], uuid=group1['uuid']),
+                    )
+                ),
+            ),
+        )
+
 
 @fixtures.group(wazo_tenant=MAIN_TENANT)
 @fixtures.group(wazo_tenant=SUB_TENANT)

--- a/integration_tests/suite/base/test_switchboard_member_user.py
+++ b/integration_tests/suite/base/test_switchboard_member_user.py
@@ -1,7 +1,13 @@
 # Copyright 2016-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from hamcrest import assert_that, contains_inanyorder, empty, has_entries
+from hamcrest import (
+    assert_that,
+    contains_inanyorder,
+    empty,
+    has_entries,
+    has_items,
+)
 
 from . import confd
 from ..helpers import (
@@ -132,12 +138,13 @@ def test_get_switchboards_associated_to_user(switchboard1, switchboard2, user):
         response = confd.users.get()
         assert_that(
             response.items,
-            contains_inanyorder(
+            has_items(
                 has_entries(
+                    uuid=user['uuid'],
                     switchboards=contains_inanyorder(
                         has_entries(uuid=switchboard1['uuid']),
                         has_entries(uuid=switchboard2['uuid']),
-                    )
+                    ),
                 ),
             ),
         )

--- a/integration_tests/suite/base/test_switchboard_member_user.py
+++ b/integration_tests/suite/base/test_switchboard_member_user.py
@@ -128,6 +128,20 @@ def test_get_switchboards_associated_to_user(switchboard1, switchboard2, user):
             ),
         )
 
+        # Listing use different schema
+        response = confd.users.get()
+        assert_that(
+            response.items,
+            contains_inanyorder(
+                has_entries(
+                    switchboards=contains_inanyorder(
+                        has_entries(uuid=switchboard1['uuid']),
+                        has_entries(uuid=switchboard2['uuid']),
+                    )
+                ),
+            ),
+        )
+
 
 @fixtures.switchboard()
 @fixtures.user()

--- a/integration_tests/suite/base/test_users.py
+++ b/integration_tests/suite/base/test_users.py
@@ -1032,3 +1032,16 @@ def test_post_full_user_no_error(
             confd.extensions(
                 payload['lines'][0]['extensions'][0]['id']
             ).delete().assert_deleted()
+
+
+@fixtures.group()
+@fixtures.user()
+@fixtures.line_sip()
+def test_get_users_list_returns_HTTP_200(group, user, line):
+    """
+    Check if a minimalistic GET on /users returned 200
+    """
+    with a.user_line(user, line):
+        confd.users(user['uuid']).groups.put(groups=[group])
+
+        confd.users.get().assert_ok()

--- a/integration_tests/suite/base/test_users.py
+++ b/integration_tests/suite/base/test_users.py
@@ -1035,13 +1035,17 @@ def test_post_full_user_no_error(
 
 
 @fixtures.group()
+@fixtures.switchboard()
 @fixtures.user()
 @fixtures.line_sip()
-def test_get_users_list_returns_HTTP_200(group, user, line):
+def test_get_users_list_returns_HTTP_200(group, switchboard, user, line):
     """
     Check if a minimalistic GET on /users returned 200
     """
     with a.user_line(user, line):
         confd.users(user['uuid']).groups.put(groups=[group])
+        confd.switchboards(switchboard['uuid']).members.users.put(
+            users=[{'uuid': user['uuid']}]
+        )
 
         confd.users.get().assert_ok()

--- a/integration_tests/suite/base/test_users.py
+++ b/integration_tests/suite/base/test_users.py
@@ -1032,20 +1032,3 @@ def test_post_full_user_no_error(
             confd.extensions(
                 payload['lines'][0]['extensions'][0]['id']
             ).delete().assert_deleted()
-
-
-@fixtures.group()
-@fixtures.switchboard()
-@fixtures.user()
-@fixtures.line_sip()
-def test_get_users_list_returns_HTTP_200(group, switchboard, user, line):
-    """
-    Check if a minimalistic GET on /users returned 200
-    """
-    with a.user_line(user, line):
-        confd.users(user['uuid']).groups.put(groups=[group])
-        confd.switchboards(switchboard['uuid']).members.users.put(
-            users=[{'uuid': user['uuid']}]
-        )
-
-        confd.users.get().assert_ok()

--- a/wazo_confd/plugins/user/resource.py
+++ b/wazo_confd/plugins/user/resource.py
@@ -46,7 +46,7 @@ class UserList(ListResource):
         params = self.search_params()
         tenant_uuids = self._build_tenant_list(params)
         view = params.get('view')
-        schema = self.view_schemas.get(view, self.schema)
+        schema = self.view_schemas.get(view, UserSchema)
         result = self.service.search(params, tenant_uuids)
         return {'total': result.total, 'items': schema().dump(result.items, many=True)}
 

--- a/wazo_confd/plugins/user/schema.py
+++ b/wazo_confd/plugins/user/schema.py
@@ -278,9 +278,9 @@ class UserExtensionSchema(BaseSchema):
 
 class UserGroupSchema(BaseSchema):
     uuid = fields.String(validate=Length(max=40), required=True)
-    links = ListLink(Link('groups'))
+    links = ListLink(Link('groups', field='uuid'))
 
 
 class UserSwitchboardSchema(BaseSchema):
     uuid = fields.String(validate=Length(max=40), required=True)
-    links = ListLink(Link('switchboards'))
+    links = ListLink(Link('switchboards', field='uuid'))


### PR DESCRIPTION
Fix the error
`werkzeug.routing.BuildError: Could not build url for endpoint 'groups' with values ['id']. Did you forget to specify values ['uuid']?`