### PR TITLE
Improve tenant deletion (including some related resources)

### DIFF
--- a/integration_tests/suite/base/test_sync_db.py
+++ b/integration_tests/suite/base/test_sync_db.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2020-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import (
@@ -25,11 +25,11 @@ def test_remove_user_with_voicemail(_, user, voicemail):
         with BaseIntegrationTest.delete_auth_tenant(DELETED_TENANT):
             BaseIntegrationTest.sync_db()
 
-        response = confd.users(user['uuid']).get()
-        response.assert_status(404)
+            response = confd.users(user['uuid']).get()
+            response.assert_status(404)
 
-        response = confd.voicemails(voicemail['id']).get()
-        assert_that(response.item, has_entries(users=empty()))
+            response = confd.voicemails(voicemail['id']).get()
+            response.assert_status(404)
 
 
 @fixtures.context(name='DELETED', wazo_tenant=DELETED_TENANT)
@@ -40,11 +40,11 @@ def test_remove_user_with_line(context, user):
             with BaseIntegrationTest.delete_auth_tenant(DELETED_TENANT):
                 BaseIntegrationTest.sync_db()
 
-            response = confd.users(user['uuid']).get()
-            response.assert_status(404)
+                response = confd.users(user['uuid']).get()
+                response.assert_status(404)
 
-            response = confd.lines(line['id']).get()
-            assert_that(response.item, has_entries(users=empty()))
+                response = confd.lines(line['id']).get()
+                response.assert_status(404)
 
 
 def test_create_default_templates_when_not_exist():
@@ -55,24 +55,23 @@ def test_create_default_templates_when_not_exist():
 
     with BaseIntegrationTest.create_auth_tenant(CREATED_TENANT):
         BaseIntegrationTest.sync_db()
-
-    response = confd.endpoints.sip.templates.get(wazo_tenant=CREATED_TENANT)
-    assert_that(
-        response.items,
-        contains_inanyorder(
-            has_entries(
-                label='global',
-                transport=has_entries(uuid=transport_udp['uuid']),
+        response = confd.endpoints.sip.templates.get(wazo_tenant=CREATED_TENANT)
+        assert_that(
+            response.items,
+            contains_inanyorder(
+                has_entries(
+                    label='global',
+                    transport=has_entries(uuid=transport_udp['uuid']),
+                ),
+                has_entries(
+                    label='webrtc',
+                    transport=has_entries(uuid=transport_wss['uuid']),
+                ),
+                has_entries(label='meeting_guest'),
+                has_entries(label='registration_trunk'),
+                has_entries(label='twilio_trunk'),
             ),
-            has_entries(
-                label='webrtc',
-                transport=has_entries(uuid=transport_wss['uuid']),
-            ),
-            has_entries(label='meeting_guest'),
-            has_entries(label='registration_trunk'),
-            has_entries(label='twilio_trunk'),
-        ),
-    )
+        )
 
 
 def test_no_create_default_templates_when_exist():

--- a/integration_tests/suite/base/test_tenants.py
+++ b/integration_tests/suite/base/test_tenants.py
@@ -68,7 +68,6 @@ def test_list_multi_tenant(_):
     )
 
 
-
 @fixtures.user(wazo_tenant=DELETED_TENANT)
 @fixtures.group(wazo_tenant=DELETED_TENANT)
 @fixtures.incall(wazo_tenant=DELETED_TENANT)
@@ -124,7 +123,6 @@ def test_delete_tenant_by_event(
 def test_delete_tenant_by_sync_db(
     user, group, incall, outcall, trunk, conference, context, voicemail
 ):
-
     with BaseIntegrationTest.delete_auth_tenant(DELETED_TENANT):
         BaseIntegrationTest.sync_db()
 

--- a/integration_tests/suite/base/test_tenants.py
+++ b/integration_tests/suite/base/test_tenants.py
@@ -9,13 +9,21 @@ from hamcrest import (
     has_key,
     not_,
 )
-
+from unittest import TestCase
+from sqlalchemy.sql import text
 from wazo_test_helpers import until
 
-from . import confd, BaseIntegrationTest
-from ..helpers import errors as e, fixtures
+from . import confd, db, BaseIntegrationTest
+from ..helpers import errors as e, fixtures, associations as a
 from ..helpers.bus import BusClient
-from ..helpers.config import MAIN_TENANT, SUB_TENANT, DELETED_TENANT
+from ..helpers.config import (
+    MAIN_TENANT,
+    SUB_TENANT,
+    DELETED_TENANT,
+    gen_group_exten,
+    gen_line_exten,
+    ALL_TENANTS,
+    DEFAULT_TENANTS)
 
 
 def test_get():
@@ -68,90 +76,266 @@ def test_list_multi_tenant(_):
     )
 
 
-@fixtures.user(wazo_tenant=DELETED_TENANT)
-@fixtures.group(wazo_tenant=DELETED_TENANT)
-@fixtures.incall(wazo_tenant=DELETED_TENANT)
-@fixtures.outcall(wazo_tenant=DELETED_TENANT)
-@fixtures.trunk(wazo_tenant=DELETED_TENANT)
-@fixtures.conference(wazo_tenant=DELETED_TENANT)
-@fixtures.context(name='mycontext', wazo_tenant=DELETED_TENANT)
-@fixtures.voicemail(context='mycontext', wazo_tenant=DELETED_TENANT)
-def test_delete_tenant_by_event(
-    user, group, incall, outcall, trunk, conference, context, voicemail
-):
-    BusClient.send_tenant_deleted(DELETED_TENANT, 'slug2')
+class BaseTestTenants(TestCase):
 
-    def tenant_deleted():
-        response = confd.tenants(DELETED_TENANT).get(wazo_tenant=MAIN_TENANT)
-        response.assert_match(404, e.not_found(resource='Tenant'))
+    def count_tables_rows(self):
+        tables_counts = {}
+        with self.db.queries() as queries:
+            query = text(
+                """
+                SELECT * 
+                FROM pg_catalog.pg_tables
+                WHERE schemaname != 'pg_catalog' AND
+                      schemaname != 'information_schema';
+                """
+            )
+            result = queries.connection.execute(query)
+            for row in result:
+                if row.tablename not in self.excluded_tables:
+                    query = text(f"SELECT COUNT(*) FROM {row.tablename};")
+                    count = queries.connection.execute(query).scalar()
+                    tables_counts[row.tablename] = count
+        return tables_counts
 
-        response = confd.users(user['uuid']).get()
-        response.assert_status(404)
+    def diff(self, after_tables_rows_counts):
+        diff = {
+            k: {
+                'before': self.before_tables_rows_counts[k],
+                'after': after_tables_rows_counts[k],
+            }
+            for k in self.before_tables_rows_counts
+            if k in after_tables_rows_counts
+            and self.before_tables_rows_counts[k] != after_tables_rows_counts[k]
+        }
+        return diff
 
-        response = confd.groups(group['uuid']).get()
-        response.assert_status(404)
-
-        response = confd.incalls(incall['id']).get()
-        response.assert_status(404)
-
-        response = confd.outcalls(outcall['id']).get()
-        response.assert_status(404)
-
-        response = confd.trunks(trunk['id']).get()
-        response.assert_status(404)
-
-        response = confd.conferences(conference['id']).get()
-        response.assert_status(404)
-
-        response = confd.context(context['id']).get()
-        response.assert_status(404)
-
-        response = confd.voicemails(voicemail['id']).get()
-        response.assert_status(404)
-
-    until.assert_(tenant_deleted, tries=5, interval=5)
+class BaseTestDeleteByEvent(BaseTestTenants):
+    def setUp(self):
+        self.db = db
+        self.excluded_tables = [
+            'agentqueueskill',
+            'extensions',
+            'dialaction',
+            'queue',
+            'queuemember',
+            'pickupmember',
+            'queueskillcat',
+            'func_key',
+            'func_key_dest_custom',
+        ]
+        self.before_tables_rows_counts = self.count_tables_rows()
 
 
-@fixtures.user(wazo_tenant=DELETED_TENANT)
-@fixtures.group(wazo_tenant=DELETED_TENANT)
-@fixtures.incall(wazo_tenant=DELETED_TENANT)
-@fixtures.outcall(wazo_tenant=DELETED_TENANT)
-@fixtures.trunk(wazo_tenant=DELETED_TENANT)
-@fixtures.conference(wazo_tenant=DELETED_TENANT)
-@fixtures.context(name='mycontext', wazo_tenant=DELETED_TENANT)
-@fixtures.voicemail(context='mycontext', wazo_tenant=DELETED_TENANT)
-def test_delete_tenant_by_sync_db(
-    user, group, incall, outcall, trunk, conference, context, voicemail
-):
-    with BaseIntegrationTest.delete_auth_tenant(DELETED_TENANT):
+    @fixtures.user(wazo_tenant=DELETED_TENANT)
+    @fixtures.group(wazo_tenant=DELETED_TENANT)
+    @fixtures.incall(wazo_tenant=DELETED_TENANT)
+    @fixtures.outcall(wazo_tenant=DELETED_TENANT)
+    @fixtures.conference(wazo_tenant=DELETED_TENANT)
+    @fixtures.context(name='mycontext', wazo_tenant=DELETED_TENANT)
+    @fixtures.voicemail(context='mycontext', wazo_tenant=DELETED_TENANT)
+    @fixtures.line_sip(context={'name': 'mycontext'}, wazo_tenant=DELETED_TENANT)
+    @fixtures.extension(exten=gen_group_exten(), context='mycontext')
+    @fixtures.funckey_template(
+        keys={'1': {'destination': {'type': 'custom', 'exten': '123'}}},
+        wazo_tenant=DELETED_TENANT,
+    )
+    @fixtures.switchboard(wazo_tenant=DELETED_TENANT)
+    @fixtures.device(wazo_tenant=DELETED_TENANT)
+    @fixtures.queue(wazo_tenant=DELETED_TENANT)
+    @fixtures.trunk(wazo_tenant=DELETED_TENANT)
+    @fixtures.trunk(wazo_tenant=DELETED_TENANT)
+    @fixtures.trunk(wazo_tenant=DELETED_TENANT)
+    @fixtures.sip(name='endpoint_sip', wazo_tenant=DELETED_TENANT)
+    @fixtures.sip(name='name_search', wazo_tenant=DELETED_TENANT)
+    @fixtures.iax(name='name_search', wazo_tenant=DELETED_TENANT)
+    @fixtures.custom(interface='name_search', wazo_tenant=DELETED_TENANT)
+    @fixtures.agent(number='1234', wazo_tenant=DELETED_TENANT)
+    @fixtures.extension(exten=gen_line_exten(), context='mycontext')
+    @fixtures.extension(exten=gen_line_exten(), context='mycontext')
+    @fixtures.skill(wazo_tenant=DELETED_TENANT, category='mycategory')
+    @fixtures.call_pickup(wazo_tenant=DELETED_TENANT)
+    @fixtures.user(wazo_tenant=DELETED_TENANT)
+    @fixtures.call_permission(wazo_tenant=DELETED_TENANT)
+    @fixtures.call_filter(wazo_tenant=DELETED_TENANT)
+    def test_delete_tenant_with_many_resources_by_event(
+        self,
+        user,
+        group,
+        incall,
+        outcall,
+        conference,
+        context,
+        voicemail,
+        line,
+        group_extension,
+        funckey_template,
+        switchboard,
+        device,
+        queue,
+        trunk_sip,
+        trunk_iax,
+        trunk_custom,
+        user_sip,
+        sip,
+        iax,
+        custom,
+        agent,
+        incall_extension,
+        outcall_extension,
+        skill,
+        call_pickup,
+        user2,
+        call_permission,
+        call_filter,
+    ):
+        with (
+            a.user_line(user, line, check=False),
+            a.line_endpoint_sip(line, user_sip, check=False),
+            a.user_voicemail(user, voicemail, check=False),
+            a.switchboard_member_user(switchboard, [user], check=False),
+            a.group_extension(group, group_extension, check=False),
+            a.user_agent(user, agent, check=False),
+            a.queue_member_agent(queue, agent, check=False),
+            a.agent_skill(agent, skill, check=False),
+            a.incall_extension(incall, incall_extension, check=False),
+            a.outcall_extension(outcall, outcall_extension, check=False),
+            a.group_member_user(group, user, check=False),
+            a.trunk_endpoint_sip(trunk_sip, sip, check=False),
+            a.trunk_endpoint_iax(trunk_iax, iax, check=False),
+            a.trunk_endpoint_custom(trunk_custom, custom, check=False),
+            a.call_pickup_interceptor_user(call_pickup, user, check=False),
+            a.call_pickup_target_user(call_pickup, user2, check=False),
+        ):
+            BusClient.send_tenant_deleted(DELETED_TENANT, 'slug2')
+
+            def resources_deleted():
+                after_deletion_tables_rows_counts = self.count_tables_rows()
+                diff = self.diff(after_deletion_tables_rows_counts)
+                assert (
+                    len(diff) == 0
+                ), "Some tables are not properly cleaned after the tenant deletion"
+
+            until.assert_(resources_deleted, tries=5, interval=5)
+
+class BaseTestDeleteBySyncDb(BaseTestTenants):
+    def setUp(self):
+        self.db = db
+        self.excluded_tables = [
+            'agentqueueskill',
+            'extensions',
+            'dialaction',
+            'queue',
+            'queuemember',
+            'pickupmember',
+            'queueskillcat',
+            'func_key',
+            'func_key_dest_custom',
+        ]
+
+        BaseIntegrationTest.mock_auth.set_tenants(*DEFAULT_TENANTS)
+
+        for t in DEFAULT_TENANTS:
+            BusClient.send_tenant_created(t['uuid'], t['slug'])
+
+        # xivo-manage-db creates a tenant (with a random uuid)
+        # sync_db is called now to remove this tenant
         BaseIntegrationTest.sync_db()
 
-        def tenant_deleted():
-            response = confd.tenants(DELETED_TENANT).get(wazo_tenant=MAIN_TENANT)
-            response.assert_match(404, e.not_found(resource='Tenant'))
+        # count before the creation of the DELETED_TENANT
+        self.before_tables_rows_counts = self.count_tables_rows()
 
-            response = confd.users(user['uuid']).get()
-            response.assert_status(404)
+        # add the tenant DELETED_TENANT in wazo-auth for the authorization,
+        # to be able to create the tenant in wazo-confd
+        BaseIntegrationTest.mock_auth.set_tenants(*ALL_TENANTS)
 
-            response = confd.groups(group['uuid']).get()
-            response.assert_status(404)
 
-            response = confd.incalls(incall['id']).get()
-            response.assert_status(404)
+    @fixtures.user(wazo_tenant=DELETED_TENANT)
+    @fixtures.group(wazo_tenant=DELETED_TENANT)
+    @fixtures.incall(wazo_tenant=DELETED_TENANT)
+    @fixtures.outcall(wazo_tenant=DELETED_TENANT)
+    @fixtures.conference(wazo_tenant=DELETED_TENANT)
+    @fixtures.context(name='mycontext', wazo_tenant=DELETED_TENANT)
+    @fixtures.voicemail(context='mycontext', wazo_tenant=DELETED_TENANT)
+    @fixtures.line_sip(context={'name': 'mycontext'}, wazo_tenant=DELETED_TENANT)
+    @fixtures.extension(exten=gen_group_exten(), context='mycontext')
+    @fixtures.funckey_template(
+        keys={'1': {'destination': {'type': 'custom', 'exten': '123'}}},
+        wazo_tenant=DELETED_TENANT,
+    )
+    @fixtures.switchboard(wazo_tenant=DELETED_TENANT)
+    @fixtures.device(wazo_tenant=DELETED_TENANT)
+    @fixtures.queue(wazo_tenant=DELETED_TENANT)
+    @fixtures.trunk(wazo_tenant=DELETED_TENANT)
+    @fixtures.trunk(wazo_tenant=DELETED_TENANT)
+    @fixtures.trunk(wazo_tenant=DELETED_TENANT)
+    @fixtures.sip(name='endpoint_sip2', wazo_tenant=DELETED_TENANT)
+    @fixtures.sip(name='name_search2', wazo_tenant=DELETED_TENANT)
+    @fixtures.iax(name='name_search', wazo_tenant=DELETED_TENANT)
+    @fixtures.custom(interface='name_search', wazo_tenant=DELETED_TENANT)
+    @fixtures.agent(number='1234', wazo_tenant=DELETED_TENANT)
+    @fixtures.extension(exten=gen_line_exten(), context='mycontext')
+    @fixtures.extension(exten=gen_line_exten(), context='mycontext')
+    @fixtures.skill(wazo_tenant=DELETED_TENANT, category='mycategory')
+    @fixtures.call_pickup(wazo_tenant=DELETED_TENANT)
+    @fixtures.user(wazo_tenant=DELETED_TENANT)
+    @fixtures.call_permission(wazo_tenant=DELETED_TENANT)
+    @fixtures.call_filter(wazo_tenant=DELETED_TENANT)
+    def test_delete_tenant_with_many_resources_by_syncdb(
+        self,
+        user,
+        group,
+        incall,
+        outcall,
+        conference,
+        context,
+        voicemail,
+        line,
+        group_extension,
+        funckey_template,
+        switchboard,
+        device,
+        queue,
+        trunk_sip,
+        trunk_iax,
+        trunk_custom,
+        user_sip,
+        sip,
+        iax,
+        custom,
+        agent,
+        incall_extension,
+        outcall_extension,
+        skill,
+        call_pickup,
+        user2,
+        call_permission,
+        call_filter,
+    ):
+        with (
+            a.user_line(user, line, check=False),
+            a.line_endpoint_sip(line, user_sip, check=False),
+            a.user_voicemail(user, voicemail, check=False),
+            a.switchboard_member_user(switchboard, [user], check=False),
+            a.group_extension(group, group_extension, check=False),
+            a.user_agent(user, agent, check=False),
+            a.queue_member_agent(queue, agent, check=False),
+            a.agent_skill(agent, skill, check=False),
+            a.incall_extension(incall, incall_extension, check=False),
+            a.outcall_extension(outcall, outcall_extension, check=False),
+            a.group_member_user(group, user, check=False),
+            a.trunk_endpoint_sip(trunk_sip, sip, check=False),
+            a.trunk_endpoint_iax(trunk_iax, iax, check=False),
+            a.trunk_endpoint_custom(trunk_custom, custom, check=False),
+            a.call_pickup_interceptor_user(call_pickup, user, check=False),
+            a.call_pickup_target_user(call_pickup, user2, check=False),
+        ):
+            with BaseIntegrationTest.delete_auth_tenant(DELETED_TENANT):
+                BaseIntegrationTest.sync_db()
 
-            response = confd.outcalls(outcall['id']).get()
-            response.assert_status(404)
-
-            response = confd.trunks(trunk['id']).get()
-            response.assert_status(404)
-
-            response = confd.conferences(conference['id']).get()
-            response.assert_status(404)
-
-            response = confd.context(context['id']).get()
-            response.assert_status(404)
-
-            response = confd.voicemails(voicemail['id']).get()
-            response.assert_status(404)
-
-        until.assert_(tenant_deleted, tries=5, interval=5)
+                def resources_deleted():
+                    after_deletion_tables_rows_counts = self.count_tables_rows()
+                    diff = self.diff(after_deletion_tables_rows_counts)
+                    assert (
+                        len(diff) == 0
+                    ), "Some tables are not properly cleaned after tenant deletion"
+                until.assert_(resources_deleted, tries=5, interval=5)

--- a/integration_tests/suite/base/test_tenants.py
+++ b/integration_tests/suite/base/test_tenants.py
@@ -23,7 +23,8 @@ from ..helpers.config import (
     gen_group_exten,
     gen_line_exten,
     ALL_TENANTS,
-    DEFAULT_TENANTS)
+    DEFAULT_TENANTS,
+)
 
 
 def test_get():
