### PR TITLE
WAZO-3256 support commas in pjsip transport option value strings

### DIFF
--- a/integration_tests/suite/base/test_pjsip_transports.py
+++ b/integration_tests/suite/base/test_pjsip_transports.py
@@ -111,6 +111,17 @@ def test_edit_minimal_parameters(transport):
     response.assert_updated()
 
 
+@fixtures.transport()
+def test_edit_options_with_commas(transport):
+    parameters = {
+        'options': [
+            ['cipher', 'ECDHE-RSA-AES128-GCM-SHA256,TLS_CHACHA20_POLY1305_SHA256']
+        ]
+    }
+    response = confd.sip.transports(transport['uuid']).put(parameters)
+    response.assert_updated()
+
+
 def test_get_errors():
     fake_transport = confd.sip.transports(FAKE_UUID).get
     yield s.check_resource_not_found, fake_transport, 'Transport'

--- a/wazo_confd/helpers/mallow.py
+++ b/wazo_confd/helpers/mallow.py
@@ -110,7 +110,7 @@ class ListLink(fields.Field):
 
 
 class PJSIPSectionOption(fields.List):
-    DEFAULT_OPTION_REGEX = r"^[a-zA-Z0-9-_\/\.:]*$"
+    DEFAULT_OPTION_REGEX = r"^[a-zA-Z0-9-_\/\.:,]*$"
 
     def __init__(self, option_regex=DEFAULT_OPTION_REGEX, **kwargs):
         kwargs['validate'] = [validate.Length(min=1, max=4092)]


### PR DESCRIPTION
## Added test case to support pjsip transport options with commas in values


## Updated PJSIPSectionOption regex to allow commas in values