### PR TITLE
Limit sqlalchemy to version 1 in tests

### DIFF
--- a/integration_tests/test-requirements.txt
+++ b/integration_tests/test-requirements.txt
@@ -10,4 +10,4 @@ openapi-spec-validator
 psycopg2-binary  # sqlalchemy engine
 pyhamcrest
 requests
-sqlalchemy
+sqlalchemy<2


### PR DESCRIPTION
sqlalchemy version 2.0 needs work before the migration

https://docs.sqlalchemy.org/en/14/changelog/migration_20.html