### PR TITLE
pagings: fix flaky test

### DIFF
--- a/integration_tests/suite/base/test_pagings.py
+++ b/integration_tests/suite/base/test_pagings.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import (
@@ -34,7 +34,7 @@ def test_post_errors():
         yield check
 
 
-@fixtures.paging()
+@fixtures.paging(number='724464')
 def test_put_errors(paging):
     url = confd.pagings(paging['id']).put
     for check in error_checks(url):


### PR DESCRIPTION
Why:

* the test creates 2 different paging, one with a random number, another
  with number 123
* when the random number is 123, the test fails