### PR TITLE
Remove Flask app context from syncdb

### DIFF
--- a/wazo_confd/plugins/event_handlers/plugin.py
+++ b/wazo_confd/plugins/event_handlers/plugin.py
@@ -8,7 +8,10 @@ from xivo_dao.helpers.db_utils import session_scope
 from xivo_dao.resources.endpoint_sip import dao as sip_dao
 from xivo_dao.resources.pjsip_transport import dao as transport_dao
 
+from wazo_confd import sysconfd
+
 from .service import DefaultSIPTemplateService
+from ...http_server import app
 from ...sync_db import remove_tenant
 
 logger = logging.getLogger(__name__)
@@ -32,7 +35,8 @@ class TenantEventHandler:
             self.service.copy_slug(tenant, slug)
 
     def _auth_tenant_deleted(self, event):
-        remove_tenant(event['uuid'])
+        with app.app_context():
+            remove_tenant(event['uuid'], sysconfd)
 
 
 class Plugin:

--- a/wazo_confd/plugins/event_handlers/plugin.py
+++ b/wazo_confd/plugins/event_handlers/plugin.py
@@ -16,10 +16,10 @@ logger = logging.getLogger(__name__)
 
 
 class TenantEventHandler:
-    def __init__(self, tenant_dao, service, config):
+    def __init__(self, tenant_dao, service, sysconfd):
         self.tenant_dao = tenant_dao
         self.service = service
-        self.sysconfd = SysconfdPublisher.from_config(config)
+        self.sysconfd = sysconfd
 
     def subscribe(self, bus_consumer):
         bus_consumer.subscribe('auth_tenant_added', self._auth_tenant_added)
@@ -43,9 +43,10 @@ class Plugin:
         config = dependencies['config']
 
         service = DefaultSIPTemplateService(sip_dao, transport_dao)
+        sysconfd = SysconfdPublisher.from_config(config)
         tenant_event_handler = TenantEventHandler(
             tenant_dao,
             service,
-            config,
+            sysconfd,
         )
         tenant_event_handler.subscribe(bus_consumer)


### PR DESCRIPTION
When the tenant deletion is called from the CLI (syncdb) the Flask app is not running. So the sysconfd client must be initialized without using a Flask app.