@@ -77,7 +78,6 @@ def test_list_multi_tenant(_):
 
 
 class BaseTestTenants(TestCase):
-
     def count_tables_rows(self):
         tables_counts = {}
         with self.db.queries() as queries:
@@ -109,6 +109,7 @@ class BaseTestTenants(TestCase):
         }
         return diff
 
+
 class BaseTestDeleteByEvent(BaseTestTenants):
     def setUp(self):
         self.db = db
@@ -124,7 +125,6 @@ class BaseTestDeleteByEvent(BaseTestTenants):
             'func_key_dest_custom',
         ]
         self.before_tables_rows_counts = self.count_tables_rows()
-
 
     @fixtures.user(wazo_tenant=DELETED_TENANT)
     @fixtures.group(wazo_tenant=DELETED_TENANT)
@@ -217,6 +217,7 @@ class BaseTestDeleteByEvent(BaseTestTenants):
 
             until.assert_(resources_deleted, tries=5, interval=5)
 
+
 class BaseTestDeleteBySyncDb(BaseTestTenants):
     def setUp(self):
         self.db = db
@@ -247,7 +248,6 @@ class BaseTestDeleteBySyncDb(BaseTestTenants):
         # add the tenant DELETED_TENANT in wazo-auth for the authorization,
         # to be able to create the tenant in wazo-confd
         BaseIntegrationTest.mock_auth.set_tenants(*ALL_TENANTS)
