### PR TITLE
[WP-624] event_handlers: add new default endpoint option

### DIFF
--- a/wazo_confd/plugins/event_handlers/service.py
+++ b/wazo_confd/plugins/event_handlers/service.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2020-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
@@ -80,6 +80,7 @@ class DefaultSIPTemplateService:
                 ['trust_id_inbound', 'no'],
                 ['allow_subscribe', 'yes'],
                 ['allow', '!all,ulaw'],
+                ['notify_early_inuse_ringing', 'yes'],
             ],
             'registration_section_options': [],
             'registration_outbound_auth_section_options': [],


### PR DESCRIPTION
`notify_early_inuse_ringing` is available to mimick the chan_sip
behaviour for BLF function keys to pickup a call of a user that is
already busy.