### PR TITLE
Pull request for WAZO-3502-simplify-provd-config

### DIFF
--- a/wazo_confd/plugins/provisioning_networking/api.yml
+++ b/wazo_confd/plugins/provisioning_networking/api.yml
@@ -33,7 +33,7 @@ definitions:
     properties:
       provision_host:
         type: string
-        description: The hostname or IP address used for HTTP and TFTP provisioning requests.
+        description: The hostname or IP address used for HTTP and TFTP provisioning requests for DHCP integration.
       provision_http_port:
         type: integer
         description: The port used by the HTTP provisioning server.

--- a/wazo_confd/plugins/registrar/api.yml
+++ b/wazo_confd/plugins/registrar/api.yml
@@ -124,7 +124,7 @@ definitions:
         description: Backup registrar port
       proxy_main_host:
         type: string
-        description: Proxy host
+        description: 'Proxy host. Using IPv4 is recommended to have a better integration with some provisioning plugins. (ex: Yealink DND integration)'
       proxy_main_port:
         type: integer
         description: Proxy port


### PR DESCRIPTION
## registrar: add notice about proxy_main_host and IPv4

why: this key is used for action_uri_limit_ip and must be IPv4.
Otherwise a popup can show up on the device

## prov network: improte description for provision_host

why: now provision_host is only used for DHCP integration