### PR TITLE
Update swagger doc

### DIFF
--- a/wazo_confd/plugins/user/api.yml
+++ b/wazo_confd/plugins/user/api.yml
@@ -680,10 +680,6 @@ definitions:
           properties:
             uuid:
               type: string
-              description: A comma separated list of groups UUIDs
-            id:
-              type: integer
-              description: A comma separated list of groups IDs
       switchboards:
         type: array
         items:
@@ -691,10 +687,6 @@ definitions:
           properties:
             uuid:
               type: string
-              description: A comma separated list of switchboards UUIDs
-            id:
-              type: integer
-              description: A comma separated list of switchboards IDs
       auth:
         type: object
         properties:

--- a/wazo_confd/plugins/user/api.yml
+++ b/wazo_confd/plugins/user/api.yml
@@ -676,13 +676,25 @@ definitions:
       groups:
         type: array
         items:
-          type: string
-          description: A comma separated list of groups UUIDs
+          type: object
+          properties:
+            uuid:
+              type: string
+              description: A comma separated list of groups UUIDs
+            id:
+              type: string
+              description: A comma separated list of groups IDs
       switchboards:
         type: array
         items:
-          type: string
-          description: A comma separated list of switchboards UUIDs
+          type: object
+          properties:
+            uuid:
+              type: string
+              description: A comma separated list of switchboards UUIDs
+            id:
+              type: string
+              description: A comma separated list of switchboards IDs
       auth:
         type: object
         properties:

--- a/wazo_confd/plugins/user/api.yml
+++ b/wazo_confd/plugins/user/api.yml
@@ -682,7 +682,7 @@ definitions:
               type: string
               description: A comma separated list of groups UUIDs
             id:
-              type: string
+              type: integer
               description: A comma separated list of groups IDs
       switchboards:
         type: array
@@ -693,7 +693,7 @@ definitions:
               type: string
               description: A comma separated list of switchboards UUIDs
             id:
-              type: string
+              type: integer
               description: A comma separated list of switchboards IDs
       auth:
         type: object


### PR DESCRIPTION
`groups: ["string"]` is not correct.
should be `groups: [{ uuid: "string", id: "string" }]`

same thing for switchboards.