-
 
     @fixtures.user(wazo_tenant=DELETED_TENANT)
     @fixtures.group(wazo_tenant=DELETED_TENANT)
@@ -338,4 +338,5 @@ class BaseTestDeleteBySyncDb(BaseTestTenants):
                     assert (
                         len(diff) == 0
                     ), "Some tables are not properly cleaned after tenant deletion"
+
                 until.assert_(resources_deleted, tries=5, interval=5)

--- a/integration_tests/suite/base/test_tenants.py
+++ b/integration_tests/suite/base/test_tenants.py
@@ -82,10 +82,7 @@ class BaseTestTenants(TestCase):
         tables_counts = {}
         with self.db.queries() as queries:
             query = text(
-                """SELECT * 
-                FROM pg_catalog.pg_tables 
-                WHERE schemaname != 'pg_catalog' AND 
-                schemaname != 'information_schema';"""
+                "SELECT * FROM pg_catalog.pg_tables WHERE schemaname != 'pg_catalog' AND schemaname != 'information_schema';"
             )
             result = queries.connection.execute(query)
             for row in result:

--- a/integration_tests/suite/base/test_tenants.py
+++ b/integration_tests/suite/base/test_tenants.py
@@ -82,12 +82,10 @@ class BaseTestTenants(TestCase):
         tables_counts = {}
         with self.db.queries() as queries:
             query = text(
-                """
-                SELECT * 
-                FROM pg_catalog.pg_tables
-                WHERE schemaname != 'pg_catalog' AND
-                      schemaname != 'information_schema';
-                """
+                """SELECT * 
+                FROM pg_catalog.pg_tables 
+                WHERE schemaname != 'pg_catalog' AND 
+                schemaname != 'information_schema';"""
             )
             result = queries.connection.execute(query)
             for row in result:

