### PR TITLE
user: select query strategy based on pagination

### DIFF
--- a/wazo_confd/config.py
+++ b/wazo_confd/config.py
@@ -179,6 +179,7 @@ DEFAULT_CONFIG = {
     'wizard': {'service_id': None, 'service_key': None},
     'pjsip_config_doc_filename': '/usr/share/doc/asterisk-doc/json/pjsip.json.gz',
     'sync_db': {'quiet': False},
+    'paginated_user_strategy_threshold': 101,
 }
 
 

--- a/wazo_confd/plugins/meeting/plugin.py
+++ b/wazo_confd/plugins/meeting/plugin.py
@@ -1,4 +1,4 @@
-# Copyright 2021-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2021-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from .resource import (
@@ -36,6 +36,7 @@ class Plugin:
         bus_consumer = dependencies['bus_consumer']
         bus_publisher = dependencies['bus_publisher']
         pjsip_doc = dependencies['pjsip_doc']
+        config = dependencies['config']
 
         ingress_http_service = build_ingress_http_service()
         extension_features_service = build_extension_features_service()
@@ -58,7 +59,12 @@ class Plugin:
         endpoint_sip_template_service = build_endpoint_sip_template_service(
             None, pjsip_doc
         )
-        user_service = build_user_service(provd_client=None)
+        user_service = build_user_service(
+            provd_client=None,
+            paginated_user_strategy_threshold=config[
+                'paginated_user_strategy_threshold'
+            ],
+        )
         tenant_service = build_tenant_service()
         args = [service, user_service, ingress_http_service, extension_features_service]
 

--- a/wazo_confd/plugins/user/plugin.py
+++ b/wazo_confd/plugins/user/plugin.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from wazo_provd_client import Client as ProvdClient
@@ -29,7 +29,9 @@ class Plugin:
         provd_client = ProvdClient(**config['provd'])
         token_changed_subscribe(provd_client.set_token)
 
-        service = build_service(provd_client)
+        service = build_service(
+            provd_client, config['paginated_user_strategy_threshold']
+        )
         service_callservice = build_service_callservice()
         service_forward = build_service_forward()
         wazo_user_service = build_wazo_user_service()

--- a/wazo_confd/plugins/user/service.py
+++ b/wazo_confd/plugins/user/service.py
@@ -19,10 +19,19 @@ class UserBaseService(CRUDService):
 
 
 class UserService(UserBaseService):
-    def __init__(self, dao, validator, notifier, device_updater, func_key_dao):
+    def __init__(
+        self,
+        dao,
+        validator,
+        notifier,
+        device_updater,
+        func_key_dao,
+        paginated_user_strategy_threshold,
+    ):
         super().__init__(dao, validator, notifier)
         self.device_updater = device_updater
         self.func_key_dao = func_key_dao
+        self._paginated_user_strategy_threshold = paginated_user_strategy_threshold
 
     def edit(self, user, updated_fields=None):
         super().edit(user, updated_fields)
@@ -38,7 +47,7 @@ class UserService(UserBaseService):
 
     def search_collated(self, parameters, tenant_uuids=None):
         limit = parameters.get('limit')
-        if limit is None or limit > 101:
+        if limit is None or limit > self._paginated_user_strategy_threshold:
             selected_strategy = strategy.user_unpaginated_strategy
         else:
             selected_strategy = strategy.no_strategy
@@ -47,10 +56,15 @@ class UserService(UserBaseService):
             return self.dao.search_collated(tenant_uuids=tenant_uuids, **parameters)
 
 
-def build_service(provd_client):
+def build_service(provd_client, paginated_user_strategy_threshold):
     updater = build_device_updater(provd_client)
     return UserService(
-        user_dao, build_validator(), build_notifier(), updater, func_key_dao
+        user_dao,
+        build_validator(),
+        build_notifier(),
+        updater,
+        func_key_dao,
+        paginated_user_strategy_threshold,
     )
 
 

--- a/wazo_confd/plugins/user_import/plugin.py
+++ b/wazo_confd/plugins/user_import/plugin.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2021 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from collections import OrderedDict
@@ -96,7 +96,12 @@ class Plugin:
         provd_client = ProvdClient(**config['provd'])
         token_changed_subscribe(provd_client.set_token)
 
-        user_service = build_user_service(provd_client)
+        user_service = build_user_service(
+            provd_client,
+            paginated_user_strategy_threshold=config[
+                'paginated_user_strategy_threshold'
+            ],
+        )
         wazo_user_service = build_wazo_user_service()
         user_voicemail_service = build_uv_service()
         voicemail_service = build_voicemail_service()


### PR DESCRIPTION
If using large pages (101) or unpaginated queries the existing loading strategy is used. Paginated queries will use the default sqlalchemy behavior, which is lazyloading.

For a small enough number of resource (101 here) this is enough to make the route significantly faster.

Depends-On: https://github.com/wazo-platform/xivo-dao/pull/249