### PR TITLE
[WAZO-3256] PJSIP allow multiple values separated by comma

### DIFF
--- a/integration_tests/suite/base/test_pjsip_transports.py
+++ b/integration_tests/suite/base/test_pjsip_transports.py
@@ -86,6 +86,7 @@ def test_create_all_parameters():
             ['local_net', '192.168.0.0/16'],
             ['local_net', '10.37.1.0/24'],
         ],
+        'cipher': 'ECDHE-RSA-AES128-GCM-SHA256,TLS_CHACHA20_POLY1305_SHA256',
     }
     response = confd.sip.transports.post(parameters)
     response.assert_created()

--- a/wazo_confd/helpers/mallow.py
+++ b/wazo_confd/helpers/mallow.py
@@ -110,7 +110,7 @@ class ListLink(fields.Field):
 
 
 class PJSIPSectionOption(fields.List):
-    DEFAULT_OPTION_REGEX = r"^[a-zA-Z0-9-_\/\.:]*$"
+    DEFAULT_OPTION_REGEX = r"^[a-zA-Z0-9-_\/\.:,]*$"
 
     def __init__(self, option_regex=DEFAULT_OPTION_REGEX, **kwargs):
         kwargs['validate'] = [validate.Length(min=1, max=4092)]


### PR DESCRIPTION
Allow to configure this settings for example `cipher=ECDHE-RSA-AES256-GCM-SHA384,ECDHE-RSA-CHACHA20-POLY1305`