--- a/integration_tests/suite/helpers/base.py
+++ b/integration_tests/suite/helpers/base.py
@@ -82,21 +82,15 @@ class IntegrationTest(AssetLaunchingTestCase):
 
     @classmethod
     def _create_auth_tenant(cls):
-        cls.mock_auth.set_tenants(
-            *DEFAULT_TENANTS
-        )
+        cls.mock_auth.set_tenants(*DEFAULT_TENANTS)
 
     @classmethod
     def _delete_auth_tenant(cls):
-        cls.mock_auth.set_tenants(
-            *DEFAULT_TENANTS
-        )
+        cls.mock_auth.set_tenants(*DEFAULT_TENANTS)
 
     @classmethod
     def _reset_auth_tenants(cls):
-        cls.mock_auth.set_tenants(
-            *ALL_TENANTS
-        )
+        cls.mock_auth.set_tenants(*ALL_TENANTS)
 
     @classmethod
     @contextmanager

--- a/integration_tests/suite/helpers/base.py
+++ b/integration_tests/suite/helpers/base.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import os
@@ -32,9 +32,9 @@ from .config import (
     TOKEN_SUB_TENANT,
     MAIN_TENANT,
     SUB_TENANT,
-    DELETED_TENANT,
-    CREATED_TENANT,
     USER_UUID,
+    DEFAULT_TENANTS,
+    ALL_TENANTS,
 )
 
 
