### PR TITLE
fix tox.ini for tox4

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@
 
 [tox]
 envlist = py37, pycodestyle, pylint
-skipsdist = true
+skipsdist = false
 
 [testenv]
 basepython = python3.7
@@ -23,7 +23,7 @@ commands =
     -sh -c 'pycodestyle --ignore=E501,W503 wazo_confd > pycodestyle.txt'
 deps =
     pycodestyle
-whitelist_externals =
+allowlist_externals =
     sh
 
 [testenv:black]
@@ -41,7 +41,7 @@ commands =
   flake8
 
 [testenv:integration]
-usedevelop = true
+use_develop = true
 deps = -rintegration_tests/test-requirements.txt
 changedir = integration_tests
 passenv =
@@ -50,7 +50,7 @@ passenv =
 commands =
     make test-setup
     nosetests -v {posargs}
-whitelist_externals =
+allowlist_externals =
     make
 
 [testenv:pylint]


### PR DESCRIPTION
changes:

* skipsdist and usedevelop are now mutually exclusive
* usedevelop -> use_develop for future
* whitelist_externals -> allowlist_externals