@@ -83,58 +83,19 @@ class IntegrationTest(AssetLaunchingTestCase):
     @classmethod
     def _create_auth_tenant(cls):
         cls.mock_auth.set_tenants(
-            {
-                'uuid': MAIN_TENANT,
-                'name': 'name1',
-                'slug': 'slug1',
-                'parent_uuid': MAIN_TENANT,
-            },
-            {
-                'uuid': CREATED_TENANT,
-                'name': 'name4',
-                'slug': 'slug2',
-                'parent_uuid': MAIN_TENANT,
-            },
+            *DEFAULT_TENANTS
         )
 
     @classmethod
     def _delete_auth_tenant(cls):
         cls.mock_auth.set_tenants(
-            {
-                'uuid': MAIN_TENANT,
-                'name': 'name1',
-                'slug': 'slug1',
-                'parent_uuid': MAIN_TENANT,
-            },
+            *DEFAULT_TENANTS
         )
 
     @classmethod
     def _reset_auth_tenants(cls):
         cls.mock_auth.set_tenants(
-            {
-                'uuid': MAIN_TENANT,
-                'name': 'name1',
-                'slug': 'slug1',
-                'parent_uuid': MAIN_TENANT,
-            },
-            {
-                'uuid': SUB_TENANT,
-                'name': 'name2',
-                'slug': 'slug2',
-                'parent_uuid': MAIN_TENANT,
-            },
-            {
-                'uuid': DELETED_TENANT,
-                'name': 'name3',
-                'slug': 'slug3',
-                'parent_uuid': MAIN_TENANT,
-            },
-            {
-                'uuid': CREATED_TENANT,
-                'name': 'name4',
-                'slug': 'slug4',
-                'parent_uuid': MAIN_TENANT,
-            },
+            *ALL_TENANTS
         )
 
     @classmethod

--- a/integration_tests/suite/helpers/config.py
+++ b/integration_tests/suite/helpers/config.py
@@ -15,31 +15,34 @@ TOKEN_SUB_TENANT = '00000000-0000-4000-9000-000000000222'
 DELETED_TENANT = '66666666-6666-4666-8666-666666666666'
 CREATED_TENANT = '77777777-7777-4777-8777-777777777777'
 USER_UUID = 'd1534a6c-3e35-44db-b4df-0e2957cdea77'
-DEFAULT_TENANTS =[ {
-                'uuid': MAIN_TENANT,
-                'name': 'name1',
-                'slug': 'slug1',
-                'parent_uuid': MAIN_TENANT,
-            },
-            {
-                'uuid': SUB_TENANT,
-                'name': 'name2',
-                'slug': 'slug2',
-                'parent_uuid': MAIN_TENANT,
-            },
-            {
-                'uuid': CREATED_TENANT,
-                'name': 'name4',
-                'slug': 'slug4',
-                'parent_uuid': MAIN_TENANT,
-            },
+DEFAULT_TENANTS = [
+    {
+        'uuid': MAIN_TENANT,
+        'name': 'name1',
+        'slug': 'slug1',
+        'parent_uuid': MAIN_TENANT,
+    },
+    {
+        'uuid': SUB_TENANT,
+        'name': 'name2',
+        'slug': 'slug2',
+        'parent_uuid': MAIN_TENANT,
+    },
+    {
+        'uuid': CREATED_TENANT,
+        'name': 'name4',
+        'slug': 'slug4',
+        'parent_uuid': MAIN_TENANT,
+    },
 ]
-ALL_TENANTS = DEFAULT_TENANTS + [{
-                'uuid': DELETED_TENANT,
-                'name': 'name3',
-                'slug': 'slug3',
-                'parent_uuid': MAIN_TENANT,
-            }]
+ALL_TENANTS = DEFAULT_TENANTS + [
+    {
+        'uuid': DELETED_TENANT,
+        'name': 'name3',
+        'slug': 'slug3',
+        'parent_uuid': MAIN_TENANT,
+    }
+]
 
 
 def gen_line_exten():

--- a/integration_tests/suite/helpers/config.py
+++ b/integration_tests/suite/helpers/config.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2021 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import random
@@ -15,6 +15,31 @@ TOKEN_SUB_TENANT = '00000000-0000-4000-9000-000000000222'
 DELETED_TENANT = '66666666-6666-4666-8666-666666666666'
 CREATED_TENANT = '77777777-7777-4777-8777-777777777777'
 USER_UUID = 'd1534a6c-3e35-44db-b4df-0e2957cdea77'
+DEFAULT_TENANTS =[ {
+                'uuid': MAIN_TENANT,
+                'name': 'name1',
+                'slug': 'slug1',
+                'parent_uuid': MAIN_TENANT,
+            },
+            {
+                'uuid': SUB_TENANT,
+                'name': 'name2',
+                'slug': 'slug2',
+                'parent_uuid': MAIN_TENANT,
+            },
+            {
+                'uuid': CREATED_TENANT,
+                'name': 'name4',
+                'slug': 'slug4',
+                'parent_uuid': MAIN_TENANT,
+            },
+]
+ALL_TENANTS = DEFAULT_TENANTS + [{
+                'uuid': DELETED_TENANT,
+                'name': 'name3',
+                'slug': 'slug3',
+                'parent_uuid': MAIN_TENANT,
+            }]
 
 
 def gen_line_exten():

--- a/wazo_confd/plugins/event_handlers/plugin.py
+++ b/wazo_confd/plugins/event_handlers/plugin.py
@@ -1,29 +1,23 @@
-# Copyright 2020-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2020-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
 
-from wazo_provd_client import Client as ProvdClient
-from wazo_provd_client.exceptions import ProvdError
 from xivo_dao import tenant_dao
 from xivo_dao.helpers.db_utils import session_scope
 from xivo_dao.resources.endpoint_sip import dao as sip_dao
 from xivo_dao.resources.pjsip_transport import dao as transport_dao
 
-from wazo_confd.plugins.device.model import Device
-from wazo_confd.plugins.device.notifier import DeviceNotifier
-
 from .service import DefaultSIPTemplateService
+from ...sync_db import remove_tenant
 
 logger = logging.getLogger(__name__)
 
 
 class TenantEventHandler:
-    def __init__(self, tenant_dao, service, provd_client, device_notifier):
+    def __init__(self, tenant_dao, service):
         self.tenant_dao = tenant_dao
         self.service = service
-        self.provd = provd_client
-        self.device_notifier = device_notifier
 
     def subscribe(self, bus_consumer):
         bus_consumer.subscribe('auth_tenant_added', self._auth_tenant_added)
@@ -38,47 +32,16 @@ class TenantEventHandler:
             self.service.copy_slug(tenant, slug)
 
     def _auth_tenant_deleted(self, event):
-        tenant_uuid = event['uuid']
-        logger.debug('Deleting devices for tenant "%s"', tenant_uuid)
-        devices = self.provd.devices.list(tenant_uuid=tenant_uuid, recurse=True)[
-            'devices'
-        ]
-        for device in devices:
-            self._delete_device(device)
-            self._delete_config(device['config'])
-
-    def _delete_device(self, device):
-        device_model = Device(device)
-        self.provd.devices.delete(device_model.id)
-        self.device_notifier.deleted(device_model)
-
-    def _delete_config(self, config):
-        try:
-            self.provd.configs.delete(config)
-        except ProvdError as e:
-            if e.status_code != 404:
-                raise
-        except Exception:
-            pass  # device has no config
+        remove_tenant(event['uuid'])
 
 
 class Plugin:
     def load(self, dependencies):
-        config = dependencies['config']
         bus_consumer = dependencies['bus_consumer']
-        bus_publisher = dependencies['bus_publisher']
-        token_changed_subscribe = dependencies['token_changed_subscribe']
-
-        provd_client = ProvdClient(**config['provd'])
-        token_changed_subscribe(provd_client.set_token)
-
-        device_notifier = DeviceNotifier(bus_publisher, immediate=True)
 
         service = DefaultSIPTemplateService(sip_dao, transport_dao)
         tenant_event_handler = TenantEventHandler(
             tenant_dao,
             service,
-            provd_client,
-            device_notifier,
         )
         tenant_event_handler.subscribe(bus_consumer)

--- a/wazo_confd/sync_db.py
+++ b/wazo_confd/sync_db.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2020-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import argparse
@@ -10,9 +10,9 @@ from xivo.config_helper import read_config_file_hierarchy
 from xivo_dao import init_db_from_config
 from xivo_dao.alchemy.tenant import Tenant
 from xivo_dao.helpers.db_utils import session_scope
-from xivo_dao.resources.user import dao as user_dao
 from xivo_dao.resources.pjsip_transport import dao as transport_dao
 from xivo_dao.resources.endpoint_sip import dao as sip_dao
+from xivo_dao.resources.tenant import dao as tenant_resources_dao
 from xivo_dao import tenant_dao
 from wazo_auth_client import Client as AuthClient
 
@@ -84,7 +84,6 @@ def main():
 
         removed_tenants = confd_tenants - auth_tenants
         for tenant_uuid in removed_tenants:
-            logger.info('Removing tenant: %s... (SKIP)', tenant_uuid)
             remove_tenant(tenant_uuid)
 
     with session_scope() as session:
@@ -102,10 +101,10 @@ def main():
 
 
 def remove_tenant(tenant_uuid):
-    for user in user_dao.find_all_by(tenant_uuid=tenant_uuid):
-        logger.debug('Removing user: %s', user.uuid)
-        user_dao.delete(user)
+    logger.debug('Removing tenant : %s', tenant_uuid)
+    with session_scope():
+        tenant = tenant_resources_dao.get(tenant_uuid)
+        tenant_resources_dao.delete(tenant)
 
-    # FIXME(fblackburn):
-    # * Add all other resources related to tenant_uuid
-    # * Reset device to autoprov
+if __name__ == '__main__':
+    main()

--- a/wazo_confd/sync_db.py
+++ b/wazo_confd/sync_db.py
@@ -106,5 +106,6 @@ def remove_tenant(tenant_uuid):
         tenant = tenant_resources_dao.get(tenant_uuid)
         tenant_resources_dao.delete(tenant)
 
+
 if __name__ == '__main__':
     main()

--- a/wazo_confd/sync_db.py
+++ b/wazo_confd/sync_db.py
@@ -81,6 +81,7 @@ def main():
             if not tenant.slug:
                 confd_tenant_without_slugs.add(tenant.uuid)
         logger.debug('wazo-confd tenants: %s', confd_tenants)
+        logger.debug('wazo-auth tenants: %s', auth_tenants)
 
         removed_tenants = confd_tenants - auth_tenants
         for tenant_uuid in removed_tenants:
@@ -101,7 +102,7 @@ def main():
 
 
 def remove_tenant(tenant_uuid):
-    logger.debug('Removing tenant : %s', tenant_uuid)
+    logger.debug('Removing tenant: %s', tenant_uuid)
     with session_scope():
         tenant = tenant_resources_dao.get(tenant_uuid)
         tenant_resources_dao.delete(tenant)


### PR DESCRIPTION
Deletion is triggered by the auth_tenant_deleted event and by cron (synd_db.py)

Depends-On: https://github.com/wazo-platform/xivo-dao/pull/225
Depends-On: https://github.com/wazo-platform/xivo-dao/pull/226
Depends-On: https://github.com/wazo-platform/xivo-dao/pull/227