### PR TITLE
Pull request for WAZO-3547-remove-nosetests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,3 @@
 .tox
 coverage.xml
 unit-tests.xml
-nosetests.xml

--- a/integration_tests/Makefile
+++ b/integration_tests/Makefile
@@ -26,9 +26,7 @@ build-provd:
 	docker build -t wazoplatform/wazo-provd $(PROVD_DIR)
 
 test:
-	# Explicit match to avoid to include AssetLaunchingTestCase helper methods
-	# This constraint must be removed when tests will be migrated to pytest
-	nosetests --match '^[Tt]est' -x
+	pytest -x
 
 egg-info:
 	cd .. && python setup.py egg_info

--- a/integration_tests/suite/base/__init__.py
+++ b/integration_tests/suite/base/__init__.py
@@ -23,11 +23,11 @@ class BaseIntegrationTest(IntegrationTest):
         cls.setup_helpers()
 
 
-def setUpModule():
+def setup_module(module):
     BaseIntegrationTest.setUpClass()
 
 
-def tearDownModule():
+def teardown_module(module):
     BaseIntegrationTest.tearDownClass()
 
 

--- a/integration_tests/suite/base/test_access_features.py
+++ b/integration_tests/suite/base/test_access_features.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import assert_that, empty, has_entries, has_entry, has_item, is_not, not_
@@ -14,33 +14,31 @@ from ..helpers.config import TOKEN_SUB_TENANT
 
 def test_get_errors():
     fake_access_feature = confd.access_features(999999).get
-    yield s.check_resource_not_found, fake_access_feature, 'AccessFeatures'
+    s.check_resource_not_found(fake_access_feature, 'AccessFeatures')
 
 
 def test_delete_errors():
     fake_access_feature = confd.access_features(999999).delete
-    yield s.check_resource_not_found, fake_access_feature, 'AccessFeatures'
+    s.check_resource_not_found(fake_access_feature, 'AccessFeatures')
 
 
 def test_post_errors():
     url = confd.access_features.post
-    for check in error_checks(url):
-        yield check
+    error_checks(url)
 
 
 @fixtures.access_feature()
 def test_put_errors(access_feature):
     url = confd.access_features(access_feature['id']).put
-    for check in error_checks(url):
-        yield check
+    error_checks(url)
 
 
 def error_checks(url):
-    yield s.check_bogus_field_returns_error, url, 'host', None
-    yield s.check_bogus_field_returns_error, url, 'enabled', 'invalid'
-    yield s.check_bogus_field_returns_error, url, 'enabled', None
-    yield s.check_bogus_field_returns_error, url, 'feature', 'invalid'
-    yield s.check_bogus_field_returns_error, url, 'feature', None
+    s.check_bogus_field_returns_error(url, 'host', None)
+    s.check_bogus_field_returns_error(url, 'enabled', 'invalid')
+    s.check_bogus_field_returns_error(url, 'enabled', None)
+    s.check_bogus_field_returns_error(url, 'feature', 'invalid')
+    s.check_bogus_field_returns_error(url, 'feature', None)
 
 
 @fixtures.access_feature(host='1.2.3.0/24', enabled=False)
@@ -50,7 +48,7 @@ def test_search(access_feature, hidden):
     searches = {'host': '1.2.3', 'enabled': False}
 
     for field, term in searches.items():
-        yield check_search, url, access_feature, hidden, field, term
+        check_search(url, access_feature, hidden, field, term)
 
 
 def check_search(url, context, hidden, field, term):
@@ -67,9 +65,9 @@ def check_search(url, context, hidden, field, term):
 @fixtures.access_feature(host='1.2.4.0/24')
 def test_sorting_offset_limit(access_feature1, access_feature2):
     url = confd.access_features.get
-    yield s.check_sorting, url, access_feature1, access_feature2, 'host', '1.2.'
-    yield s.check_offset, url, access_feature1, access_feature2, 'host', '1.2.'
-    yield s.check_limit, url, access_feature1, access_feature2, 'host', '1.2.'
+    s.check_sorting(url, access_feature1, access_feature2, 'host', '1.2.')
+    s.check_offset(url, access_feature1, access_feature2, 'host', '1.2.')
+    s.check_limit(url, access_feature1, access_feature2, 'host', '1.2.')
 
 
 @fixtures.access_feature(host='1.2.3.0/24')
@@ -168,13 +166,22 @@ def test_restrict_only_master_tenant(access):
 def test_bus_events(access_feature):
     expected_headers = {}
 
-    yield s.check_event, 'access_feature_created', expected_headers, confd.access_features.post, {
-        'host': '9.2.4.0/24',
-        'feature': 'phonebook',
-    }
-    yield s.check_event, 'access_feature_edited', expected_headers, confd.access_features(
-        access_feature['id']
-    ).put
-    yield s.check_event, 'access_feature_deleted', expected_headers, confd.access_features(
-        access_feature['id']
-    ).delete
+    s.check_event(
+        'access_feature_created',
+        expected_headers,
+        confd.access_features.post,
+        {
+            'host': '9.2.4.0/24',
+            'feature': 'phonebook',
+        },
+    )
+    s.check_event(
+        'access_feature_edited',
+        expected_headers,
+        confd.access_features(access_feature['id']).put,
+    )
+    s.check_event(
+        'access_feature_deleted',
+        expected_headers,
+        confd.access_features(access_feature['id']).delete,
+    )

--- a/integration_tests/suite/base/test_agent_skill.py
+++ b/integration_tests/suite/base/test_agent_skill.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import assert_that, contains_inanyorder, has_entries
@@ -16,20 +16,19 @@ def test_associate_errors(agent, skill):
     fake_agent = confd.agents(FAKE_ID).skills(skill['id']).put
     fake_skill = confd.agents(agent['id']).skills(FAKE_ID).put
 
-    yield s.check_resource_not_found, fake_agent, 'Agent'
-    yield s.check_resource_not_found, fake_skill, 'Skill'
+    s.check_resource_not_found(fake_agent, 'Agent')
+    s.check_resource_not_found(fake_skill, 'Skill')
 
     url = confd.agents(agent['id']).skills(skill['id']).put
-    for check in error_checks(url):
-        yield check
+    error_checks(url)
 
 
 def error_checks(url):
-    yield s.check_bogus_field_returns_error, url, 'skill_weight', -1
-    yield s.check_bogus_field_returns_error, url, 'skill_weight', None
-    yield s.check_bogus_field_returns_error, url, 'skill_weight', 'string'
-    yield s.check_bogus_field_returns_error, url, 'skill_weight', []
-    yield s.check_bogus_field_returns_error, url, 'skill_weight', {}
+    s.check_bogus_field_returns_error(url, 'skill_weight', -1)
+    s.check_bogus_field_returns_error(url, 'skill_weight', None)
+    s.check_bogus_field_returns_error(url, 'skill_weight', 'string')
+    s.check_bogus_field_returns_error(url, 'skill_weight', [])
+    s.check_bogus_field_returns_error(url, 'skill_weight', {})
 
 
 @fixtures.agent()
@@ -38,8 +37,8 @@ def test_dissociate_errors(agent, skill):
     fake_agent = confd.agents(FAKE_ID).skills(skill['id']).delete
     fake_skill = confd.agents(agent['id']).skills(FAKE_ID).delete
 
-    yield s.check_resource_not_found, fake_agent, 'Agent'
-    yield s.check_resource_not_found, fake_skill, 'Skill'
+    s.check_resource_not_found(fake_agent, 'Agent')
+    s.check_resource_not_found(fake_skill, 'Skill')
 
 
 @fixtures.agent()
@@ -237,5 +236,5 @@ def test_bus_events(agent, skill):
     url = confd.agents(agent['id']).skills(skill['id'])
     expected_headers = {'tenant_uuid': MAIN_TENANT}
 
-    yield s.check_event, 'agent_skill_associated', expected_headers, url.put
-    yield s.check_event, 'agent_skill_dissociated', expected_headers, url.delete
+    s.check_event('agent_skill_associated', expected_headers, url.put)
+    s.check_event('agent_skill_dissociated', expected_headers, url.delete)

--- a/integration_tests/suite/base/test_agents.py
+++ b/integration_tests/suite/base/test_agents.py
@@ -223,6 +223,9 @@ def test_create_multi_tenant():
 
     assert_that(response_main.item, has_entries(tenant_uuid=MAIN_TENANT))
 
+    confd.agents(response_sub.item['id']).delete().assert_deleted()
+    confd.agents(response_main.item['id']).delete().assert_deleted()
+
 
 @fixtures.agent()
 def test_edit_minimal_parameters(agent):

--- a/integration_tests/suite/base/test_agents.py
+++ b/integration_tests/suite/base/test_agents.py
@@ -21,75 +21,70 @@ from ..helpers.config import MAIN_TENANT, SUB_TENANT, SUB_TENANT2
 
 def test_get_errors():
     fake_agent = confd.agents(999999).get
-    yield s.check_resource_not_found, fake_agent, 'Agent'
+    s.check_resource_not_found(fake_agent, 'Agent')
 
 
 def test_delete_errors():
     fake_agent = confd.agents(999999).delete
-    yield s.check_resource_not_found, fake_agent, 'Agent'
+    s.check_resource_not_found(fake_agent, 'Agent')
 
 
 def test_post_errors():
     url = confd.agents.post
-    for check in error_checks(url):
-        yield check
+    error_checks(url)
 
-    yield s.check_bogus_field_returns_error, url, 'number', 123
-    yield s.check_bogus_field_returns_error, url, 'number', True
-    yield s.check_bogus_field_returns_error, url, 'number', 'invalid'
-    yield s.check_bogus_field_returns_error, url, 'number', s.random_string(0)
-    yield s.check_bogus_field_returns_error, url, 'number', s.random_string(41)
-    yield s.check_bogus_field_returns_error, url, 'number', []
-    yield s.check_bogus_field_returns_error, url, 'number', {}
+    s.check_bogus_field_returns_error(url, 'number', 123)
+    s.check_bogus_field_returns_error(url, 'number', True)
+    s.check_bogus_field_returns_error(url, 'number', 'invalid')
+    s.check_bogus_field_returns_error(url, 'number', s.random_string(0))
+    s.check_bogus_field_returns_error(url, 'number', s.random_string(41))
+    s.check_bogus_field_returns_error(url, 'number', [])
+    s.check_bogus_field_returns_error(url, 'number', {})
 
-    for check in unique_error_checks(url):
-        yield check
+    unique_error_checks(url)
 
 
 @fixtures.agent()
 def test_put_errors(agent):
     url = confd.agents(agent['id']).put
-    for check in error_checks(url):
-        yield check
+    error_checks(url)
 
 
 def error_checks(url):
-    yield s.check_bogus_field_returns_error, url, 'firstname', 123
-    yield s.check_bogus_field_returns_error, url, 'firstname', True
-    yield s.check_bogus_field_returns_error, url, 'firstname', s.random_string(129)
-    yield s.check_bogus_field_returns_error, url, 'firstname', []
-    yield s.check_bogus_field_returns_error, url, 'firstname', {}
-    yield s.check_bogus_field_returns_error, url, 'lastname', 123
-    yield s.check_bogus_field_returns_error, url, 'lastname', True
-    yield s.check_bogus_field_returns_error, url, 'lastname', s.random_string(129)
-    yield s.check_bogus_field_returns_error, url, 'lastname', []
-    yield s.check_bogus_field_returns_error, url, 'lastname', {}
-    yield s.check_bogus_field_returns_error, url, 'password', 123
-    yield s.check_bogus_field_returns_error, url, 'password', True
-    yield s.check_bogus_field_returns_error, url, 'password', s.random_string(129)
-    yield s.check_bogus_field_returns_error, url, 'password', []
-    yield s.check_bogus_field_returns_error, url, 'password', {}
-    yield s.check_bogus_field_returns_error, url, 'language', 123
-    yield s.check_bogus_field_returns_error, url, 'language', True
-    yield s.check_bogus_field_returns_error, url, 'language', s.random_string(21)
-    yield s.check_bogus_field_returns_error, url, 'language', []
-    yield s.check_bogus_field_returns_error, url, 'language', {}
-    yield s.check_bogus_field_returns_error, url, 'description', 123
-    yield s.check_bogus_field_returns_error, url, 'description', True
-    yield s.check_bogus_field_returns_error, url, 'description', []
-    yield s.check_bogus_field_returns_error, url, 'description', {}
-    yield s.check_bogus_field_returns_error, url, 'preprocess_subroutine', 123
-    yield s.check_bogus_field_returns_error, url, 'preprocess_subroutine', True
-    yield s.check_bogus_field_returns_error, url, 'preprocess_subroutine', s.random_string(
-        80
-    )
-    yield s.check_bogus_field_returns_error, url, 'preprocess_subroutine', []
-    yield s.check_bogus_field_returns_error, url, 'preprocess_subroutine', {}
+    s.check_bogus_field_returns_error(url, 'firstname', 123)
+    s.check_bogus_field_returns_error(url, 'firstname', True)
+    s.check_bogus_field_returns_error(url, 'firstname', s.random_string(129))
+    s.check_bogus_field_returns_error(url, 'firstname', [])
+    s.check_bogus_field_returns_error(url, 'firstname', {})
+    s.check_bogus_field_returns_error(url, 'lastname', 123)
+    s.check_bogus_field_returns_error(url, 'lastname', True)
+    s.check_bogus_field_returns_error(url, 'lastname', s.random_string(129))
+    s.check_bogus_field_returns_error(url, 'lastname', [])
+    s.check_bogus_field_returns_error(url, 'lastname', {})
+    s.check_bogus_field_returns_error(url, 'password', 123)
+    s.check_bogus_field_returns_error(url, 'password', True)
+    s.check_bogus_field_returns_error(url, 'password', s.random_string(129))
+    s.check_bogus_field_returns_error(url, 'password', [])
+    s.check_bogus_field_returns_error(url, 'password', {})
+    s.check_bogus_field_returns_error(url, 'language', 123)
+    s.check_bogus_field_returns_error(url, 'language', True)
+    s.check_bogus_field_returns_error(url, 'language', s.random_string(21))
+    s.check_bogus_field_returns_error(url, 'language', [])
+    s.check_bogus_field_returns_error(url, 'language', {})
+    s.check_bogus_field_returns_error(url, 'description', 123)
+    s.check_bogus_field_returns_error(url, 'description', True)
+    s.check_bogus_field_returns_error(url, 'description', [])
+    s.check_bogus_field_returns_error(url, 'description', {})
+    s.check_bogus_field_returns_error(url, 'preprocess_subroutine', 123)
+    s.check_bogus_field_returns_error(url, 'preprocess_subroutine', True)
+    s.check_bogus_field_returns_error(url, 'preprocess_subroutine', s.random_string(80))
+    s.check_bogus_field_returns_error(url, 'preprocess_subroutine', [])
+    s.check_bogus_field_returns_error(url, 'preprocess_subroutine', {})
 
 
 @fixtures.agent(number='1234')
 def unique_error_checks(url, agent):
-    yield s.check_bogus_field_returns_error, url, 'number', agent['number']
+    s.check_bogus_field_returns_error(url, 'number', agent['number'])
 
 
 @fixtures.agent(firstname='hidden', lastname='hidden', preprocess_subroutine='hidden')
@@ -103,7 +98,7 @@ def test_search(hidden, agent):
     }
 
     for field, term in searches.items():
-        yield check_search, url, agent, hidden, field, term
+        check_search(url, agent, hidden, field, term)
 
 
 def check_search(url, agent, hidden, field, term):
@@ -133,13 +128,13 @@ def test_list_multi_tenant(main, sub):
 @fixtures.agent(firstname='sort2', lastname='sort2', preprocess_subroutine='sort2')
 def test_sorting_offset_limit(agent1, agent2):
     url = confd.agents.get
-    yield s.check_sorting, url, agent1, agent2, 'firstname', 'sort'
-    yield s.check_sorting, url, agent1, agent2, 'lastname', 'sort'
-    yield s.check_sorting, url, agent1, agent2, 'preprocess_subroutine', 'sort'
+    s.check_sorting(url, agent1, agent2, 'firstname', 'sort')
+    s.check_sorting(url, agent1, agent2, 'lastname', 'sort')
+    s.check_sorting(url, agent1, agent2, 'preprocess_subroutine', 'sort')
 
-    yield s.check_offset, url, agent1, agent2, 'firstname', 'sort'
+    s.check_offset(url, agent1, agent2, 'firstname', 'sort')
 
-    yield s.check_limit, url, agent1, agent2, 'firstname', 'sort'
+    s.check_limit(url, agent1, agent2, 'firstname', 'sort')
 
 
 @fixtures.agent()
@@ -292,13 +287,14 @@ def test_delete_multi_tenant(main, sub):
 def test_bus_events(agent):
     expected_headers = {'tenant_uuid': MAIN_TENANT}
 
-    yield s.check_event, 'agent_created', expected_headers, confd.agents.post, {
-        'number': '123456789123456789'
-    }
-    yield s.check_event, 'agent_edited', expected_headers, confd.agents(agent['id']).put
-    yield s.check_event, 'agent_deleted', expected_headers, confd.agents(
-        agent['id']
-    ).delete
+    s.check_event(
+        'agent_created',
+        expected_headers,
+        confd.agents.post,
+        {'number': '123456789123456789'},
+    )
+    s.check_event('agent_edited', expected_headers, confd.agents(agent['id']).put)
+    s.check_event('agent_deleted', expected_headers, confd.agents(agent['id']).delete)
 
 
 def test_create_multi_tenant_same_number():

--- a/integration_tests/suite/base/test_applications.py
+++ b/integration_tests/suite/base/test_applications.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import (
@@ -22,38 +22,36 @@ FAKE_UUID = '00000000-0000-0000-0000-000000000000'
 
 def test_get_errors():
     fake_application = confd.applications(FAKE_UUID).get
-    yield s.check_resource_not_found, fake_application, 'Application'
+    s.check_resource_not_found(fake_application, 'Application')
 
 
 def test_delete_errors():
     fake_application = confd.applications(FAKE_UUID).delete
-    yield s.check_resource_not_found, fake_application, 'Application'
+    s.check_resource_not_found(fake_application, 'Application')
 
 
 def test_post_errors():
     url = confd.applications.post
-    for check in error_checks(url):
-        yield check
+    error_checks(url)
 
 
 @fixtures.application()
 def test_put_errors(application):
     url = confd.applications(application['uuid']).put
-    for check in error_checks(url):
-        yield check
+    error_checks(url)
 
 
 def error_checks(url):
-    yield s.check_bogus_field_returns_error, url, 'name', True
-    yield s.check_bogus_field_returns_error, url, 'name', 1234
-    yield s.check_bogus_field_returns_error, url, 'name', s.random_string(129)
-    yield s.check_bogus_field_returns_error, url, 'name', []
-    yield s.check_bogus_field_returns_error, url, 'name', {}
-    yield s.check_bogus_field_returns_error, url, 'destination', True
-    yield s.check_bogus_field_returns_error, url, 'destination', 1234
-    yield s.check_bogus_field_returns_error, url, 'destination', 'invalid choice'
-    yield s.check_bogus_field_returns_error, url, 'destination', []
-    yield s.check_bogus_field_returns_error, url, 'destination', {}
+    s.check_bogus_field_returns_error(url, 'name', True)
+    s.check_bogus_field_returns_error(url, 'name', 1234)
+    s.check_bogus_field_returns_error(url, 'name', s.random_string(129))
+    s.check_bogus_field_returns_error(url, 'name', [])
+    s.check_bogus_field_returns_error(url, 'name', {})
+    s.check_bogus_field_returns_error(url, 'destination', True)
+    s.check_bogus_field_returns_error(url, 'destination', 1234)
+    s.check_bogus_field_returns_error(url, 'destination', 'invalid choice')
+    s.check_bogus_field_returns_error(url, 'destination', [])
+    s.check_bogus_field_returns_error(url, 'destination', {})
 
 
 @fixtures.application(name='search')
@@ -63,7 +61,7 @@ def test_search(application, hidden):
     searches = {'name': 'search'}
 
     for field, term in searches.items():
-        yield check_search, url, application, hidden, field, term
+        check_search(url, application, hidden, field, term)
 
 
 def check_search(url, application, hidden, field, term):
@@ -81,9 +79,9 @@ def check_search(url, application, hidden, field, term):
 def test_sort_offset_limit(application1, application2):
     url = confd.applications.get
     id_field = 'uuid'
-    yield s.check_sorting, url, application1, application2, 'name', 'sort', id_field
-    yield s.check_offset, url, application1, application2, 'name', 'sort', id_field
-    yield s.check_limit, url, application1, application2, 'name', 'sort', id_field
+    s.check_sorting(url, application1, application2, 'name', 'sort', id_field)
+    s.check_offset(url, application1, application2, 'name', 'sort', id_field)
+    s.check_limit(url, application1, application2, 'name', 'sort', id_field)
 
 
 @fixtures.application(wazo_tenant=MAIN_TENANT)
@@ -318,6 +316,6 @@ def test_bus_events(application):
     url = confd.applications(application['uuid'])
     expected_headers = {'tenant_uuid': MAIN_TENANT}
 
-    yield s.check_event, 'application_created', expected_headers, confd.applications.post
-    yield s.check_event, 'application_edited', expected_headers, url.put
-    yield s.check_event, 'application_deleted', expected_headers, url.delete
+    s.check_event('application_created', expected_headers, confd.applications.post)
+    s.check_event('application_edited', expected_headers, url.put)
+    s.check_event('application_deleted', expected_headers, url.delete)

--- a/integration_tests/suite/base/test_call_filter_fallback.py
+++ b/integration_tests/suite/base/test_call_filter_fallback.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import assert_that, equal_to, has_entries
@@ -13,28 +13,33 @@ FAKE_ID = 999999999
 
 def test_get_errors():
     fake_call_filter = confd.callfilters(FAKE_ID).fallbacks.get
-    yield s.check_resource_not_found, fake_call_filter, 'CallFilter'
+    s.check_resource_not_found(fake_call_filter, 'CallFilter')
 
 
 @fixtures.call_filter()
 @fixtures.user()
 def test_put_errors(call_filter, user):
     fake_call_filter = confd.callfilters(FAKE_ID).fallbacks.put
-    yield s.check_resource_not_found, fake_call_filter, 'CallFilter'
+    s.check_resource_not_found(fake_call_filter, 'CallFilter')
 
     url = confd.callfilters(call_filter['id']).fallbacks.put
-    for check in error_checks(url, user):
-        yield check
+    error_checks(url, user)
 
 
 def error_checks(url, user):
     for destination in invalid_destinations():
-        yield s.check_bogus_field_returns_error, url, 'noanswer_destination', destination
-    yield s.check_bogus_field_returns_error, url, 'noanswer_destination', {
-        'type': 'user',
-        'user_id': user['id'],
-        'moh_uuid': '00000000-0000-0000-0000-000000000000',
-    }, {}, 'MOH was not found'
+        s.check_bogus_field_returns_error(url, 'noanswer_destination', destination)
+    s.check_bogus_field_returns_error(
+        url,
+        'noanswer_destination',
+        {
+            'type': 'user',
+            'user_id': user['id'],
+            'moh_uuid': '00000000-0000-0000-0000-000000000000',
+        },
+        {},
+        'MOH was not found',
+    )
 
 
 @fixtures.call_filter()
@@ -112,9 +117,7 @@ def test_edit_multi_tenant(main, sub):
 @fixtures.moh()
 def test_valid_destinations(call_filter, *destinations):
     for destination in valid_destinations(*destinations):
-        yield _update_call_filter_fallbacks_with_destination, call_filter[
-            'id'
-        ], destination
+        _update_call_filter_fallbacks_with_destination(call_filter['id'], destination)
 
 
 def _update_call_filter_fallbacks_with_destination(call_filter_id, destination):
@@ -158,17 +161,17 @@ def test_nonexistent_destinations(call_filter, moh):
             'voicemail',
             'conference',
         ):
-            yield _update_user_fallbacks_with_nonexistent_destination, call_filter[
-                'id'
-            ], destination
+            _update_user_fallbacks_with_nonexistent_destination(
+                call_filter['id'], destination
+            )
 
         if (
             destination['type'] == 'application'
             and destination['application'] == 'custom'
         ):
-            yield _update_user_fallbacks_with_nonexistent_destination, call_filter[
-                'id'
-            ], destination
+            _update_user_fallbacks_with_nonexistent_destination(
+                call_filter['id'], destination
+            )
 
 
 def _update_user_fallbacks_with_nonexistent_destination(call_filter_id, destination):
@@ -183,7 +186,7 @@ def test_bus_events(call_filter):
     url = confd.callfilters(call_filter['id']).fallbacks.put
     expected_headers = {'tenant_uuid': MAIN_TENANT}
 
-    yield s.check_event, 'call_filter_fallback_edited', expected_headers, url
+    s.check_event('call_filter_fallback_edited', expected_headers, url)
 
 
 @fixtures.call_filter()

--- a/integration_tests/suite/base/test_call_filter_recipient_user.py
+++ b/integration_tests/suite/base/test_call_filter_recipient_user.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import assert_that, contains, empty, has_entries
@@ -18,37 +18,36 @@ def test_associate_errors(call_filter, user):
     response.assert_status(404)
 
     url = confd.callfilters(call_filter['id']).recipients.users.put
-    for check in error_checks(url):
-        yield check
+    error_checks(url)
 
 
 def error_checks(url):
-    yield s.check_bogus_field_returns_error, url, 'users', 123
-    yield s.check_bogus_field_returns_error, url, 'users', None
-    yield s.check_bogus_field_returns_error, url, 'users', True
-    yield s.check_bogus_field_returns_error, url, 'users', 'string'
-    yield s.check_bogus_field_returns_error, url, 'users', [123]
-    yield s.check_bogus_field_returns_error, url, 'users', [None]
-    yield s.check_bogus_field_returns_error, url, 'users', ['string']
-    yield s.check_bogus_field_returns_error, url, 'users', [{}]
-    yield s.check_bogus_field_returns_error, url, 'users', [{'uuid': None}]
-    yield s.check_bogus_field_returns_error, url, 'users', [{'uuid': 1}, {'uuid': None}]
-    yield s.check_bogus_field_returns_error, url, 'users', [{'not_uuid': 123}]
-    yield s.check_bogus_field_returns_error, url, 'users', [{'uuid': FAKE_UUID}]
+    s.check_bogus_field_returns_error(url, 'users', 123)
+    s.check_bogus_field_returns_error(url, 'users', None)
+    s.check_bogus_field_returns_error(url, 'users', True)
+    s.check_bogus_field_returns_error(url, 'users', 'string')
+    s.check_bogus_field_returns_error(url, 'users', [123])
+    s.check_bogus_field_returns_error(url, 'users', [None])
+    s.check_bogus_field_returns_error(url, 'users', ['string'])
+    s.check_bogus_field_returns_error(url, 'users', [{}])
+    s.check_bogus_field_returns_error(url, 'users', [{'uuid': None}])
+    s.check_bogus_field_returns_error(url, 'users', [{'uuid': 1}, {'uuid': None}])
+    s.check_bogus_field_returns_error(url, 'users', [{'not_uuid': 123}])
+    s.check_bogus_field_returns_error(url, 'users', [{'uuid': FAKE_UUID}])
 
     regex = r'users.*timeout'
-    yield s.check_bogus_field_returns_error_matching_regex, url, 'users', [
-        {'timeout': 'ten'}
-    ], regex
-    yield s.check_bogus_field_returns_error_matching_regex, url, 'users', [
-        {'timeout': -1}
-    ], regex
-    yield s.check_bogus_field_returns_error_matching_regex, url, 'users', [
-        {'timeout': {}}
-    ], regex
-    yield s.check_bogus_field_returns_error_matching_regex, url, 'users', [
-        {'timeout': []}
-    ], regex
+    s.check_bogus_field_returns_error_matching_regex(
+        url, 'users', [{'timeout': 'ten'}], regex
+    )
+    s.check_bogus_field_returns_error_matching_regex(
+        url, 'users', [{'timeout': -1}], regex
+    )
+    s.check_bogus_field_returns_error_matching_regex(
+        url, 'users', [{'timeout': {}}], regex
+    )
+    s.check_bogus_field_returns_error_matching_regex(
+        url, 'users', [{'timeout': []}], regex
+    )
 
 
 @fixtures.call_filter()
@@ -139,7 +138,7 @@ def test_delete_call_filter_when_call_filter_and_user_associated(
         confd.callfilters(call_filter['id']).delete().assert_deleted()
 
         deleted_call_filter = confd.callfilters(call_filter['id']).get
-        yield s.check_resource_not_found, deleted_call_filter, 'CallFilter'
+        s.check_resource_not_found(deleted_call_filter, 'CallFilter')
 
         # When the relation will be added,
         # we should check if users have the key.callfilters to empty
@@ -157,10 +156,10 @@ def test_delete_user_when_call_filter_and_user_associated(
         confd.users(user['uuid']).delete().assert_deleted()
 
         response = confd.callfilters(call_filter1['id']).get()
-        yield assert_that, response.item['recipients']['users'], empty()
+        assert_that(response.item['recipients']['users'], empty())
 
         response = confd.callfilters(call_filter2['id']).get()
-        yield assert_that, response.item['recipients']['users'], empty()
+        assert_that(response.item['recipients']['users'], empty())
 
 
 @fixtures.call_filter()
@@ -170,4 +169,4 @@ def test_bus_events(call_filter, user):
     body = {'users': [user]}
     headers = {'tenant_uuid': MAIN_TENANT}
 
-    yield s.check_event, 'call_filter_recipient_users_associated', headers, url, body
+    s.check_event('call_filter_recipient_users_associated', headers, url, body)

--- a/integration_tests/suite/base/test_call_filter_surrogate_user.py
+++ b/integration_tests/suite/base/test_call_filter_surrogate_user.py
@@ -18,23 +18,22 @@ def test_associate_errors(call_filter, user):
     response.assert_status(404)
 
     url = confd.callfilters(call_filter['id']).surrogates.users.put
-    for check in error_checks(url):
-        yield check
+    error_checks(url)
 
 
 def error_checks(url):
-    yield s.check_bogus_field_returns_error, url, 'users', 123
-    yield s.check_bogus_field_returns_error, url, 'users', None
-    yield s.check_bogus_field_returns_error, url, 'users', True
-    yield s.check_bogus_field_returns_error, url, 'users', 'string'
-    yield s.check_bogus_field_returns_error, url, 'users', [123]
-    yield s.check_bogus_field_returns_error, url, 'users', [None]
-    yield s.check_bogus_field_returns_error, url, 'users', ['string']
-    yield s.check_bogus_field_returns_error, url, 'users', [{}]
-    yield s.check_bogus_field_returns_error, url, 'users', [{'uuid': None}]
-    yield s.check_bogus_field_returns_error, url, 'users', [{'uuid': 1}, {'uuid': None}]
-    yield s.check_bogus_field_returns_error, url, 'users', [{'not_uuid': 123}]
-    yield s.check_bogus_field_returns_error, url, 'users', [{'uuid': FAKE_UUID}]
+    s.check_bogus_field_returns_error(url, 'users', 123)
+    s.check_bogus_field_returns_error(url, 'users', None)
+    s.check_bogus_field_returns_error(url, 'users', True)
+    s.check_bogus_field_returns_error(url, 'users', 'string')
+    s.check_bogus_field_returns_error(url, 'users', [123])
+    s.check_bogus_field_returns_error(url, 'users', [None])
+    s.check_bogus_field_returns_error(url, 'users', ['string'])
+    s.check_bogus_field_returns_error(url, 'users', [{}])
+    s.check_bogus_field_returns_error(url, 'users', [{'uuid': None}])
+    s.check_bogus_field_returns_error(url, 'users', [{'uuid': 1}, {'uuid': None}])
+    s.check_bogus_field_returns_error(url, 'users', [{'not_uuid': 123}])
+    s.check_bogus_field_returns_error(url, 'users', [{'uuid': FAKE_UUID}])
 
 
 @fixtures.call_filter()
@@ -157,7 +156,7 @@ def test_delete_call_filter_when_call_filter_and_user_associated(
         confd.callfilters(call_filter['id']).delete().assert_deleted()
 
         deleted_call_filter = confd.callfilters(call_filter['id']).get
-        yield s.check_resource_not_found, deleted_call_filter, 'CallFilter'
+        s.check_resource_not_found(deleted_call_filter, 'CallFilter')
 
         # When the relation will be added,
         # we should check if users have the key.callfilters to empty
@@ -175,10 +174,10 @@ def test_delete_user_when_call_filter_and_user_associated(
         confd.users(user['uuid']).delete().assert_deleted()
 
         response = confd.callfilters(call_filter1['id']).get()
-        yield assert_that, response.item['surrogates']['users'], empty()
+        assert_that(response.item['surrogates']['users'], empty())
 
         response = confd.callfilters(call_filter2['id']).get()
-        yield assert_that, response.item['surrogates']['users'], empty()
+        assert_that(response.item['surrogates']['users'], empty())
 
 
 @fixtures.call_filter()
@@ -188,7 +187,7 @@ def test_bus_events(call_filter, user):
     body = {'users': [user]}
     headers = {'tenant_uuid': MAIN_TENANT}
 
-    yield s.check_event, 'call_filter_surrogate_users_associated', headers, url, body
+    s.check_event('call_filter_surrogate_users_associated', headers, url, body)
 
 
 @fixtures.call_filter()

--- a/integration_tests/suite/base/test_call_filters.py
+++ b/integration_tests/suite/base/test_call_filters.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import (
@@ -21,73 +21,75 @@ from ..helpers.config import MAIN_TENANT, SUB_TENANT
 
 def test_get_errors():
     fake_get = confd.callfilters(999999).get
-    yield s.check_resource_not_found, fake_get, 'CallFilter'
+    s.check_resource_not_found(fake_get, 'CallFilter')
 
 
 def test_post_errors():
     url = confd.callfilters.post
-    for check in error_checks(url):
-        yield check
+    error_checks(url)
 
 
 @fixtures.call_filter()
 def test_put_errors(call_filter):
     url = confd.callfilters(call_filter['id']).put
-    for check in error_checks(url):
-        yield check
+    error_checks(url)
 
 
 def error_checks(url):
-    yield s.check_bogus_field_returns_error, url, 'name', 123
-    yield s.check_bogus_field_returns_error, url, 'name', None
-    yield s.check_bogus_field_returns_error, url, 'name', True
-    yield s.check_bogus_field_returns_error, url, 'name', {}
-    yield s.check_bogus_field_returns_error, url, 'name', []
-    yield s.check_bogus_field_returns_error, url, 'source', 123
-    yield s.check_bogus_field_returns_error, url, 'source', True
-    yield s.check_bogus_field_returns_error, url, 'source', 'invalid'
-    yield s.check_bogus_field_returns_error, url, 'source', {}
-    yield s.check_bogus_field_returns_error, url, 'source', []
-    yield s.check_bogus_field_returns_error, url, 'strategy', 123
-    yield s.check_bogus_field_returns_error, url, 'strategy', None
-    yield s.check_bogus_field_returns_error, url, 'strategy', False
-    yield s.check_bogus_field_returns_error, url, 'strategy', 'invalid'
-    yield s.check_bogus_field_returns_error, url, 'strategy', {}
-    yield s.check_bogus_field_returns_error, url, 'strategy', []
-    yield s.check_bogus_field_returns_error, url, 'surrogates_timeout', 'ten'
-    yield s.check_bogus_field_returns_error, url, 'surrogates_timeout', -1
-    yield s.check_bogus_field_returns_error, url, 'surrogates_timeout', {}
-    yield s.check_bogus_field_returns_error, url, 'surrogates_timeout', []
-    yield s.check_bogus_field_returns_error, url, 'caller_id_mode', True
-    yield s.check_bogus_field_returns_error, url, 'caller_id_mode', 'invalid'
-    yield s.check_bogus_field_returns_error, url, 'caller_id_mode', 1234
-    yield s.check_bogus_field_returns_error, url, 'caller_id_mode', {}
-    yield s.check_bogus_field_returns_error, url, 'caller_id_mode', []
-    yield s.check_bogus_field_returns_error, url, 'caller_id_name', 1234
-    yield s.check_bogus_field_returns_error, url, 'caller_id_name', True
-    yield s.check_bogus_field_returns_error, url, 'caller_id_name', s.random_string(81)
-    yield s.check_bogus_field_returns_error, url, 'caller_id_name', {}
-    yield s.check_bogus_field_returns_error, url, 'caller_id_name', []
-    yield s.check_bogus_field_returns_error, url, 'description', 123
-    yield s.check_bogus_field_returns_error, url, 'description', True
-    yield s.check_bogus_field_returns_error, url, 'description', {}
-    yield s.check_bogus_field_returns_error, url, 'description', []
-    yield s.check_bogus_field_returns_error, url, 'enabled', None
-    yield s.check_bogus_field_returns_error, url, 'enabled', 123
-    yield s.check_bogus_field_returns_error, url, 'enabled', 'invalid'
-    yield s.check_bogus_field_returns_error, url, 'enabled', {}
-    yield s.check_bogus_field_returns_error, url, 'enabled', []
+    s.check_bogus_field_returns_error(url, 'name', 123)
+    s.check_bogus_field_returns_error(url, 'name', None)
+    s.check_bogus_field_returns_error(url, 'name', True)
+    s.check_bogus_field_returns_error(url, 'name', {})
+    s.check_bogus_field_returns_error(url, 'name', [])
+    s.check_bogus_field_returns_error(url, 'source', 123)
+    s.check_bogus_field_returns_error(url, 'source', True)
+    s.check_bogus_field_returns_error(url, 'source', 'invalid')
+    s.check_bogus_field_returns_error(url, 'source', {})
+    s.check_bogus_field_returns_error(url, 'source', [])
+    s.check_bogus_field_returns_error(url, 'strategy', 123)
+    s.check_bogus_field_returns_error(url, 'strategy', None)
+    s.check_bogus_field_returns_error(url, 'strategy', False)
+    s.check_bogus_field_returns_error(url, 'strategy', 'invalid')
+    s.check_bogus_field_returns_error(url, 'strategy', {})
+    s.check_bogus_field_returns_error(url, 'strategy', [])
+    s.check_bogus_field_returns_error(url, 'surrogates_timeout', 'ten')
+    s.check_bogus_field_returns_error(url, 'surrogates_timeout', -1)
+    s.check_bogus_field_returns_error(url, 'surrogates_timeout', {})
+    s.check_bogus_field_returns_error(url, 'surrogates_timeout', [])
+    s.check_bogus_field_returns_error(url, 'caller_id_mode', True)
+    s.check_bogus_field_returns_error(url, 'caller_id_mode', 'invalid')
+    s.check_bogus_field_returns_error(url, 'caller_id_mode', 1234)
+    s.check_bogus_field_returns_error(url, 'caller_id_mode', {})
+    s.check_bogus_field_returns_error(url, 'caller_id_mode', [])
+    s.check_bogus_field_returns_error(url, 'caller_id_name', 1234)
+    s.check_bogus_field_returns_error(url, 'caller_id_name', True)
+    s.check_bogus_field_returns_error(url, 'caller_id_name', s.random_string(81))
+    s.check_bogus_field_returns_error(url, 'caller_id_name', {})
+    s.check_bogus_field_returns_error(url, 'caller_id_name', [])
+    s.check_bogus_field_returns_error(url, 'description', 123)
+    s.check_bogus_field_returns_error(url, 'description', True)
+    s.check_bogus_field_returns_error(url, 'description', {})
+    s.check_bogus_field_returns_error(url, 'description', [])
+    s.check_bogus_field_returns_error(url, 'enabled', None)
+    s.check_bogus_field_returns_error(url, 'enabled', 123)
+    s.check_bogus_field_returns_error(url, 'enabled', 'invalid')
+    s.check_bogus_field_returns_error(url, 'enabled', {})
+    s.check_bogus_field_returns_error(url, 'enabled', [])
 
-    for check in unique_error_checks(url):
-        yield check
+    unique_error_checks(url)
 
 
 @fixtures.call_filter(name='unique')
 def unique_error_checks(url, call_filter):
-    yield s.check_bogus_field_returns_error, url, 'name', call_filter['name'], {
-        'strategy': 'all',
-        'source': 'all',
-    }
+    s.check_bogus_field_returns_error(
+        url,
+        'name',
+        call_filter['name'],
+        {
+            'strategy': 'all',
+            'source': 'all',
+        },
+    )
 
 
 @fixtures.call_filter(name="search", description="SearchDesc")
@@ -97,7 +99,7 @@ def test_search(call_filter, hidden):
     searches = {'name': 'search', 'description': 'Search'}
 
     for field, term in searches.items():
-        yield check_search, url, call_filter, hidden, field, term
+        check_search(url, call_filter, hidden, field, term)
 
 
 def check_search(url, call_filter, hidden, field, term):
@@ -114,11 +116,11 @@ def check_search(url, call_filter, hidden, field, term):
 @fixtures.call_filter(name="sort2", description="Sort 2")
 def test_sorting_offset_limit(call_filter1, call_filter2):
     url = confd.callfilters.get
-    yield s.check_sorting, url, call_filter1, call_filter2, 'name', 'sort'
-    yield s.check_sorting, url, call_filter1, call_filter2, 'description', 'Sort'
+    s.check_sorting(url, call_filter1, call_filter2, 'name', 'sort')
+    s.check_sorting(url, call_filter1, call_filter2, 'description', 'Sort')
 
-    yield s.check_offset, url, call_filter1, call_filter2, 'name', 'sort'
-    yield s.check_limit, url, call_filter1, call_filter2, 'name', 'sort'
+    s.check_offset(url, call_filter1, call_filter2, 'name', 'sort')
+    s.check_limit(url, call_filter1, call_filter2, 'name', 'sort')
 
 
 @fixtures.call_filter(wazo_tenant=MAIN_TENANT)

--- a/integration_tests/suite/base/test_call_permissions.py
+++ b/integration_tests/suite/base/test_call_permissions.py
@@ -22,53 +22,51 @@ from ..helpers.config import MAIN_TENANT, SUB_TENANT
 
 def test_get_errors():
     fake_get = confd.callpermissions(999999).get
-    yield s.check_resource_not_found, fake_get, 'CallPermission'
+    s.check_resource_not_found(fake_get, 'CallPermission')
 
 
 def test_post_errors():
     url = confd.callpermissions.post
-    for check in error_checks(url):
-        yield check
+    error_checks(url)
 
 
 @fixtures.call_permission()
 def test_put_errors(call_permission):
     url = confd.callpermissions(call_permission['id']).put
-    for check in error_checks(url):
-        yield check
+    error_checks(url)
 
 
 def error_checks(url):
-    yield s.check_bogus_field_returns_error, url, 'name', 123
-    yield s.check_bogus_field_returns_error, url, 'name', None
-    yield s.check_bogus_field_returns_error, url, 'name', True
-    yield s.check_bogus_field_returns_error, url, 'name', 'a' * 129
-    yield s.check_bogus_field_returns_error, url, 'name', ''
-    yield s.check_bogus_field_returns_error, url, 'name', {}
-    yield s.check_bogus_field_returns_error, url, 'name', []
-    yield s.check_bogus_field_returns_error, url, 'password', 123
-    yield s.check_bogus_field_returns_error, url, 'password', True
-    yield s.check_bogus_field_returns_error, url, 'password', 'invalid'
-    yield s.check_bogus_field_returns_error, url, 'password', {}
-    yield s.check_bogus_field_returns_error, url, 'password', []
-    yield s.check_bogus_field_returns_error, url, 'description', 123
-    yield s.check_bogus_field_returns_error, url, 'description', True
-    yield s.check_bogus_field_returns_error, url, 'description', {}
-    yield s.check_bogus_field_returns_error, url, 'description', []
-    yield s.check_bogus_field_returns_error, url, 'mode', 123
-    yield s.check_bogus_field_returns_error, url, 'mode', None
-    yield s.check_bogus_field_returns_error, url, 'mode', False
-    yield s.check_bogus_field_returns_error, url, 'mode', 'invalid'
-    yield s.check_bogus_field_returns_error, url, 'enabled', None
-    yield s.check_bogus_field_returns_error, url, 'enabled', 123
-    yield s.check_bogus_field_returns_error, url, 'enabled', 'invalid'
-    yield s.check_bogus_field_returns_error, url, 'enabled', {}
-    yield s.check_bogus_field_returns_error, url, 'enabled', []
-    yield s.check_bogus_field_returns_error, url, 'extensions', 'invalid'
-    yield s.check_bogus_field_returns_error, url, 'extensions', 123
-    yield s.check_bogus_field_returns_error, url, 'extensions', True
-    yield s.check_bogus_field_returns_error, url, 'extensions', None
-    yield s.check_bogus_field_returns_error, url, 'extensions', {}
+    s.check_bogus_field_returns_error(url, 'name', 123)
+    s.check_bogus_field_returns_error(url, 'name', None)
+    s.check_bogus_field_returns_error(url, 'name', True)
+    s.check_bogus_field_returns_error(url, 'name', 'a' * 129)
+    s.check_bogus_field_returns_error(url, 'name', '')
+    s.check_bogus_field_returns_error(url, 'name', {})
+    s.check_bogus_field_returns_error(url, 'name', [])
+    s.check_bogus_field_returns_error(url, 'password', 123)
+    s.check_bogus_field_returns_error(url, 'password', True)
+    s.check_bogus_field_returns_error(url, 'password', 'invalid')
+    s.check_bogus_field_returns_error(url, 'password', {})
+    s.check_bogus_field_returns_error(url, 'password', [])
+    s.check_bogus_field_returns_error(url, 'description', 123)
+    s.check_bogus_field_returns_error(url, 'description', True)
+    s.check_bogus_field_returns_error(url, 'description', {})
+    s.check_bogus_field_returns_error(url, 'description', [])
+    s.check_bogus_field_returns_error(url, 'mode', 123)
+    s.check_bogus_field_returns_error(url, 'mode', None)
+    s.check_bogus_field_returns_error(url, 'mode', False)
+    s.check_bogus_field_returns_error(url, 'mode', 'invalid')
+    s.check_bogus_field_returns_error(url, 'enabled', None)
+    s.check_bogus_field_returns_error(url, 'enabled', 123)
+    s.check_bogus_field_returns_error(url, 'enabled', 'invalid')
+    s.check_bogus_field_returns_error(url, 'enabled', {})
+    s.check_bogus_field_returns_error(url, 'enabled', [])
+    s.check_bogus_field_returns_error(url, 'extensions', 'invalid')
+    s.check_bogus_field_returns_error(url, 'extensions', 123)
+    s.check_bogus_field_returns_error(url, 'extensions', True)
+    s.check_bogus_field_returns_error(url, 'extensions', None)
+    s.check_bogus_field_returns_error(url, 'extensions', {})
 
 
 @fixtures.call_permission(
@@ -87,18 +85,18 @@ def test_search(call_permission, hidden):
     }
 
     for field, term in searches.items():
-        yield check_search, url, call_permission, hidden, field, term
+        check_search(url, call_permission, hidden, field, term)
 
 
 @fixtures.call_permission(name="sort1", description="Sort 1")
 @fixtures.call_permission(name="sort2", description="Sort 2")
 def test_sorting_offset_limit(call_permission1, call_permission2):
     url = confd.callpermissions.get
-    yield s.check_sorting, url, call_permission1, call_permission2, 'name', 'sort'
-    yield s.check_sorting, url, call_permission1, call_permission2, 'description', 'Sort'
+    s.check_sorting(url, call_permission1, call_permission2, 'name', 'sort')
+    s.check_sorting(url, call_permission1, call_permission2, 'description', 'Sort')
 
-    yield s.check_offset, url, call_permission1, call_permission2, 'name', 'sort'
-    yield s.check_limit, url, call_permission1, call_permission2, 'name', 'sort'
+    s.check_offset(url, call_permission1, call_permission2, 'name', 'sort')
+    s.check_limit(url, call_permission1, call_permission2, 'name', 'sort')
 
 
 def check_search(url, call_permission, hidden, field, term):

--- a/integration_tests/suite/base/test_call_pickup_interceptor_group.py
+++ b/integration_tests/suite/base/test_call_pickup_interceptor_group.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import assert_that, contains_inanyorder, empty, has_entries
@@ -17,23 +17,22 @@ def test_associate_errors(call_pickup, group):
     response.assert_status(404)
 
     url = confd.callpickups(call_pickup['id']).interceptors.groups.put
-    for check in error_checks(url):
-        yield check
+    error_checks(url)
 
 
 def error_checks(url):
-    yield s.check_bogus_field_returns_error, url, 'groups', 123
-    yield s.check_bogus_field_returns_error, url, 'groups', None
-    yield s.check_bogus_field_returns_error, url, 'groups', True
-    yield s.check_bogus_field_returns_error, url, 'groups', 'string'
-    yield s.check_bogus_field_returns_error, url, 'groups', [123]
-    yield s.check_bogus_field_returns_error, url, 'groups', [None]
-    yield s.check_bogus_field_returns_error, url, 'groups', ['string']
-    yield s.check_bogus_field_returns_error, url, 'groups', [{}]
-    yield s.check_bogus_field_returns_error, url, 'groups', [{'id': None}]
-    yield s.check_bogus_field_returns_error, url, 'groups', [{'id': 1}, {'id': None}]
-    yield s.check_bogus_field_returns_error, url, 'groups', [{'not_id': 123}]
-    yield s.check_bogus_field_returns_error, url, 'groups', [{'id': FAKE_ID}]
+    s.check_bogus_field_returns_error(url, 'groups', 123)
+    s.check_bogus_field_returns_error(url, 'groups', None)
+    s.check_bogus_field_returns_error(url, 'groups', True)
+    s.check_bogus_field_returns_error(url, 'groups', 'string')
+    s.check_bogus_field_returns_error(url, 'groups', [123])
+    s.check_bogus_field_returns_error(url, 'groups', [None])
+    s.check_bogus_field_returns_error(url, 'groups', ['string'])
+    s.check_bogus_field_returns_error(url, 'groups', [{}])
+    s.check_bogus_field_returns_error(url, 'groups', [{'id': None}])
+    s.check_bogus_field_returns_error(url, 'groups', [{'id': 1}, {'id': None}])
+    s.check_bogus_field_returns_error(url, 'groups', [{'not_id': 123}])
+    s.check_bogus_field_returns_error(url, 'groups', [{'id': FAKE_ID}])
 
 
 @fixtures.call_pickup()
@@ -147,7 +146,7 @@ def test_delete_call_pickup_when_call_pickup_and_group_associated(
         confd.callpickups(call_pickup['id']).delete().assert_deleted()
 
         deleted_call_pickup = confd.callpickups(call_pickup['id']).get
-        yield s.check_resource_not_found, deleted_call_pickup, 'CallPickup'
+        s.check_resource_not_found(deleted_call_pickup, 'CallPickup')
 
         # When the relation will be added,
         # we should check if groups have the key.callpickups to empty
@@ -165,10 +164,10 @@ def test_delete_group_when_call_pickup_and_group_associated(
         confd.groups(group['id']).delete().assert_deleted()
 
         response = confd.callpickups(call_pickup1['id']).get()
-        yield assert_that, response.item['interceptors']['groups'], empty()
+        assert_that(response.item['interceptors']['groups'], empty())
 
         response = confd.callpickups(call_pickup2['id']).get()
-        yield assert_that, response.item['interceptors']['groups'], empty()
+        assert_that(response.item['interceptors']['groups'], empty())
 
 
 @fixtures.call_pickup()
@@ -178,4 +177,4 @@ def test_bus_events(call_pickup, group):
     body = {'groups': [group]}
     headers = {'tenant_uuid': MAIN_TENANT}
 
-    yield s.check_event, 'call_pickup_interceptor_groups_associated', headers, url, body
+    s.check_event('call_pickup_interceptor_groups_associated', headers, url, body)

--- a/integration_tests/suite/base/test_call_pickup_interceptor_user.py
+++ b/integration_tests/suite/base/test_call_pickup_interceptor_user.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import assert_that, contains_inanyorder, empty, has_entries
@@ -17,23 +17,22 @@ def test_associate_errors(call_pickup, user):
     response.assert_status(404)
 
     url = confd.callpickups(call_pickup['id']).interceptors.users.put
-    for check in error_checks(url):
-        yield check
+    error_checks(url)
 
 
 def error_checks(url):
-    yield s.check_bogus_field_returns_error, url, 'users', 123
-    yield s.check_bogus_field_returns_error, url, 'users', None
-    yield s.check_bogus_field_returns_error, url, 'users', True
-    yield s.check_bogus_field_returns_error, url, 'users', 'string'
-    yield s.check_bogus_field_returns_error, url, 'users', [123]
-    yield s.check_bogus_field_returns_error, url, 'users', [None]
-    yield s.check_bogus_field_returns_error, url, 'users', ['string']
-    yield s.check_bogus_field_returns_error, url, 'users', [{}]
-    yield s.check_bogus_field_returns_error, url, 'users', [{'uuid': None}]
-    yield s.check_bogus_field_returns_error, url, 'users', [{'uuid': 1}, {'uuid': None}]
-    yield s.check_bogus_field_returns_error, url, 'users', [{'not_uuid': 123}]
-    yield s.check_bogus_field_returns_error, url, 'users', [{'uuid': FAKE_UUID}]
+    s.check_bogus_field_returns_error(url, 'users', 123)
+    s.check_bogus_field_returns_error(url, 'users', None)
+    s.check_bogus_field_returns_error(url, 'users', True)
+    s.check_bogus_field_returns_error(url, 'users', 'string')
+    s.check_bogus_field_returns_error(url, 'users', [123])
+    s.check_bogus_field_returns_error(url, 'users', [None])
+    s.check_bogus_field_returns_error(url, 'users', ['string'])
+    s.check_bogus_field_returns_error(url, 'users', [{}])
+    s.check_bogus_field_returns_error(url, 'users', [{'uuid': None}])
+    s.check_bogus_field_returns_error(url, 'users', [{'uuid': 1}, {'uuid': None}])
+    s.check_bogus_field_returns_error(url, 'users', [{'not_uuid': 123}])
+    s.check_bogus_field_returns_error(url, 'users', [{'uuid': FAKE_UUID}])
 
 
 @fixtures.call_pickup()
@@ -149,7 +148,7 @@ def test_delete_call_pickup_when_call_pickup_and_user_associated(
         confd.callpickups(call_pickup['id']).delete().assert_deleted()
 
         deleted_call_pickup = confd.callpickups(call_pickup['id']).get
-        yield s.check_resource_not_found, deleted_call_pickup, 'CallPickup'
+        s.check_resource_not_found(deleted_call_pickup, 'CallPickup')
 
         # When the relation will be added,
         # we should check if users have the key.callpickups to empty
@@ -167,10 +166,10 @@ def test_delete_user_when_call_pickup_and_user_associated(
         confd.users(user['uuid']).delete().assert_deleted()
 
         response = confd.callpickups(call_pickup1['id']).get()
-        yield assert_that, response.item['interceptors']['users'], empty()
+        assert_that(response.item['interceptors']['users'], empty())
 
         response = confd.callpickups(call_pickup2['id']).get()
-        yield assert_that, response.item['interceptors']['users'], empty()
+        assert_that(response.item['interceptors']['users'], empty())
 
 
 @fixtures.call_pickup()
@@ -180,4 +179,4 @@ def test_bus_events(call_pickup, user):
     body = {'users': [user]}
     headers = {'tenant_uuid': MAIN_TENANT}
 
-    yield s.check_event, 'call_pickup_interceptor_users_associated', headers, url, body
+    s.check_event('call_pickup_interceptor_users_associated', headers, url, body)

--- a/integration_tests/suite/base/test_call_pickup_target_group.py
+++ b/integration_tests/suite/base/test_call_pickup_target_group.py
@@ -17,23 +17,22 @@ def test_associate_errors(call_pickup, group):
     response.assert_status(404)
 
     url = confd.callpickups(call_pickup['id']).targets.groups.put
-    for check in error_checks(url):
-        yield check
+    error_checks(url)
 
 
 def error_checks(url):
-    yield s.check_bogus_field_returns_error, url, 'groups', 123
-    yield s.check_bogus_field_returns_error, url, 'groups', None
-    yield s.check_bogus_field_returns_error, url, 'groups', True
-    yield s.check_bogus_field_returns_error, url, 'groups', 'string'
-    yield s.check_bogus_field_returns_error, url, 'groups', [123]
-    yield s.check_bogus_field_returns_error, url, 'groups', [None]
-    yield s.check_bogus_field_returns_error, url, 'groups', ['string']
-    yield s.check_bogus_field_returns_error, url, 'groups', [{}]
-    yield s.check_bogus_field_returns_error, url, 'groups', [{'id': None}]
-    yield s.check_bogus_field_returns_error, url, 'groups', [{'id': 1}, {'id': None}]
-    yield s.check_bogus_field_returns_error, url, 'groups', [{'not_id': 123}]
-    yield s.check_bogus_field_returns_error, url, 'groups', [{'id': FAKE_ID}]
+    s.check_bogus_field_returns_error(url, 'groups', 123)
+    s.check_bogus_field_returns_error(url, 'groups', None)
+    s.check_bogus_field_returns_error(url, 'groups', True)
+    s.check_bogus_field_returns_error(url, 'groups', 'string')
+    s.check_bogus_field_returns_error(url, 'groups', [123])
+    s.check_bogus_field_returns_error(url, 'groups', [None])
+    s.check_bogus_field_returns_error(url, 'groups', ['string'])
+    s.check_bogus_field_returns_error(url, 'groups', [{}])
+    s.check_bogus_field_returns_error(url, 'groups', [{'id': None}])
+    s.check_bogus_field_returns_error(url, 'groups', [{'id': 1}, {'id': None}])
+    s.check_bogus_field_returns_error(url, 'groups', [{'not_id': 123}])
+    s.check_bogus_field_returns_error(url, 'groups', [{'id': FAKE_ID}])
 
 
 @fixtures.call_pickup()
@@ -206,7 +205,7 @@ def test_delete_call_pickup_when_call_pickup_and_group_associated(
         confd.callpickups(call_pickup['id']).delete().assert_deleted()
 
         deleted_call_pickup = confd.callpickups(call_pickup['id']).get
-        yield s.check_resource_not_found, deleted_call_pickup, 'CallPickup'
+        s.check_resource_not_found(deleted_call_pickup, 'CallPickup')
 
         # When the relation will be added,
         # we should check if groups have the key.callpickups to empty
@@ -224,10 +223,10 @@ def test_delete_group_when_call_pickup_and_group_associated(
         confd.groups(group['id']).delete().assert_deleted()
 
         response = confd.callpickups(call_pickup1['id']).get()
-        yield assert_that, response.item['targets']['groups'], empty()
+        assert_that(response.item['targets']['groups'], empty())
 
         response = confd.callpickups(call_pickup2['id']).get()
-        yield assert_that, response.item['targets']['groups'], empty()
+        assert_that(response.item['targets']['groups'], empty())
 
 
 @fixtures.call_pickup()
@@ -237,4 +236,4 @@ def test_bus_events(call_pickup, group):
     body = {'groups': [group]}
     headers = {'tenant_uuid': MAIN_TENANT}
 
-    yield s.check_event, 'call_pickup_target_groups_associated', headers, url, body
+    s.check_event('call_pickup_target_groups_associated', headers, url, body)

--- a/integration_tests/suite/base/test_call_pickup_target_user.py
+++ b/integration_tests/suite/base/test_call_pickup_target_user.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import assert_that, contains_inanyorder, empty, has_entries
@@ -17,23 +17,22 @@ def test_associate_errors(call_pickup, user):
     response.assert_status(404)
 
     url = confd.callpickups(call_pickup['id']).targets.users.put
-    for check in error_checks(url):
-        yield check
+    error_checks(url)
 
 
 def error_checks(url):
-    yield s.check_bogus_field_returns_error, url, 'users', 123
-    yield s.check_bogus_field_returns_error, url, 'users', None
-    yield s.check_bogus_field_returns_error, url, 'users', True
-    yield s.check_bogus_field_returns_error, url, 'users', 'string'
-    yield s.check_bogus_field_returns_error, url, 'users', [123]
-    yield s.check_bogus_field_returns_error, url, 'users', [None]
-    yield s.check_bogus_field_returns_error, url, 'users', ['string']
-    yield s.check_bogus_field_returns_error, url, 'users', [{}]
-    yield s.check_bogus_field_returns_error, url, 'users', [{'uuid': None}]
-    yield s.check_bogus_field_returns_error, url, 'users', [{'uuid': 1}, {'uuid': None}]
-    yield s.check_bogus_field_returns_error, url, 'users', [{'not_uuid': 123}]
-    yield s.check_bogus_field_returns_error, url, 'users', [{'uuid': FAKE_UUID}]
+    s.check_bogus_field_returns_error(url, 'users', 123)
+    s.check_bogus_field_returns_error(url, 'users', None)
+    s.check_bogus_field_returns_error(url, 'users', True)
+    s.check_bogus_field_returns_error(url, 'users', 'string')
+    s.check_bogus_field_returns_error(url, 'users', [123])
+    s.check_bogus_field_returns_error(url, 'users', [None])
+    s.check_bogus_field_returns_error(url, 'users', ['string'])
+    s.check_bogus_field_returns_error(url, 'users', [{}])
+    s.check_bogus_field_returns_error(url, 'users', [{'uuid': None}])
+    s.check_bogus_field_returns_error(url, 'users', [{'uuid': 1}, {'uuid': None}])
+    s.check_bogus_field_returns_error(url, 'users', [{'not_uuid': 123}])
+    s.check_bogus_field_returns_error(url, 'users', [{'uuid': FAKE_UUID}])
 
 
 @fixtures.call_pickup()
@@ -192,7 +191,7 @@ def test_delete_call_pickup_when_call_pickup_and_user_associated(
         confd.callpickups(call_pickup['id']).delete().assert_deleted()
 
         deleted_call_pickup = confd.callpickups(call_pickup['id']).get
-        yield s.check_resource_not_found, deleted_call_pickup, 'CallPickup'
+        s.check_resource_not_found(deleted_call_pickup, 'CallPickup')
 
         # When the relation will be added,
         # we should check if users have the key.callpickups to empty
@@ -210,10 +209,10 @@ def test_delete_user_when_call_pickup_and_user_associated(
         confd.users(user['uuid']).delete().assert_deleted()
 
         response = confd.callpickups(call_pickup1['id']).get()
-        yield assert_that, response.item['targets']['users'], empty()
+        assert_that(response.item['targets']['users'], empty())
 
         response = confd.callpickups(call_pickup2['id']).get()
-        yield assert_that, response.item['targets']['users'], empty()
+        assert_that(response.item['targets']['users'], empty())
 
 
 @fixtures.call_pickup()
@@ -223,4 +222,4 @@ def test_bus_events(call_pickup, user):
     body = {'users': [user]}
     headers = {'tenant_uuid': MAIN_TENANT}
 
-    yield s.check_event, 'call_pickup_target_users_associated', headers, url, body
+    s.check_event('call_pickup_target_users_associated', headers, url, body)

--- a/integration_tests/suite/base/test_call_pickups.py
+++ b/integration_tests/suite/base/test_call_pickups.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import (
@@ -21,45 +21,42 @@ from ..helpers.config import MAIN_TENANT, SUB_TENANT
 
 def test_get_errors():
     fake_get = confd.callpickups(999999).get
-    yield s.check_resource_not_found, fake_get, 'CallPickup'
+    s.check_resource_not_found(fake_get, 'CallPickup')
 
 
 def test_post_errors():
     url = confd.callpickups.post
-    for check in error_checks(url):
-        yield check
+    error_checks(url)
 
 
 @fixtures.call_pickup()
 def test_put_errors(call_pickup):
     url = confd.callpickups(call_pickup['id']).put
-    for check in error_checks(url):
-        yield check
+    error_checks(url)
 
 
 def error_checks(url):
-    yield s.check_bogus_field_returns_error, url, 'name', 123
-    yield s.check_bogus_field_returns_error, url, 'name', None
-    yield s.check_bogus_field_returns_error, url, 'name', True
-    yield s.check_bogus_field_returns_error, url, 'name', {}
-    yield s.check_bogus_field_returns_error, url, 'name', []
-    yield s.check_bogus_field_returns_error, url, 'description', 123
-    yield s.check_bogus_field_returns_error, url, 'description', True
-    yield s.check_bogus_field_returns_error, url, 'description', {}
-    yield s.check_bogus_field_returns_error, url, 'description', []
-    yield s.check_bogus_field_returns_error, url, 'enabled', None
-    yield s.check_bogus_field_returns_error, url, 'enabled', 123
-    yield s.check_bogus_field_returns_error, url, 'enabled', 'invalid'
-    yield s.check_bogus_field_returns_error, url, 'enabled', {}
-    yield s.check_bogus_field_returns_error, url, 'enabled', []
+    s.check_bogus_field_returns_error(url, 'name', 123)
+    s.check_bogus_field_returns_error(url, 'name', None)
+    s.check_bogus_field_returns_error(url, 'name', True)
+    s.check_bogus_field_returns_error(url, 'name', {})
+    s.check_bogus_field_returns_error(url, 'name', [])
+    s.check_bogus_field_returns_error(url, 'description', 123)
+    s.check_bogus_field_returns_error(url, 'description', True)
+    s.check_bogus_field_returns_error(url, 'description', {})
+    s.check_bogus_field_returns_error(url, 'description', [])
+    s.check_bogus_field_returns_error(url, 'enabled', None)
+    s.check_bogus_field_returns_error(url, 'enabled', 123)
+    s.check_bogus_field_returns_error(url, 'enabled', 'invalid')
+    s.check_bogus_field_returns_error(url, 'enabled', {})
+    s.check_bogus_field_returns_error(url, 'enabled', [])
 
-    for check in unique_error_checks(url):
-        yield check
+    unique_error_checks(url)
 
 
 @fixtures.call_pickup(name='unique')
 def unique_error_checks(url, call_pickup):
-    yield s.check_bogus_field_returns_error, url, 'name', call_pickup['name']
+    s.check_bogus_field_returns_error(url, 'name', call_pickup['name'])
 
 
 @fixtures.call_pickup(wazo_tenant=MAIN_TENANT)
@@ -82,7 +79,7 @@ def test_search(call_pickup, hidden):
     searches = {'name': 'search', 'description': 'Search'}
 
     for field, term in searches.items():
-        yield check_search, url, call_pickup, hidden, field, term
+        check_search(url, call_pickup, hidden, field, term)
 
 
 def check_search(url, call_pickup, hidden, field, term):
@@ -100,11 +97,11 @@ def check_search(url, call_pickup, hidden, field, term):
 @fixtures.call_pickup(name="sort2", description="Sort 2")
 def test_sorting_offset_limit(call_pickup1, call_pickup2):
     url = confd.callpickups.get
-    yield s.check_sorting, url, call_pickup1, call_pickup2, 'name', 'sort'
-    yield s.check_sorting, url, call_pickup1, call_pickup2, 'description', 'Sort'
+    s.check_sorting(url, call_pickup1, call_pickup2, 'name', 'sort')
+    s.check_sorting(url, call_pickup1, call_pickup2, 'description', 'Sort')
 
-    yield s.check_offset, url, call_pickup1, call_pickup2, 'name', 'sort'
-    yield s.check_limit, url, call_pickup1, call_pickup2, 'name', 'sort'
+    s.check_offset(url, call_pickup1, call_pickup2, 'name', 'sort')
+    s.check_limit(url, call_pickup1, call_pickup2, 'name', 'sort')
 
 
 @fixtures.call_pickup()

--- a/integration_tests/suite/base/test_confbridge_wazo_default_bridge.py
+++ b/integration_tests/suite/base/test_confbridge_wazo_default_bridge.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import assert_that, has_entries
@@ -10,17 +10,16 @@ from ..helpers.config import TOKEN_SUB_TENANT
 
 def test_put_errors():
     url = confd.asterisk.confbridge.wazo_default_bridge.put
-    for check in error_checks(url):
-        yield check
+    error_checks(url)
 
 
 def error_checks(url):
-    yield s.check_bogus_field_returns_error, url, 'options', 123
-    yield s.check_bogus_field_returns_error, url, 'options', None
-    yield s.check_bogus_field_returns_error, url, 'options', 'string'
-    yield s.check_bogus_field_returns_error, url, 'options', [['ordered', 'option']]
-    yield s.check_bogus_field_returns_error, url, 'options', {'wrong_value': 23}
-    yield s.check_bogus_field_returns_error, url, 'options', {'none_value': None}
+    s.check_bogus_field_returns_error(url, 'options', 123)
+    s.check_bogus_field_returns_error(url, 'options', None)
+    s.check_bogus_field_returns_error(url, 'options', 'string')
+    s.check_bogus_field_returns_error(url, 'options', [['ordered', 'option']])
+    s.check_bogus_field_returns_error(url, 'options', {'wrong_value': 23})
+    s.check_bogus_field_returns_error(url, 'options', {'none_value': None})
 
 
 def test_get():
@@ -59,6 +58,6 @@ def test_bus_event_when_edited():
     url = confd.asterisk.confbridge.wazo_default_bridge
     headers = {}
 
-    yield s.check_event, 'confbridge_wazo_default_bridge_edited', headers, url.put, {
-        'options': {}
-    }
+    s.check_event(
+        'confbridge_wazo_default_bridge_edited', headers, url.put, {'options': {}}
+    )

--- a/integration_tests/suite/base/test_confbridge_wazo_default_user.py
+++ b/integration_tests/suite/base/test_confbridge_wazo_default_user.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import assert_that, has_entries
@@ -10,17 +10,16 @@ from ..helpers.config import TOKEN_SUB_TENANT
 
 def test_put_errors():
     url = confd.asterisk.confbridge.wazo_default_user.put
-    for check in error_checks(url):
-        yield check
+    error_checks(url)
 
 
 def error_checks(url):
-    yield s.check_bogus_field_returns_error, url, 'options', 123
-    yield s.check_bogus_field_returns_error, url, 'options', None
-    yield s.check_bogus_field_returns_error, url, 'options', 'string'
-    yield s.check_bogus_field_returns_error, url, 'options', [['ordered', 'option']]
-    yield s.check_bogus_field_returns_error, url, 'options', {'wrong_value': 23}
-    yield s.check_bogus_field_returns_error, url, 'options', {'none_value': None}
+    s.check_bogus_field_returns_error(url, 'options', 123)
+    s.check_bogus_field_returns_error(url, 'options', None)
+    s.check_bogus_field_returns_error(url, 'options', 'string')
+    s.check_bogus_field_returns_error(url, 'options', [['ordered', 'option']])
+    s.check_bogus_field_returns_error(url, 'options', {'wrong_value': 23})
+    s.check_bogus_field_returns_error(url, 'options', {'none_value': None})
 
 
 def test_get():
@@ -59,6 +58,6 @@ def test_bus_event_when_edited():
     url = confd.asterisk.confbridge.wazo_default_user
     headers = {}
 
-    yield s.check_event, 'confbridge_wazo_default_user_edited', headers, url.put, {
-        'options': {}
-    }
+    s.check_event(
+        'confbridge_wazo_default_user_edited', headers, url.put, {'options': {}}
+    )

--- a/integration_tests/suite/base/test_conference_extension.py
+++ b/integration_tests/suite/base/test_conference_extension.py
@@ -22,8 +22,8 @@ def test_associate_errors(conference, extension):
     fake_conference = confd.conferences(FAKE_ID).extensions(extension['id']).put
     fake_extension = confd.conferences(conference['id']).extensions(FAKE_ID).put
 
-    yield s.check_resource_not_found, fake_conference, 'Conference'
-    yield s.check_resource_not_found, fake_extension, 'Extension'
+    s.check_resource_not_found(fake_conference, 'Conference')
+    s.check_resource_not_found(fake_extension, 'Extension')
 
 
 @fixtures.conference()
@@ -32,8 +32,8 @@ def test_dissociate_errors(conference, extension):
     fake_conference = confd.conferences(FAKE_ID).extensions(extension['id']).delete
     fake_extension = confd.conferences(conference['id']).extensions(FAKE_ID).delete
 
-    yield s.check_resource_not_found, fake_conference, 'Conference'
-    yield s.check_resource_not_found, fake_extension, 'Extension'
+    s.check_resource_not_found(fake_conference, 'Conference')
+    s.check_resource_not_found(fake_extension, 'Extension')
 
 
 @fixtures.extension(exten=gen_conference_exten())

--- a/integration_tests/suite/base/test_conferences.py
+++ b/integration_tests/suite/base/test_conferences.py
@@ -29,71 +29,67 @@ from ..helpers.config import (
 
 def test_get_errors():
     fake_conference = confd.conferences(999999).get
-    yield s.check_resource_not_found, fake_conference, 'Conference'
+    s.check_resource_not_found(fake_conference, 'Conference')
 
 
 def test_delete_errors():
     fake_conference = confd.conferences(999999).delete
-    yield s.check_resource_not_found, fake_conference, 'Conference'
+    s.check_resource_not_found(fake_conference, 'Conference')
 
 
 def test_post_errors():
     url = confd.conferences.post
-    for check in error_checks(url):
-        yield check
+    error_checks(url)
 
 
 @fixtures.conference()
 def test_put_errors(conference):
     url = confd.conferences(conference['id']).put
-    for check in error_checks(url):
-        yield check
+    error_checks(url)
 
 
 def error_checks(url):
-    yield s.check_bogus_field_returns_error, url, 'name', True
-    yield s.check_bogus_field_returns_error, url, 'name', 1234
-    yield s.check_bogus_field_returns_error, url, 'name', s.random_string(129)
-    yield s.check_bogus_field_returns_error, url, 'name', []
-    yield s.check_bogus_field_returns_error, url, 'name', {}
-    yield s.check_bogus_field_returns_error, url, 'preprocess_subroutine', True
-    yield s.check_bogus_field_returns_error, url, 'preprocess_subroutine', 123
-    yield s.check_bogus_field_returns_error, url, 'preprocess_subroutine', s.random_string(
-        80
-    )
-    yield s.check_bogus_field_returns_error, url, 'preprocess_subroutine', []
-    yield s.check_bogus_field_returns_error, url, 'preprocess_subroutine', {}
-    yield s.check_bogus_field_returns_error, url, 'music_on_hold', 1234
-    yield s.check_bogus_field_returns_error, url, 'music_on_hold', True
-    yield s.check_bogus_field_returns_error, url, 'music_on_hold', s.random_string(129)
-    yield s.check_bogus_field_returns_error, url, 'music_on_hold', []
-    yield s.check_bogus_field_returns_error, url, 'music_on_hold', {}
-    yield s.check_bogus_field_returns_error, url, 'announce_only_user', 'invalid'
-    yield s.check_bogus_field_returns_error, url, 'announce_only_user', None
-    yield s.check_bogus_field_returns_error, url, 'announce_only_user', []
-    yield s.check_bogus_field_returns_error, url, 'announce_only_user', {}
-    yield s.check_bogus_field_returns_error, url, 'announce_join_leave', 'invalid'
-    yield s.check_bogus_field_returns_error, url, 'announce_join_leave', None
-    yield s.check_bogus_field_returns_error, url, 'announce_join_leave', []
-    yield s.check_bogus_field_returns_error, url, 'announce_join_leave', {}
-    yield s.check_bogus_field_returns_error, url, 'quiet_join_leave', 'invalid'
-    yield s.check_bogus_field_returns_error, url, 'quiet_join_leave', None
-    yield s.check_bogus_field_returns_error, url, 'quiet_join_leave', []
-    yield s.check_bogus_field_returns_error, url, 'quiet_join_leave', {}
-    yield s.check_bogus_field_returns_error, url, 'announce_user_count', 'invalid'
-    yield s.check_bogus_field_returns_error, url, 'announce_user_count', None
-    yield s.check_bogus_field_returns_error, url, 'announce_user_count', []
-    yield s.check_bogus_field_returns_error, url, 'announce_user_count', {}
-    yield s.check_bogus_field_returns_error, url, 'record', 'invalid'
-    yield s.check_bogus_field_returns_error, url, 'record', None
-    yield s.check_bogus_field_returns_error, url, 'record', []
-    yield s.check_bogus_field_returns_error, url, 'record', {}
-    yield s.check_bogus_field_returns_error, url, 'pin', 'invalid'
-    yield s.check_bogus_field_returns_error, url, 'pin', []
-    yield s.check_bogus_field_returns_error, url, 'pin', {}
-    yield s.check_bogus_field_returns_error, url, 'admin_pin', 'invalid'
-    yield s.check_bogus_field_returns_error, url, 'admin_pin', []
-    yield s.check_bogus_field_returns_error, url, 'admin_pin', {}
+    s.check_bogus_field_returns_error(url, 'name', True)
+    s.check_bogus_field_returns_error(url, 'name', 1234)
+    s.check_bogus_field_returns_error(url, 'name', s.random_string(129))
+    s.check_bogus_field_returns_error(url, 'name', [])
+    s.check_bogus_field_returns_error(url, 'name', {})
+    s.check_bogus_field_returns_error(url, 'preprocess_subroutine', True)
+    s.check_bogus_field_returns_error(url, 'preprocess_subroutine', 123)
+    s.check_bogus_field_returns_error(url, 'preprocess_subroutine', s.random_string(80))
+    s.check_bogus_field_returns_error(url, 'preprocess_subroutine', [])
+    s.check_bogus_field_returns_error(url, 'preprocess_subroutine', {})
+    s.check_bogus_field_returns_error(url, 'music_on_hold', 1234)
+    s.check_bogus_field_returns_error(url, 'music_on_hold', True)
+    s.check_bogus_field_returns_error(url, 'music_on_hold', s.random_string(129))
+    s.check_bogus_field_returns_error(url, 'music_on_hold', [])
+    s.check_bogus_field_returns_error(url, 'music_on_hold', {})
+    s.check_bogus_field_returns_error(url, 'announce_only_user', 'invalid')
+    s.check_bogus_field_returns_error(url, 'announce_only_user', None)
+    s.check_bogus_field_returns_error(url, 'announce_only_user', [])
+    s.check_bogus_field_returns_error(url, 'announce_only_user', {})
+    s.check_bogus_field_returns_error(url, 'announce_join_leave', 'invalid')
+    s.check_bogus_field_returns_error(url, 'announce_join_leave', None)
+    s.check_bogus_field_returns_error(url, 'announce_join_leave', [])
+    s.check_bogus_field_returns_error(url, 'announce_join_leave', {})
+    s.check_bogus_field_returns_error(url, 'quiet_join_leave', 'invalid')
+    s.check_bogus_field_returns_error(url, 'quiet_join_leave', None)
+    s.check_bogus_field_returns_error(url, 'quiet_join_leave', [])
+    s.check_bogus_field_returns_error(url, 'quiet_join_leave', {})
+    s.check_bogus_field_returns_error(url, 'announce_user_count', 'invalid')
+    s.check_bogus_field_returns_error(url, 'announce_user_count', None)
+    s.check_bogus_field_returns_error(url, 'announce_user_count', [])
+    s.check_bogus_field_returns_error(url, 'announce_user_count', {})
+    s.check_bogus_field_returns_error(url, 'record', 'invalid')
+    s.check_bogus_field_returns_error(url, 'record', None)
+    s.check_bogus_field_returns_error(url, 'record', [])
+    s.check_bogus_field_returns_error(url, 'record', {})
+    s.check_bogus_field_returns_error(url, 'pin', 'invalid')
+    s.check_bogus_field_returns_error(url, 'pin', [])
+    s.check_bogus_field_returns_error(url, 'pin', {})
+    s.check_bogus_field_returns_error(url, 'admin_pin', 'invalid')
+    s.check_bogus_field_returns_error(url, 'admin_pin', [])
+    s.check_bogus_field_returns_error(url, 'admin_pin', {})
 
 
 @fixtures.extension(exten=gen_conference_exten())
@@ -104,12 +100,12 @@ def test_search(extension, conference, hidden):
     searches = {'name': 'search', 'preprocess_subroutine': 'search'}
 
     for field, term in searches.items():
-        yield check_search, url, conference, hidden, field, term
+        check_search(url, conference, hidden, field, term)
 
     searches = {'exten': extension['exten']}
     with a.conference_extension(conference, extension):
         for field, term in searches.items():
-            yield check_relation_search, url, conference, hidden, field, term
+            check_relation_search(url, conference, hidden, field, term)
 
 
 def check_search(url, conference, hidden, field, term):
@@ -149,10 +145,10 @@ def test_list_multi_tenant(main, sub):
 @fixtures.conference(name='sort2')
 def test_sorting_offset_limit(conference1, conference2):
     url = confd.conferences.get
-    yield s.check_sorting, url, conference1, conference2, 'name', 'sort'
+    s.check_sorting(url, conference1, conference2, 'name', 'sort')
 
-    yield s.check_offset, url, conference1, conference2, 'name', 'sort'
-    yield s.check_limit, url, conference1, conference2, 'name', 'sort'
+    s.check_offset(url, conference1, conference2, 'name', 'sort')
+    s.check_limit(url, conference1, conference2, 'name', 'sort')
 
 
 @fixtures.conference()
@@ -341,10 +337,8 @@ def test_delete_multi_tenant(main, sub):
 def test_bus_events(conference):
     headers = {'tenant_uuid': MAIN_TENANT}
 
-    yield s.check_event, 'conference_created', headers, confd.conferences.post
-    yield s.check_event, 'conference_edited', headers, confd.conferences(
-        conference['id']
-    ).put
-    yield s.check_event, 'conference_deleted', headers, confd.conferences(
-        conference['id']
-    ).delete
+    s.check_event('conference_created', headers, confd.conferences.post)
+    s.check_event('conference_edited', headers, confd.conferences(conference['id']).put)
+    s.check_event(
+        'conference_deleted', headers, confd.conferences(conference['id']).delete
+    )

--- a/integration_tests/suite/base/test_configuration.py
+++ b/integration_tests/suite/base/test_configuration.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2021 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import assert_that
@@ -11,16 +11,15 @@ from ..helpers.config import TOKEN_SUB_TENANT
 def test_put_errors():
     url = confd.configuration.live_reload.put
 
-    for check in error_checks(url):
-        yield check
+    error_checks(url)
 
 
 def error_checks(url):
-    yield s.check_bogus_field_returns_error, url, 'enabled', 1
-    yield s.check_bogus_field_returns_error, url, 'enabled', None
-    yield s.check_bogus_field_returns_error, url, 'enabled', 'string'
-    yield s.check_bogus_field_returns_error, url, 'enabled', []
-    yield s.check_bogus_field_returns_error, url, 'enabled', {}
+    s.check_bogus_field_returns_error(url, 'enabled', 1)
+    s.check_bogus_field_returns_error(url, 'enabled', None)
+    s.check_bogus_field_returns_error(url, 'enabled', 'string')
+    s.check_bogus_field_returns_error(url, 'enabled', [])
+    s.check_bogus_field_returns_error(url, 'enabled', {})
 
 
 def test_live_reload_true():

--- a/integration_tests/suite/base/test_context_context.py
+++ b/integration_tests/suite/base/test_context_context.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import assert_that, contains, empty, has_entries
@@ -15,24 +15,23 @@ def test_associate_errors(context):
     response.assert_status(404)
 
     url = confd.contexts(context['id']).contexts().put
-    for check in error_checks(url):
-        yield check
+    error_checks(url)
 
 
 def error_checks(url):
-    yield s.check_bogus_field_returns_error, url, 'contexts', 123
-    yield s.check_bogus_field_returns_error, url, 'contexts', None
-    yield s.check_bogus_field_returns_error, url, 'contexts', True
-    yield s.check_bogus_field_returns_error, url, 'contexts', 'string'
-    yield s.check_bogus_field_returns_error, url, 'contexts', [123]
-    yield s.check_bogus_field_returns_error, url, 'contexts', [None]
-    yield s.check_bogus_field_returns_error, url, 'contexts', ['string']
-    yield s.check_bogus_field_returns_error, url, 'contexts', [{}]
-    yield s.check_bogus_field_returns_error, url, 'contexts', [{'id': None}]
-    yield s.check_bogus_field_returns_error, url, 'contexts', [{'id': 'string'}]
-    yield s.check_bogus_field_returns_error, url, 'contexts', [{'id': 1}, {'id': None}]
-    yield s.check_bogus_field_returns_error, url, 'contexts', [{'not_id': 123}]
-    yield s.check_bogus_field_returns_error, url, 'contexts', [{'id': FAKE_ID}]
+    s.check_bogus_field_returns_error(url, 'contexts', 123)
+    s.check_bogus_field_returns_error(url, 'contexts', None)
+    s.check_bogus_field_returns_error(url, 'contexts', True)
+    s.check_bogus_field_returns_error(url, 'contexts', 'string')
+    s.check_bogus_field_returns_error(url, 'contexts', [123])
+    s.check_bogus_field_returns_error(url, 'contexts', [None])
+    s.check_bogus_field_returns_error(url, 'contexts', ['string'])
+    s.check_bogus_field_returns_error(url, 'contexts', [{}])
+    s.check_bogus_field_returns_error(url, 'contexts', [{'id': None}])
+    s.check_bogus_field_returns_error(url, 'contexts', [{'id': 'string'}])
+    s.check_bogus_field_returns_error(url, 'contexts', [{'id': 1}, {'id': None}])
+    s.check_bogus_field_returns_error(url, 'contexts', [{'not_id': 123}])
+    s.check_bogus_field_returns_error(url, 'contexts', [{'id': FAKE_ID}])
 
 
 @fixtures.context()
@@ -124,7 +123,7 @@ def test_delete_context_when_context_and_sub_context_associated(
         confd.contexts(context['id']).delete().assert_deleted()
 
         deleted_context = confd.contexts(context['id']).get
-        yield s.check_resource_not_found, deleted_context, 'Context'
+        s.check_resource_not_found(deleted_context, 'Context')
 
 
 @fixtures.context()
@@ -139,10 +138,10 @@ def test_delete_sub_context_when_context_and_sub_context_associated(
         confd.contexts(sub_context['id']).delete().assert_deleted()
 
         deleted_sub_context = confd.contexts(sub_context['id']).get
-        yield s.check_resource_not_found, deleted_sub_context, 'Context'
+        s.check_resource_not_found(deleted_sub_context, 'Context')
 
         response = confd.contexts(context1['id']).get()
-        yield assert_that, response.item['contexts'], empty()
+        assert_that(response.item['contexts'], empty())
 
         response = confd.contexts(context2['id']).get()
-        yield assert_that, response.item['contexts'], empty()
+        assert_that(response.item['contexts'], empty())

--- a/integration_tests/suite/base/test_context_range.py
+++ b/integration_tests/suite/base/test_context_range.py
@@ -321,7 +321,7 @@ def test_search_order(context):
 @fixtures.context()
 def test_search_errors(context):
     fake_context_range = confd.contexts(999999).ranges('user').get
-    yield s.check_resource_not_found, fake_context_range, 'Context'
+    s.check_resource_not_found(fake_context_range, 'Context')
 
     response = confd.contexts(context['id']).ranges('unknown').get()
     response.assert_status(404)

--- a/integration_tests/suite/base/test_contexts.py
+++ b/integration_tests/suite/base/test_contexts.py
@@ -23,157 +23,145 @@ from ..helpers.config import MAIN_TENANT, SUB_TENANT, ALL_TENANTS, DELETED_TENAN
 
 def test_get_errors():
     fake_context = confd.contexts(999999).get
-    yield s.check_resource_not_found, fake_context, 'Context'
+    s.check_resource_not_found(fake_context, 'Context')
 
 
 def test_delete_errors():
     fake_context = confd.contexts(999999).delete
-    yield s.check_resource_not_found, fake_context, 'Context'
+    s.check_resource_not_found(fake_context, 'Context')
 
 
 def test_post_errors():
     url = confd.contexts.post
-    for check in error_checks(url):
-        yield check
+    error_checks(url)
 
-    yield s.check_bogus_field_returns_error, url, 'label', 123
-    yield s.check_bogus_field_returns_error, url, 'label', True
-    yield s.check_bogus_field_returns_error, url, 'label', None
-    yield s.check_bogus_field_returns_error, url, 'label', ''
-    yield s.check_bogus_field_returns_error, url, 'label', s.random_string(129)
-    yield s.check_bogus_field_returns_error, url, 'label', []
-    yield s.check_bogus_field_returns_error, url, 'label', {}
+    s.check_bogus_field_returns_error(url, 'label', 123)
+    s.check_bogus_field_returns_error(url, 'label', True)
+    s.check_bogus_field_returns_error(url, 'label', None)
+    s.check_bogus_field_returns_error(url, 'label', '')
+    s.check_bogus_field_returns_error(url, 'label', s.random_string(129))
+    s.check_bogus_field_returns_error(url, 'label', [])
+    s.check_bogus_field_returns_error(url, 'label', {})
 
-    yield s.check_bogus_field_returns_error, url, 'name', 123, None, 'label'
-    yield s.check_bogus_field_returns_error, url, 'name', True, None, 'label'
-    yield s.check_bogus_field_returns_error, url, 'name', None, None, 'label'
-    yield s.check_bogus_field_returns_error, url, 'name', '', None, 'label'
-    yield s.check_bogus_field_returns_error, url, 'name', s.random_string(
-        129
-    ), None, 'label'
-    yield s.check_bogus_field_returns_error, url, 'name', [], None, 'label'
-    yield s.check_bogus_field_returns_error, url, 'name', {}, None, 'label'
+    s.check_bogus_field_returns_error(url, 'name', 123, None, 'label')
+    s.check_bogus_field_returns_error(url, 'name', True, None, 'label')
+    s.check_bogus_field_returns_error(url, 'name', None, None, 'label')
+    s.check_bogus_field_returns_error(url, 'name', '', None, 'label')
+    s.check_bogus_field_returns_error(url, 'name', s.random_string(129), None, 'label')
+    s.check_bogus_field_returns_error(url, 'name', [], None, 'label')
+    s.check_bogus_field_returns_error(url, 'name', {}, None, 'label')
 
 
 @fixtures.context()
 def test_put_errors(context):
     url = confd.contexts(context['id']).put
-    for check in error_checks(url):
-        yield check
+    error_checks(url)
 
 
 def error_checks(url):
-    yield s.check_bogus_field_returns_error, url, 'label', 123
-    yield s.check_bogus_field_returns_error, url, 'label', True
-    yield s.check_bogus_field_returns_error, url, 'label', s.random_string(129)
-    yield s.check_bogus_field_returns_error, url, 'label', []
-    yield s.check_bogus_field_returns_error, url, 'label', {}
-    yield s.check_bogus_field_returns_error, url, 'name', 123, None, 'label'
-    yield s.check_bogus_field_returns_error, url, 'name', True, None, 'label'
-    yield s.check_bogus_field_returns_error, url, 'name', s.random_string(
-        129
-    ), None, 'label'
-    yield s.check_bogus_field_returns_error, url, 'name', [], None, 'label'
-    yield s.check_bogus_field_returns_error, url, 'name', {}, None, 'label'
-    yield s.check_bogus_field_returns_error, url, 'type', 123
-    yield s.check_bogus_field_returns_error, url, 'type', 'invalid'
-    yield s.check_bogus_field_returns_error, url, 'type', True
-    yield s.check_bogus_field_returns_error, url, 'type', None
-    yield s.check_bogus_field_returns_error, url, 'type', []
-    yield s.check_bogus_field_returns_error, url, 'type', {}
-    yield s.check_bogus_field_returns_error, url, 'description', 1234
-    yield s.check_bogus_field_returns_error, url, 'description', []
-    yield s.check_bogus_field_returns_error, url, 'description', {}
-    yield s.check_bogus_field_returns_error, url, 'enabled', 'invalid'
-    yield s.check_bogus_field_returns_error, url, 'enabled', None
-    yield s.check_bogus_field_returns_error, url, 'enabled', []
-    yield s.check_bogus_field_returns_error, url, 'enabled', {}
-    yield s.check_bogus_field_returns_error, url, 'user_ranges', 123
-    yield s.check_bogus_field_returns_error, url, 'user_ranges', 'invalid'
-    yield s.check_bogus_field_returns_error, url, 'user_ranges', True
-    yield s.check_bogus_field_returns_error, url, 'user_ranges', None
-    yield s.check_bogus_field_returns_error, url, 'user_ranges', {}
-    yield s.check_bogus_field_returns_error, url, 'user_ranges', ['1234']
-    yield s.check_bogus_field_returns_error, url, 'user_ranges', [{'end': '1234'}]
-    yield s.check_bogus_field_returns_error, url, 'user_ranges', [{'start': None}]
-    yield s.check_bogus_field_returns_error, url, 'user_ranges', [
-        {'start': '60', 'end': '50'}
-    ]
-    yield s.check_bogus_field_returns_error, url, 'user_ranges', [
-        {'start': '50', 'end': '060'}
-    ]
-    yield s.check_bogus_field_returns_error, url, 'user_ranges', [{'start': 'invalid'}]
-    yield s.check_bogus_field_returns_error, url, 'group_ranges', 123
-    yield s.check_bogus_field_returns_error, url, 'group_ranges', 'invalid'
-    yield s.check_bogus_field_returns_error, url, 'group_ranges', True
-    yield s.check_bogus_field_returns_error, url, 'group_ranges', None
-    yield s.check_bogus_field_returns_error, url, 'group_ranges', {}
-    yield s.check_bogus_field_returns_error, url, 'group_ranges', ['1234']
-    yield s.check_bogus_field_returns_error, url, 'group_ranges', [{'end': '1234'}]
-    yield s.check_bogus_field_returns_error, url, 'group_ranges', [{'start': None}]
-    yield s.check_bogus_field_returns_error, url, 'group_ranges', [
-        {'start': '60', 'end': '50'}
-    ]
-    yield s.check_bogus_field_returns_error, url, 'group_ranges', [
-        {'start': '50', 'end': '060'}
-    ]
-    yield s.check_bogus_field_returns_error, url, 'group_ranges', [{'start': 'invalid'}]
-    yield s.check_bogus_field_returns_error, url, 'queue_ranges', 123
-    yield s.check_bogus_field_returns_error, url, 'queue_ranges', 'invalid'
-    yield s.check_bogus_field_returns_error, url, 'queue_ranges', True
-    yield s.check_bogus_field_returns_error, url, 'queue_ranges', None
-    yield s.check_bogus_field_returns_error, url, 'queue_ranges', {}
-    yield s.check_bogus_field_returns_error, url, 'queue_ranges', ['1234']
-    yield s.check_bogus_field_returns_error, url, 'queue_ranges', [{'end': '1234'}]
-    yield s.check_bogus_field_returns_error, url, 'queue_ranges', [{'start': None}]
-    yield s.check_bogus_field_returns_error, url, 'queue_ranges', [
-        {'start': '60', 'end': '50'}
-    ]
-    yield s.check_bogus_field_returns_error, url, 'queue_ranges', [
-        {'start': '50', 'end': '060'}
-    ]
-    yield s.check_bogus_field_returns_error, url, 'queue_ranges', [{'start': 'invalid'}]
-    yield s.check_bogus_field_returns_error, url, 'conference_room_ranges', 123
-    yield s.check_bogus_field_returns_error, url, 'conference_room_ranges', 'invalid'
-    yield s.check_bogus_field_returns_error, url, 'conference_room_ranges', True
-    yield s.check_bogus_field_returns_error, url, 'conference_room_ranges', None
-    yield s.check_bogus_field_returns_error, url, 'conference_room_ranges', {}
-    yield s.check_bogus_field_returns_error, url, 'conference_room_ranges', ['1234']
-    yield s.check_bogus_field_returns_error, url, 'conference_room_ranges', [
-        {'end': '1234'}
-    ]
-    yield s.check_bogus_field_returns_error, url, 'conference_room_ranges', [
-        {'start': None}
-    ]
-    yield s.check_bogus_field_returns_error, url, 'conference_room_ranges', [
-        {'start': '60', 'end': '50'}
-    ]
-    yield s.check_bogus_field_returns_error, url, 'conference_room_ranges', [
-        {'start': '50', 'end': '060'}
-    ]
-    yield s.check_bogus_field_returns_error, url, 'conference_room_ranges', [
-        {'start': 'invalid'}
-    ]
-    yield s.check_bogus_field_returns_error, url, 'incall_ranges', 123
-    yield s.check_bogus_field_returns_error, url, 'incall_ranges', 'invalid'
-    yield s.check_bogus_field_returns_error, url, 'incall_ranges', True
-    yield s.check_bogus_field_returns_error, url, 'incall_ranges', None
-    yield s.check_bogus_field_returns_error, url, 'incall_ranges', {}
-    yield s.check_bogus_field_returns_error, url, 'incall_ranges', ['1234']
-    yield s.check_bogus_field_returns_error, url, 'incall_ranges', [{'end': '1234'}]
-    yield s.check_bogus_field_returns_error, url, 'incall_ranges', [{'start': None}]
-    yield s.check_bogus_field_returns_error, url, 'incall_ranges', [
-        {'start': '60', 'end': '50'}
-    ]
-    yield s.check_bogus_field_returns_error, url, 'incall_ranges', [
-        {'start': '50', 'end': '060'}
-    ]
-    yield s.check_bogus_field_returns_error, url, 'incall_ranges', [
-        {'start': 'invalid'}
-    ]
-    yield s.check_bogus_field_returns_error, url, 'incall_ranges', [
-        {'start': '123', 'did_length': None}
-    ]
+    s.check_bogus_field_returns_error(url, 'label', 123)
+    s.check_bogus_field_returns_error(url, 'label', True)
+    s.check_bogus_field_returns_error(url, 'label', s.random_string(129))
+    s.check_bogus_field_returns_error(url, 'label', [])
+    s.check_bogus_field_returns_error(url, 'label', {})
+    s.check_bogus_field_returns_error(url, 'name', 123, None, 'label')
+    s.check_bogus_field_returns_error(url, 'name', True, None, 'label')
+    s.check_bogus_field_returns_error(url, 'name', s.random_string(129), None, 'label')
+    s.check_bogus_field_returns_error(url, 'name', [], None, 'label')
+    s.check_bogus_field_returns_error(url, 'name', {}, None, 'label')
+    s.check_bogus_field_returns_error(url, 'type', 123)
+    s.check_bogus_field_returns_error(url, 'type', 'invalid')
+    s.check_bogus_field_returns_error(url, 'type', True)
+    s.check_bogus_field_returns_error(url, 'type', None)
+    s.check_bogus_field_returns_error(url, 'type', [])
+    s.check_bogus_field_returns_error(url, 'type', {})
+    s.check_bogus_field_returns_error(url, 'description', 1234)
+    s.check_bogus_field_returns_error(url, 'description', [])
+    s.check_bogus_field_returns_error(url, 'description', {})
+    s.check_bogus_field_returns_error(url, 'enabled', 'invalid')
+    s.check_bogus_field_returns_error(url, 'enabled', None)
+    s.check_bogus_field_returns_error(url, 'enabled', [])
+    s.check_bogus_field_returns_error(url, 'enabled', {})
+    s.check_bogus_field_returns_error(url, 'user_ranges', 123)
+    s.check_bogus_field_returns_error(url, 'user_ranges', 'invalid')
+    s.check_bogus_field_returns_error(url, 'user_ranges', True)
+    s.check_bogus_field_returns_error(url, 'user_ranges', None)
+    s.check_bogus_field_returns_error(url, 'user_ranges', {})
+    s.check_bogus_field_returns_error(url, 'user_ranges', ['1234'])
+    s.check_bogus_field_returns_error(url, 'user_ranges', [{'end': '1234'}])
+    s.check_bogus_field_returns_error(url, 'user_ranges', [{'start': None}])
+    s.check_bogus_field_returns_error(
+        url, 'user_ranges', [{'start': '60', 'end': '50'}]
+    )
+    s.check_bogus_field_returns_error(
+        url, 'user_ranges', [{'start': '50', 'end': '060'}]
+    )
+    s.check_bogus_field_returns_error(url, 'user_ranges', [{'start': 'invalid'}])
+    s.check_bogus_field_returns_error(url, 'group_ranges', 123)
+    s.check_bogus_field_returns_error(url, 'group_ranges', 'invalid')
+    s.check_bogus_field_returns_error(url, 'group_ranges', True)
+    s.check_bogus_field_returns_error(url, 'group_ranges', None)
+    s.check_bogus_field_returns_error(url, 'group_ranges', {})
+    s.check_bogus_field_returns_error(url, 'group_ranges', ['1234'])
+    s.check_bogus_field_returns_error(url, 'group_ranges', [{'end': '1234'}])
+    s.check_bogus_field_returns_error(url, 'group_ranges', [{'start': None}])
+    s.check_bogus_field_returns_error(
+        url, 'group_ranges', [{'start': '60', 'end': '50'}]
+    )
+    s.check_bogus_field_returns_error(
+        url, 'group_ranges', [{'start': '50', 'end': '060'}]
+    )
+    s.check_bogus_field_returns_error(url, 'group_ranges', [{'start': 'invalid'}])
+    s.check_bogus_field_returns_error(url, 'queue_ranges', 123)
+    s.check_bogus_field_returns_error(url, 'queue_ranges', 'invalid')
+    s.check_bogus_field_returns_error(url, 'queue_ranges', True)
+    s.check_bogus_field_returns_error(url, 'queue_ranges', None)
+    s.check_bogus_field_returns_error(url, 'queue_ranges', {})
+    s.check_bogus_field_returns_error(url, 'queue_ranges', ['1234'])
+    s.check_bogus_field_returns_error(url, 'queue_ranges', [{'end': '1234'}])
+    s.check_bogus_field_returns_error(url, 'queue_ranges', [{'start': None}])
+    s.check_bogus_field_returns_error(
+        url, 'queue_ranges', [{'start': '60', 'end': '50'}]
+    )
+    s.check_bogus_field_returns_error(
+        url, 'queue_ranges', [{'start': '50', 'end': '060'}]
+    )
+    s.check_bogus_field_returns_error(url, 'queue_ranges', [{'start': 'invalid'}])
+    s.check_bogus_field_returns_error(url, 'conference_room_ranges', 123)
+    s.check_bogus_field_returns_error(url, 'conference_room_ranges', 'invalid')
+    s.check_bogus_field_returns_error(url, 'conference_room_ranges', True)
+    s.check_bogus_field_returns_error(url, 'conference_room_ranges', None)
+    s.check_bogus_field_returns_error(url, 'conference_room_ranges', {})
+    s.check_bogus_field_returns_error(url, 'conference_room_ranges', ['1234'])
+    s.check_bogus_field_returns_error(url, 'conference_room_ranges', [{'end': '1234'}])
+    s.check_bogus_field_returns_error(url, 'conference_room_ranges', [{'start': None}])
+    s.check_bogus_field_returns_error(
+        url, 'conference_room_ranges', [{'start': '60', 'end': '50'}]
+    )
+    s.check_bogus_field_returns_error(
+        url, 'conference_room_ranges', [{'start': '50', 'end': '060'}]
+    )
+    s.check_bogus_field_returns_error(
+        url, 'conference_room_ranges', [{'start': 'invalid'}]
+    )
+    s.check_bogus_field_returns_error(url, 'incall_ranges', 123)
+    s.check_bogus_field_returns_error(url, 'incall_ranges', 'invalid')
+    s.check_bogus_field_returns_error(url, 'incall_ranges', True)
+    s.check_bogus_field_returns_error(url, 'incall_ranges', None)
+    s.check_bogus_field_returns_error(url, 'incall_ranges', {})
+    s.check_bogus_field_returns_error(url, 'incall_ranges', ['1234'])
+    s.check_bogus_field_returns_error(url, 'incall_ranges', [{'end': '1234'}])
+    s.check_bogus_field_returns_error(url, 'incall_ranges', [{'start': None}])
+    s.check_bogus_field_returns_error(
+        url, 'incall_ranges', [{'start': '60', 'end': '50'}]
+    )
+    s.check_bogus_field_returns_error(
+        url, 'incall_ranges', [{'start': '50', 'end': '060'}]
+    )
+    s.check_bogus_field_returns_error(url, 'incall_ranges', [{'start': 'invalid'}])
+    s.check_bogus_field_returns_error(
+        url, 'incall_ranges', [{'start': '123', 'did_length': None}]
+    )
 
 
 @fixtures.context(
@@ -195,7 +183,7 @@ def test_search(context, hidden):
     }
 
     for field, term in searches.items():
-        yield check_search, url, context, hidden, field, term
+        check_search(url, context, hidden, field, term)
 
 
 def check_search(url, context, hidden, field, term):
@@ -225,11 +213,11 @@ def test_list_multi_tenant(main, sub):
 @fixtures.context(label='sort2', description='sort2')
 def test_sorting_offset_limit(context1, context2):
     url = confd.contexts.get
-    yield s.check_sorting, url, context1, context2, 'label', 'sort'
-    yield s.check_sorting, url, context1, context2, 'description', 'sort'
+    s.check_sorting(url, context1, context2, 'label', 'sort')
+    s.check_sorting(url, context1, context2, 'description', 'sort')
 
-    yield s.check_offset, url, context1, context2, 'label', 'sort'
-    yield s.check_limit, url, context1, context2, 'label', 'sort'
+    s.check_offset(url, context1, context2, 'label', 'sort')
+    s.check_limit(url, context1, context2, 'label', 'sort')
 
 
 @fixtures.context()
@@ -366,13 +354,11 @@ def test_delete_when_agent_is_logged(context):
 def test_bus_events(context):
     headers = {'tenant_uuid': MAIN_TENANT}
 
-    yield s.check_event, 'context_created', headers, confd.contexts.post, {
-        'name': 'bus_event'
-    }
-    yield s.check_event, 'context_edited', headers, confd.contexts(context['id']).put
-    yield s.check_event, 'context_deleted', headers, confd.contexts(
-        context['id']
-    ).delete
+    s.check_event(
+        'context_created', headers, confd.contexts.post, {'name': 'bus_event'}
+    )
+    s.check_event('context_edited', headers, confd.contexts(context['id']).put)
+    s.check_event('context_deleted', headers, confd.contexts(context['id']).delete)
 
 
 def test_create_contexts_parallel():

--- a/integration_tests/suite/base/test_devices.py
+++ b/integration_tests/suite/base/test_devices.py
@@ -193,15 +193,15 @@ def test_list_device_no_config(dev1, dev2):
 )
 def test_sorting_offset_limit(device1, device2):
     url = confd.devices.get
-    s.check_sorting(url, device1, device2, 'ip', '99.')
-    s.check_sorting(url, device1, device2, 'model', 'SortModel')
-    s.check_sorting(url, device1, device2, 'sn', 'SortSn')
-    s.check_sorting(url, device1, device2, 'vendor', 'SortVendor')
-    s.check_sorting(url, device1, device2, 'version', '1.')
-    s.check_sorting(url, device1, device2, 'description', 'SortDesc')
+    s.check_sorting(url, device1, device2, 'ip', 'Sort')
+    s.check_sorting(url, device1, device2, 'model', 'Sort')
+    s.check_sorting(url, device1, device2, 'sn', 'Sort')
+    s.check_sorting(url, device1, device2, 'vendor', 'Sort')
+    s.check_sorting(url, device1, device2, 'version', 'Sort')
+    s.check_sorting(url, device1, device2, 'description', 'Sort')
 
-    s.check_offset(url, device1, device2, 'mac', 'aa:bb')
-    s.check_limit(url, device1, device2, 'mac', 'aa:bb')
+    s.check_offset(url, device1, device2, 'mac', 'Sort')
+    s.check_limit(url, device1, device2, 'mac', 'Sort')
 
 
 @fixtures.device()

--- a/integration_tests/suite/base/test_devices.py
+++ b/integration_tests/suite/base/test_devices.py
@@ -55,38 +55,35 @@ class TestDeviceCreateWithTemplate(unittest.TestCase):
 
 def test_search_errors():
     url = confd.devices.get
-    for check in s.search_error_checks(url):
-        yield check
+    s.search_error_checks(url)
 
 
 def test_get_errors():
     fake_get = confd.devices(999999).get
-    yield s.check_resource_not_found, fake_get, 'Device'
+    s.check_resource_not_found(fake_get, 'Device')
 
 
 def test_post_errors():
     url = confd.devices.post
-    for check in error_checks(url):
-        yield check
+    error_checks(url)
 
 
 @fixtures.device()
 def test_put_errors(device):
     url = confd.devices(device['id']).put
-    for check in error_checks(url):
-        yield check
+    error_checks(url)
 
 
 def error_checks(url):
-    yield s.check_bogus_field_returns_error, url, 'ip', 123
-    yield s.check_bogus_field_returns_error, url, 'ip', 'abcd1234'
-    yield s.check_bogus_field_returns_error, url, 'mac', 123
-    yield s.check_bogus_field_returns_error, url, 'mac', 'abcd1234'
-    yield s.check_bogus_field_returns_error, url, 'mac', 'abcd1234'
-    yield s.check_bogus_field_returns_error, url, 'plugin', 'invalidplugin'
-    yield s.check_bogus_field_returns_error, url, 'template_id', 'invalidtemplateid'
-    yield s.check_bogus_field_returns_error, url, 'options', 'invalidoption'
-    yield s.check_bogus_field_returns_error, url, 'options', {'switchboard': 'yes'}
+    s.check_bogus_field_returns_error(url, 'ip', 123)
+    s.check_bogus_field_returns_error(url, 'ip', 'abcd1234')
+    s.check_bogus_field_returns_error(url, 'mac', 123)
+    s.check_bogus_field_returns_error(url, 'mac', 'abcd1234')
+    s.check_bogus_field_returns_error(url, 'mac', 'abcd1234')
+    s.check_bogus_field_returns_error(url, 'plugin', 'invalidplugin')
+    s.check_bogus_field_returns_error(url, 'template_id', 'invalidtemplateid')
+    s.check_bogus_field_returns_error(url, 'options', 'invalidoption')
+    s.check_bogus_field_returns_error(url, 'options', {'switchboard': 'yes'})
 
 
 @fixtures.device(
@@ -123,7 +120,7 @@ def test_search(device, hidden):
     }
 
     for field, term in searches.items():
-        yield check_search, url, device, hidden, field, term
+        check_search(url, device, hidden, field, term)
 
 
 def check_search(url, device, hidden, field, term):
@@ -196,15 +193,15 @@ def test_list_device_no_config(dev1, dev2):
 )
 def test_sorting_offset_limit(device1, device2):
     url = confd.devices.get
-    yield s.check_sorting, url, device1, device2, 'ip', '99.'
-    yield s.check_sorting, url, device1, device2, 'model', 'SortModel'
-    yield s.check_sorting, url, device1, device2, 'sn', 'SortSn'
-    yield s.check_sorting, url, device1, device2, 'vendor', 'SortVendor'
-    yield s.check_sorting, url, device1, device2, 'version', '1.'
-    yield s.check_sorting, url, device1, device2, 'description', 'SortDesc'
+    s.check_sorting(url, device1, device2, 'ip', '99.')
+    s.check_sorting(url, device1, device2, 'model', 'SortModel')
+    s.check_sorting(url, device1, device2, 'sn', 'SortSn')
+    s.check_sorting(url, device1, device2, 'vendor', 'SortVendor')
+    s.check_sorting(url, device1, device2, 'version', '1.')
+    s.check_sorting(url, device1, device2, 'description', 'SortDesc')
 
-    yield s.check_offset, url, device1, device2, 'mac', 'aa:bb'
-    yield s.check_limit, url, device1, device2, 'mac', 'aa:bb'
+    s.check_offset(url, device1, device2, 'mac', 'aa:bb')
+    s.check_limit(url, device1, device2, 'mac', 'aa:bb')
 
 
 @fixtures.device()

--- a/integration_tests/suite/base/test_endpoint_custom.py
+++ b/integration_tests/suite/base/test_endpoint_custom.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import (
@@ -18,45 +18,41 @@ from ..helpers.config import MAIN_TENANT, SUB_TENANT
 
 def test_get_errors():
     fake_custom_get = confd.endpoints.custom(999999).get
-    yield s.check_resource_not_found, fake_custom_get, 'CustomEndpoint'
+    s.check_resource_not_found(fake_custom_get, 'CustomEndpoint')
 
 
 def test_delete_errors():
     fake_custom = confd.endpoints.custom(999999).delete
-    yield s.check_resource_not_found, fake_custom, 'CustomEndpoint'
+    s.check_resource_not_found(fake_custom, 'CustomEndpoint')
 
 
 def test_post_errors():
     url = confd.endpoints.custom.post
-    for check in error_checks(url):
-        yield check
+    error_checks(url)
 
 
 @fixtures.custom()
 def test_put_errors(custom):
     url = confd.endpoints.custom(custom['id']).put
 
-    for check in error_checks(url):
-        yield check
+    error_checks(url)
 
 
 def error_checks(url):
-    yield s.check_bogus_field_returns_error, url, 'interface', None
-    yield s.check_bogus_field_returns_error, url, 'interface', True
-    yield s.check_bogus_field_returns_error, url, 'interface', 'custom/&&&~~~'
-    yield s.check_bogus_field_returns_error, url, 'interface', s.random_string(129)
-    yield s.check_bogus_field_returns_error, url, 'interface', []
-    yield s.check_bogus_field_returns_error, url, 'interface', {}
-    yield s.check_bogus_field_returns_error, url, 'interface_suffix', True
-    yield s.check_bogus_field_returns_error, url, 'interface_suffix', s.random_string(
-        33
-    )
-    yield s.check_bogus_field_returns_error, url, 'interface_suffix', []
-    yield s.check_bogus_field_returns_error, url, 'interface_suffix', {}
-    yield s.check_bogus_field_returns_error, url, 'enabled', None
-    yield s.check_bogus_field_returns_error, url, 'enabled', 'string'
-    yield s.check_bogus_field_returns_error, url, 'enabled', []
-    yield s.check_bogus_field_returns_error, url, 'enabled', {}
+    s.check_bogus_field_returns_error(url, 'interface', None)
+    s.check_bogus_field_returns_error(url, 'interface', True)
+    s.check_bogus_field_returns_error(url, 'interface', 'custom/&&&~~~')
+    s.check_bogus_field_returns_error(url, 'interface', s.random_string(129))
+    s.check_bogus_field_returns_error(url, 'interface', [])
+    s.check_bogus_field_returns_error(url, 'interface', {})
+    s.check_bogus_field_returns_error(url, 'interface_suffix', True)
+    s.check_bogus_field_returns_error(url, 'interface_suffix', s.random_string(33))
+    s.check_bogus_field_returns_error(url, 'interface_suffix', [])
+    s.check_bogus_field_returns_error(url, 'interface_suffix', {})
+    s.check_bogus_field_returns_error(url, 'enabled', None)
+    s.check_bogus_field_returns_error(url, 'enabled', 'string')
+    s.check_bogus_field_returns_error(url, 'enabled', [])
+    s.check_bogus_field_returns_error(url, 'enabled', {})
 
 
 @fixtures.custom()

--- a/integration_tests/suite/base/test_endpoint_iax.py
+++ b/integration_tests/suite/base/test_endpoint_iax.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import (
@@ -69,68 +69,77 @@ ALL_OPTIONS = [
 
 def test_get_errors():
     fake_iax_get = confd.endpoints.iax(999999).get
-    yield s.check_resource_not_found, fake_iax_get, 'IAXEndpoint'
+    s.check_resource_not_found(fake_iax_get, 'IAXEndpoint')
 
 
 @fixtures.iax()
 def test_delete_errors(iax):
     fake_iax_delete = confd.endpoints.iax(999999).delete
-    yield s.check_resource_not_found, fake_iax_delete, 'IAXEndpoint'
+    s.check_resource_not_found(fake_iax_delete, 'IAXEndpoint')
 
 
 def test_post_errors():
     url = confd.endpoints.iax.post
-    for check in error_checks(url):
-        yield check
+    error_checks(url)
 
 
 @fixtures.iax()
 def test_put_errors(iax):
     url = confd.endpoints.iax(iax['id']).put
-    for check in error_checks(url):
-        yield check
+    error_checks(url)
 
 
 def error_checks(url):
-    yield s.check_bogus_field_returns_error, url, 'name', 123
-    yield s.check_bogus_field_returns_error, url, 'name', None
-    yield s.check_bogus_field_returns_error, url, 'name', ']^',
-    yield s.check_bogus_field_returns_error, url, 'name', 'ûsername'
-    yield s.check_bogus_field_returns_error, url, 'name', [],
-    yield s.check_bogus_field_returns_error, url, 'name', {},
-    yield s.check_bogus_field_returns_error, url, 'type', 123
-    yield s.check_bogus_field_returns_error, url, 'type', 'invalid_choice'
-    yield s.check_bogus_field_returns_error, url, 'type', True
-    yield s.check_bogus_field_returns_error, url, 'type', None
-    yield s.check_bogus_field_returns_error, url, 'type', []
-    yield s.check_bogus_field_returns_error, url, 'type', {}
-    yield s.check_bogus_field_returns_error, url, 'host', 123
-    yield s.check_bogus_field_returns_error, url, 'host', True
-    yield s.check_bogus_field_returns_error, url, 'host', None
-    yield s.check_bogus_field_returns_error, url, 'host', []
-    yield s.check_bogus_field_returns_error, url, 'host', {}
-    yield s.check_bogus_field_returns_error, url, 'options', 123
-    yield s.check_bogus_field_returns_error, url, 'options', None
-    yield s.check_bogus_field_returns_error, url, 'options', {}
-    yield s.check_bogus_field_returns_error, url, 'options', 'string'
-    yield s.check_bogus_field_returns_error, url, 'options', [None]
-    yield s.check_bogus_field_returns_error, url, 'options', ['string', 'string']
-    yield s.check_bogus_field_returns_error, url, 'options', [123, 123]
-    yield s.check_bogus_field_returns_error, url, 'options', ['string', 123]
-    yield s.check_bogus_field_returns_error, url, 'options', [[]]
-    yield s.check_bogus_field_returns_error, url, 'options', [{'key': 'value'}]
-    yield s.check_bogus_field_returns_error, url, 'options', [['missing_value']]
-    yield s.check_bogus_field_returns_error, url, 'options', [['too', 'much', 'value']]
-    yield s.check_bogus_field_returns_error, url, 'options', [['wrong_value', 1234]]
-    yield s.check_bogus_field_returns_error, url, 'options', [['none_value', None]]
+    s.check_bogus_field_returns_error(url, 'name', 123)
+    s.check_bogus_field_returns_error(url, 'name', None)
+    s.check_bogus_field_returns_error(
+        url,
+        'name',
+        ']^',
+    )
+    s.check_bogus_field_returns_error(url, 'name', 'ûsername')
+    s.check_bogus_field_returns_error(
+        url,
+        'name',
+        [],
+    )
+    s.check_bogus_field_returns_error(
+        url,
+        'name',
+        {},
+    )
+    s.check_bogus_field_returns_error(url, 'type', 123)
+    s.check_bogus_field_returns_error(url, 'type', 'invalid_choice')
+    s.check_bogus_field_returns_error(url, 'type', True)
+    s.check_bogus_field_returns_error(url, 'type', None)
+    s.check_bogus_field_returns_error(url, 'type', [])
+    s.check_bogus_field_returns_error(url, 'type', {})
+    s.check_bogus_field_returns_error(url, 'host', 123)
+    s.check_bogus_field_returns_error(url, 'host', True)
+    s.check_bogus_field_returns_error(url, 'host', None)
+    s.check_bogus_field_returns_error(url, 'host', [])
+    s.check_bogus_field_returns_error(url, 'host', {})
+    s.check_bogus_field_returns_error(url, 'options', 123)
+    s.check_bogus_field_returns_error(url, 'options', None)
+    s.check_bogus_field_returns_error(url, 'options', {})
+    s.check_bogus_field_returns_error(url, 'options', 'string')
+    s.check_bogus_field_returns_error(url, 'options', [None])
+    s.check_bogus_field_returns_error(url, 'options', ['string', 'string'])
+    s.check_bogus_field_returns_error(url, 'options', [123, 123])
+    s.check_bogus_field_returns_error(url, 'options', ['string', 123])
+    s.check_bogus_field_returns_error(url, 'options', [[]])
+    s.check_bogus_field_returns_error(url, 'options', [{'key': 'value'}])
+    s.check_bogus_field_returns_error(url, 'options', [['missing_value']])
+    s.check_bogus_field_returns_error(url, 'options', [['too', 'much', 'value']])
+    s.check_bogus_field_returns_error(url, 'options', [['wrong_value', 1234]])
+    s.check_bogus_field_returns_error(url, 'options', [['none_value', None]])
 
-    for check in unique_error_checks(url):
-        yield check
+    unique_error_checks(url)
 
 
 @fixtures.iax(name='unique')
 def unique_error_checks(url, iax):
-    yield s.check_bogus_field_returns_error, url, 'name', iax['name']
+    s.check_bogus_field_returns_error(url, 'name', iax['name'])
 
 
 @fixtures.iax()
@@ -167,7 +176,7 @@ def test_search(iax, hidden):
     searches = {'name': 'search', 'type': 'friend', 'host': 'search'}
 
     for field, term in searches.items():
-        yield check_search, url, iax, hidden, field, term
+        check_search(url, iax, hidden, field, term)
 
 
 def check_search(url, iax, hidden, field, term):
@@ -184,10 +193,10 @@ def check_search(url, iax, hidden, field, term):
 @fixtures.iax(name='sort2')
 def test_sorting_offset_limit(iax1, iax2):
     url = confd.endpoints.iax.get
-    yield s.check_sorting, url, iax1, iax2, 'name', 'sort'
+    s.check_sorting(url, iax1, iax2, 'name', 'sort')
 
-    yield s.check_offset, url, iax1, iax2, 'name', 'sort'
-    yield s.check_limit, url, iax1, iax2, 'name', 'sort'
+    s.check_offset(url, iax1, iax2, 'name', 'sort')
+    s.check_limit(url, iax1, iax2, 'name', 'sort')
 
 
 @fixtures.iax(wazo_tenant=MAIN_TENANT)

--- a/integration_tests/suite/base/test_endpoint_sccp.py
+++ b/integration_tests/suite/base/test_endpoint_sccp.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import (
@@ -26,42 +26,40 @@ ALL_OPTIONS = [
 
 def test_get_errors():
     fake_sccp_get = confd.endpoints.sccp(999999).get
-    yield s.check_resource_not_found, fake_sccp_get, 'SCCPEndpoint'
+    s.check_resource_not_found(fake_sccp_get, 'SCCPEndpoint')
 
 
 def test_delete_errors():
     fake_sccp = confd.endpoints.sccp(999999).delete
-    yield s.check_resource_not_found, fake_sccp, 'SCCPEndpoint'
+    s.check_resource_not_found(fake_sccp, 'SCCPEndpoint')
 
 
 def test_post_errors():
     url = confd.endpoints.sccp.post
-    for check in error_checks(url):
-        yield check
+    error_checks(url)
 
 
 @fixtures.sccp()
 def test_put_errors(sccp):
     url = confd.endpoints.sccp(sccp['id']).put
-    for check in error_checks(url):
-        yield check
+    error_checks(url)
 
 
 def error_checks(url):
-    yield s.check_bogus_field_returns_error, url, 'options', 123
-    yield s.check_bogus_field_returns_error, url, 'options', None
-    yield s.check_bogus_field_returns_error, url, 'options', {}
-    yield s.check_bogus_field_returns_error, url, 'options', 'string'
-    yield s.check_bogus_field_returns_error, url, 'options', [None]
-    yield s.check_bogus_field_returns_error, url, 'options', ['string', 'string']
-    yield s.check_bogus_field_returns_error, url, 'options', [123, 123]
-    yield s.check_bogus_field_returns_error, url, 'options', ['string', 123]
-    yield s.check_bogus_field_returns_error, url, 'options', [[]]
-    yield s.check_bogus_field_returns_error, url, 'options', [{'key': 'value'}]
-    yield s.check_bogus_field_returns_error, url, 'options', [['missing_value']]
-    yield s.check_bogus_field_returns_error, url, 'options', [['too', 'much', 'value']]
-    yield s.check_bogus_field_returns_error, url, 'options', [['wrong_value', 1234]]
-    yield s.check_bogus_field_returns_error, url, 'options', [['none_value', None]]
+    s.check_bogus_field_returns_error(url, 'options', 123)
+    s.check_bogus_field_returns_error(url, 'options', None)
+    s.check_bogus_field_returns_error(url, 'options', {})
+    s.check_bogus_field_returns_error(url, 'options', 'string')
+    s.check_bogus_field_returns_error(url, 'options', [None])
+    s.check_bogus_field_returns_error(url, 'options', ['string', 'string'])
+    s.check_bogus_field_returns_error(url, 'options', [123, 123])
+    s.check_bogus_field_returns_error(url, 'options', ['string', 123])
+    s.check_bogus_field_returns_error(url, 'options', [[]])
+    s.check_bogus_field_returns_error(url, 'options', [{'key': 'value'}])
+    s.check_bogus_field_returns_error(url, 'options', [['missing_value']])
+    s.check_bogus_field_returns_error(url, 'options', [['too', 'much', 'value']])
+    s.check_bogus_field_returns_error(url, 'options', [['wrong_value', 1234]])
+    s.check_bogus_field_returns_error(url, 'options', [['none_value', None]])
 
 
 @fixtures.sccp()

--- a/integration_tests/suite/base/test_endpoint_sip.py
+++ b/integration_tests/suite/base/test_endpoint_sip.py
@@ -35,40 +35,38 @@ FAKE_UUID = '99999999-9999-4999-9999-999999999999'
 
 def test_get_errors():
     fake_sip_get = confd.endpoints.sip(FAKE_UUID).get
-    yield s.check_resource_not_found, fake_sip_get, 'SIPEndpoint'
+    s.check_resource_not_found(fake_sip_get, 'SIPEndpoint')
 
 
 @fixtures.sip()
 def test_delete_errors(sip):
     url = confd.endpoints.sip(sip['uuid'])
     url.delete()
-    yield s.check_resource_not_found, url.get, 'SIPEndpoint'
+    s.check_resource_not_found(url.get, 'SIPEndpoint')
 
 
 def test_post_errors():
     url = confd.endpoints.sip.post
-    for check in error_checks(url):
-        yield check
+    error_checks(url)
 
 
 @fixtures.sip()
 def test_put_errors(sip):
     url = confd.endpoints.sip(sip['uuid']).put
-    for check in error_checks(url):
-        yield check
+    error_checks(url)
 
-    yield s.check_bogus_field_returns_error, url, 'name', None
+    s.check_bogus_field_returns_error(url, 'name', None)
 
 
 def error_checks(url):
-    yield s.check_bogus_field_returns_error, url, 'name', 42
-    yield s.check_bogus_field_returns_error, url, 'name', 'a' * 80
-    yield s.check_bogus_field_returns_error, url, 'name', 'global'
-    yield s.check_bogus_field_returns_error, url, 'name', 'system'
-    yield s.check_bogus_field_returns_error, url, 'transport', {'uuid': FAKE_UUID}
-    yield s.check_bogus_field_returns_error, url, 'aor_section_options', [
-        ['one', 'two', 'three']
-    ]
+    s.check_bogus_field_returns_error(url, 'name', 42)
+    s.check_bogus_field_returns_error(url, 'name', 'a' * 80)
+    s.check_bogus_field_returns_error(url, 'name', 'global')
+    s.check_bogus_field_returns_error(url, 'name', 'system')
+    s.check_bogus_field_returns_error(url, 'transport', {'uuid': FAKE_UUID})
+    s.check_bogus_field_returns_error(
+        url, 'aor_section_options', [['one', 'two', 'three']]
+    )
     sections = [
         ('aor_section_options', [['auth_type', 'invalid-key']]),
         ('auth_section_options', [['max_contacts', 'invalid-key']]),
@@ -90,19 +88,18 @@ def error_checks(url):
         ('outbound_auth_section_options', [['@custom_variable', 'invalid-key']]),
     ]
     for section, values in sections:
-        yield s.check_bogus_field_returns_error, url, section, values
+        s.check_bogus_field_returns_error(url, section, values)
 
-    for check in unique_error_checks(url):
-        yield check
+    unique_error_checks(url)
 
 
 @fixtures.transport(name='transport_unique')
 @fixtures.sip(name='endpoint_unique')
 @fixtures.sip_template(name='template_unique')
 def unique_error_checks(url, transport, sip, template):
-    yield s.check_bogus_field_returns_error, url, 'name', transport['name']
-    yield s.check_bogus_field_returns_error, url, 'name', template['name']
-    yield s.check_bogus_field_returns_error, url, 'name', sip['name']
+    s.check_bogus_field_returns_error(url, 'name', transport['name'])
+    s.check_bogus_field_returns_error(url, 'name', template['name'])
+    s.check_bogus_field_returns_error(url, 'name', sip['name'])
 
 
 @fixtures.sip(name='hidden', label='hidden', asterisk_id='hidden')
@@ -112,7 +109,7 @@ def test_search(hidden, sip):
     searches = {'name': 'search', 'label': 'search', 'asterisk_id': 'search'}
 
     for field, term in searches.items():
-        yield check_search, url, sip, hidden, field, term
+        check_search(url, sip, hidden, field, term)
 
 
 def check_search(url, sip, hidden, field, term):
@@ -166,11 +163,11 @@ def test_list_multi_tenant(main, sub):
 @fixtures.sip(name='sort2', label='sort2')
 def test_sorting_offset_limit(sip1, sip2):
     url = confd.endpoints.sip.get
-    yield s.check_sorting, url, sip1, sip2, 'name', 'sort', 'uuid'
-    yield s.check_sorting, url, sip1, sip2, 'label', 'sort', 'uuid'
+    s.check_sorting(url, sip1, sip2, 'name', 'sort', 'uuid')
+    s.check_sorting(url, sip1, sip2, 'label', 'sort', 'uuid')
 
-    yield s.check_offset, url, sip1, sip2, 'name', 'sort', 'uuid'
-    yield s.check_limit, url, sip1, sip2, 'name', 'sort', 'uuid'
+    s.check_offset(url, sip1, sip2, 'name', 'sort', 'uuid')
+    s.check_limit(url, sip1, sip2, 'name', 'sort', 'uuid')
 
 
 @fixtures.sip()
@@ -500,10 +497,8 @@ def test_delete_multi_tenant(main, sub):
 def test_bus_events(sip):
     headers = {'tenant_uuid': MAIN_TENANT}
 
-    yield s.check_event, 'sip_endpoint_created', headers, confd.endpoints.sip.post
-    yield s.check_event, 'sip_endpoint_edited', headers, confd.endpoints.sip(
-        sip['uuid']
-    ).put
-    yield s.check_event, 'sip_endpoint_deleted', headers, confd.endpoints.sip(
-        sip['uuid']
-    ).delete
+    s.check_event('sip_endpoint_created', headers, confd.endpoints.sip.post)
+    s.check_event('sip_endpoint_edited', headers, confd.endpoints.sip(sip['uuid']).put)
+    s.check_event(
+        'sip_endpoint_deleted', headers, confd.endpoints.sip(sip['uuid']).delete
+    )

--- a/integration_tests/suite/base/test_endpoint_sip_templates.py
+++ b/integration_tests/suite/base/test_endpoint_sip_templates.py
@@ -31,40 +31,38 @@ FAKE_UUID = '99999999-9999-4999-9999-999999999999'
 
 def test_get_errors():
     fake_sip_get = confd.endpoints.sip.templates(FAKE_UUID).get
-    yield s.check_resource_not_found, fake_sip_get, 'SIPEndpointTemplate'
+    s.check_resource_not_found(fake_sip_get, 'SIPEndpointTemplate')
 
 
 @fixtures.sip_template()
 def test_delete_errors(sip):
     url = confd.endpoints.sip.templates(sip['uuid'])
     url.delete()
-    yield s.check_resource_not_found, url.get, 'SIPEndpointTemplate'
+    s.check_resource_not_found(url.get, 'SIPEndpointTemplate')
 
 
 def test_post_errors():
     url = confd.endpoints.sip.templates.post
-    for check in error_checks(url):
-        yield check
+    error_checks(url)
 
 
 @fixtures.sip_template()
 def test_put_errors(sip):
     url = confd.endpoints.sip.templates(sip['uuid']).put
-    for check in error_checks(url):
-        yield check
+    error_checks(url)
 
-    yield s.check_bogus_field_returns_error, url, 'name', None
+    s.check_bogus_field_returns_error(url, 'name', None)
 
 
 def error_checks(url):
-    yield s.check_bogus_field_returns_error, url, 'name', 42
-    yield s.check_bogus_field_returns_error, url, 'name', 'a' * 80
-    yield s.check_bogus_field_returns_error, url, 'name', 'global'
-    yield s.check_bogus_field_returns_error, url, 'name', 'system'
-    yield s.check_bogus_field_returns_error, url, 'transport', {'uuid': FAKE_UUID}
-    yield s.check_bogus_field_returns_error, url, 'aor_section_options', [
-        ['one', 'two', 'three']
-    ]
+    s.check_bogus_field_returns_error(url, 'name', 42)
+    s.check_bogus_field_returns_error(url, 'name', 'a' * 80)
+    s.check_bogus_field_returns_error(url, 'name', 'global')
+    s.check_bogus_field_returns_error(url, 'name', 'system')
+    s.check_bogus_field_returns_error(url, 'transport', {'uuid': FAKE_UUID})
+    s.check_bogus_field_returns_error(
+        url, 'aor_section_options', [['one', 'two', 'three']]
+    )
     sections = [
         ('aor_section_options', [['auth_type', 'invalid-key']]),
         ('auth_section_options', [['max_contacts', 'invalid-key']]),
@@ -86,19 +84,18 @@ def error_checks(url):
         ('outbound_auth_section_options', [['@custom_variable', 'invalid-key']]),
     ]
     for section, values in sections:
-        yield s.check_bogus_field_returns_error, url, section, values
+        s.check_bogus_field_returns_error(url, section, values)
 
-    for check in unique_error_checks(url):
-        yield check
+    unique_error_checks(url)
 
 
 @fixtures.transport(name='transport_unique')
 @fixtures.sip(name='endpoint_unique')
 @fixtures.sip_template(name='template_unique')
 def unique_error_checks(url, transport, sip, template):
-    yield s.check_bogus_field_returns_error, url, 'name', transport['name']
-    yield s.check_bogus_field_returns_error, url, 'name', template['name']
-    yield s.check_bogus_field_returns_error, url, 'name', sip['name']
+    s.check_bogus_field_returns_error(url, 'name', transport['name'])
+    s.check_bogus_field_returns_error(url, 'name', template['name'])
+    s.check_bogus_field_returns_error(url, 'name', sip['name'])
 
 
 @fixtures.sip_template()
@@ -125,7 +122,7 @@ def test_search(hidden, sip):
     searches = {'name': 'search', 'label': 'search', 'asterisk_id': 'search'}
 
     for field, term in searches.items():
-        yield check_search, url, sip, hidden, field, term
+        check_search(url, sip, hidden, field, term)
 
 
 def check_search(url, template, hidden, field, term):
@@ -181,11 +178,11 @@ def test_list_multi_tenant(main, sub):
 @fixtures.sip_template(name='sort2', label='sort2')
 def test_sorting_offset_limit(sip1, sip2):
     url = confd.endpoints.sip.templates.get
-    yield s.check_sorting, url, sip1, sip2, 'name', 'sort', 'uuid'
-    yield s.check_sorting, url, sip1, sip2, 'label', 'sort', 'uuid'
+    s.check_sorting(url, sip1, sip2, 'name', 'sort', 'uuid')
+    s.check_sorting(url, sip1, sip2, 'label', 'sort', 'uuid')
 
-    yield s.check_offset, url, sip1, sip2, 'name', 'sort', 'uuid'
-    yield s.check_limit, url, sip1, sip2, 'name', 'sort', 'uuid'
+    s.check_offset(url, sip1, sip2, 'name', 'sort', 'uuid')
+    s.check_limit(url, sip1, sip2, 'name', 'sort', 'uuid')
 
 
 @fixtures.sip()
@@ -510,20 +507,15 @@ def test_delete_template(template, sip):
 def test_bus_events(sip):
     headers = {'tenant_uuid': MAIN_TENANT}
 
-    yield (
-        s.check_event,
-        'sip_endpoint_template_created',
-        headers,
-        confd.endpoints.sip.templates.post,
+    s.check_event(
+        'sip_endpoint_template_created', headers, confd.endpoints.sip.templates.post
     )
-    yield (
-        s.check_event,
+    s.check_event(
         'sip_endpoint_template_edited',
         headers,
         confd.endpoints.sip.templates(sip['uuid']).put,
     )
-    yield (
-        s.check_event,
+    s.check_event(
         'sip_endpoint_template_deleted',
         headers,
         confd.endpoints.sip.templates(sip['uuid']).delete,

--- a/integration_tests/suite/base/test_extensions.py
+++ b/integration_tests/suite/base/test_extensions.py
@@ -49,52 +49,47 @@ FAKE_ID = 999999999
 
 def test_search_errors():
     url = confd.extensions.get
-    for check in s.search_error_checks(url):
-        yield check
+    s.search_error_checks(url)
 
 
 def test_get_errors():
     url = confd.extensions(FAKE_ID).get
-    yield s.check_resource_not_found, url, 'Extension'
+    s.check_resource_not_found(url, 'Extension')
 
 
 @fixtures.extension()
 def test_post_errors(extension):
     url = confd.extensions.post
-    for check in error_checks(url):
-        yield check
+    error_checks(url)
 
 
 @fixtures.extension()
 def test_put_errors(extension):
     url = confd.extensions(extension['id']).put
-    for check in error_checks(url):
-        yield check
+    error_checks(url)
 
 
 def test_delete_errors():
     url = confd.extensions(FAKE_ID).delete
-    yield s.check_resource_not_found, url, 'Extension'
+    s.check_resource_not_found(url, 'Extension')
 
 
 def error_checks(url):
-    yield s.check_bogus_field_returns_error, url, 'exten', None
-    yield s.check_bogus_field_returns_error, url, 'exten', True
-    yield s.check_bogus_field_returns_error, url, 'exten', {}
-    yield s.check_bogus_field_returns_error, url, 'exten', []
-    yield s.check_bogus_field_returns_error, url, 'exten', '01234567890123456789012345678901234567890'
-    yield s.check_bogus_field_returns_error, url, 'exten', 'ABC123', {
-        'context': CONTEXT
-    }
-    yield s.check_bogus_field_returns_error, url, 'exten', 'XXXX', {'context': CONTEXT}
-    yield s.check_bogus_field_returns_error, url, 'exten', '_+111', {'context': CONTEXT}
-    yield s.check_bogus_field_returns_error, url, 'exten', '_1+111', {
-        'context': 'to-extern'
-    }
-    yield s.check_bogus_field_returns_error, url, 'context', None
-    yield s.check_bogus_field_returns_error, url, 'context', True
-    yield s.check_bogus_field_returns_error, url, 'context', {}
-    yield s.check_bogus_field_returns_error, url, 'context', []
+    s.check_bogus_field_returns_error(url, 'exten', None)
+    s.check_bogus_field_returns_error(url, 'exten', True)
+    s.check_bogus_field_returns_error(url, 'exten', {})
+    s.check_bogus_field_returns_error(url, 'exten', [])
+    s.check_bogus_field_returns_error(
+        url, 'exten', '01234567890123456789012345678901234567890'
+    )
+    s.check_bogus_field_returns_error(url, 'exten', 'ABC123', {'context': CONTEXT})
+    s.check_bogus_field_returns_error(url, 'exten', 'XXXX', {'context': CONTEXT})
+    s.check_bogus_field_returns_error(url, 'exten', '_+111', {'context': CONTEXT})
+    s.check_bogus_field_returns_error(url, 'exten', '_1+111', {'context': 'to-extern'})
+    s.check_bogus_field_returns_error(url, 'context', None)
+    s.check_bogus_field_returns_error(url, 'context', True)
+    s.check_bogus_field_returns_error(url, 'context', {})
+    s.check_bogus_field_returns_error(url, 'context', [])
 
 
 @fixtures.context(label='main', wazo_tenant=MAIN_TENANT)
@@ -166,15 +161,15 @@ def test_create_with_enabled_parameter():
 
 def test_create_extension_in_different_ranges():
     # user range
-    yield create_in_range, '1100', 'default'
+    create_in_range('1100', 'default')
     # group range
-    yield create_in_range, '2000', 'default'
+    create_in_range('2000', 'default')
     # queue range
-    yield create_in_range, '3000', 'default'
+    create_in_range('3000', 'default')
     # conference range
-    yield create_in_range, '4000', 'default'
+    create_in_range('4000', 'default')
     # incall range
-    yield create_in_range, '3954', 'from-extern'
+    create_in_range('3954', 'from-extern')
 
 
 def create_in_range(exten, context):
@@ -482,7 +477,7 @@ def test_search(extension, hidden):
     searches = {'exten': '499', 'context': 'fault'}
 
     for field, term in searches.items():
-        yield check_search, url, extension, hidden, field, term
+        check_search(url, extension, hidden, field, term)
 
 
 def check_search(url, extension, hidden, field, term):
@@ -535,11 +530,11 @@ def test_search_multi_tenant(main_ctx, sub_ctx):
 @fixtures.extension(exten='9999', context='to-extern')
 def test_sorting_offset_limit(extension1, extension2):
     url = confd.extensions.get
-    yield s.check_sorting, url, extension1, extension2, 'exten', '999'
-    yield s.check_sorting, url, extension1, extension2, 'context', 'extern'
+    s.check_sorting(url, extension1, extension2, 'exten', '999')
+    s.check_sorting(url, extension1, extension2, 'context', 'extern')
 
-    yield s.check_offset, url, extension1, extension2, 'exten', '999'
-    yield s.check_limit, url, extension1, extension2, 'exten', '999'
+    s.check_offset(url, extension1, extension2, 'exten', '999')
+    s.check_limit(url, extension1, extension2, 'exten', '999')
 
 
 def test_search_extensions_in_context():

--- a/integration_tests/suite/base/test_extensions_features.py
+++ b/integration_tests/suite/base/test_extensions_features.py
@@ -13,36 +13,34 @@ FAKE_UUID = uuid4()
 
 def test_search_errors():
     url = confd.extensions.features.get
-    for check in s.search_error_checks(url):
-        yield check
+    s.search_error_checks(url)
 
 
 def test_get_errors():
     url = confd.extensions.features(FAKE_UUID).get
-    yield s.check_resource_not_found, url, 'FeatureExtension'
+    s.check_resource_not_found(url, 'FeatureExtension')
 
 
 @fixtures.extension_feature()
 def test_put_errors(extension):
     url = confd.extensions.features(FAKE_UUID).put
-    yield s.check_resource_not_found, url, 'FeatureExtension'
+    s.check_resource_not_found(url, 'FeatureExtension')
 
     url = confd.extensions.features(extension['uuid']).put
-    for check in error_checks(url):
-        yield check
+    error_checks(url)
 
 
 def error_checks(url):
-    yield s.check_bogus_field_returns_error, url, 'exten', None
-    yield s.check_bogus_field_returns_error, url, 'exten', True
-    yield s.check_bogus_field_returns_error, url, 'exten', 'ABC123'
-    yield s.check_bogus_field_returns_error, url, 'exten', 'XXXX'
-    yield s.check_bogus_field_returns_error, url, 'exten', {}
-    yield s.check_bogus_field_returns_error, url, 'exten', []
-    yield s.check_bogus_field_returns_error, url, 'enabled', 'invalid'
-    yield s.check_bogus_field_returns_error, url, 'enabled', None
-    yield s.check_bogus_field_returns_error, url, 'enabled', []
-    yield s.check_bogus_field_returns_error, url, 'enabled', {}
+    s.check_bogus_field_returns_error(url, 'exten', None)
+    s.check_bogus_field_returns_error(url, 'exten', True)
+    s.check_bogus_field_returns_error(url, 'exten', 'ABC123')
+    s.check_bogus_field_returns_error(url, 'exten', 'XXXX')
+    s.check_bogus_field_returns_error(url, 'exten', {})
+    s.check_bogus_field_returns_error(url, 'exten', [])
+    s.check_bogus_field_returns_error(url, 'enabled', 'invalid')
+    s.check_bogus_field_returns_error(url, 'enabled', None)
+    s.check_bogus_field_returns_error(url, 'enabled', [])
+    s.check_bogus_field_returns_error(url, 'enabled', {})
 
 
 def test_create_unimplemented():
@@ -63,7 +61,7 @@ def test_search(extension, hidden):
     searches = {'exten': '499', 'feature': 'sea'}
 
     for field, term in searches.items():
-        yield check_search, url, extension, hidden, field, term
+        check_search(url, extension, hidden, field, term)
 
 
 def check_search(url, extension, hidden, field, term):
@@ -81,10 +79,10 @@ def check_search(url, extension, hidden, field, term):
 def test_sorting_offset_limit(extension1, extension2):
     url = confd.extensions.features.get
     id_field = 'uuid'
-    yield s.check_sorting, url, extension1, extension2, 'exten', '999', id_field
+    s.check_sorting(url, extension1, extension2, 'exten', '999', id_field)
 
-    yield s.check_offset, url, extension1, extension2, 'exten', '999', id_field
-    yield s.check_limit, url, extension1, extension2, 'exten', '999', id_field
+    s.check_offset(url, extension1, extension2, 'exten', '999', id_field)
+    s.check_limit(url, extension1, extension2, 'exten', '999', id_field)
 
 
 @fixtures.extension_feature()
@@ -141,6 +139,8 @@ def test_restrict_only_master_tenant(extension):
 @fixtures.extension_feature()
 def test_bus_events(extension):
     headers = {}
-    yield s.check_event, 'extension_feature_edited', headers, confd.extensions.features(
-        extension['uuid']
-    ).put
+    s.check_event(
+        'extension_feature_edited',
+        headers,
+        confd.extensions.features(extension['uuid']).put,
+    )

--- a/integration_tests/suite/base/test_external_apps.py
+++ b/integration_tests/suite/base/test_external_apps.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2020-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import json
@@ -21,44 +21,42 @@ from ..helpers.config import MAIN_TENANT, SUB_TENANT
 
 def test_get_errors():
     fake_external_app = confd.external.apps('invalid').get
-    yield s.check_resource_not_found, fake_external_app, 'ExternalApp'
+    s.check_resource_not_found(fake_external_app, 'ExternalApp')
 
 
 def test_delete_errors():
     fake_external_app = confd.external.apps('invalid').delete
-    yield s.check_resource_not_found, fake_external_app, 'ExternalApp'
+    s.check_resource_not_found(fake_external_app, 'ExternalApp')
 
 
 @fixtures.external_app(name='unique')
 def test_post_errors(external_app):
     url = confd.external.apps.myapp.post
-    for check in error_checks(url):
-        yield check
+    error_checks(url)
 
     url = confd.external.apps(s.random_string(129)).post
-    yield s.check_bogus_field_returns_error, url, 'name', s.random_string(129)
+    s.check_bogus_field_returns_error(url, 'name', s.random_string(129))
 
     url = confd.external.apps('unique').post
-    yield s.check_bogus_field_returns_error, url, 'name', 'unique'
+    s.check_bogus_field_returns_error(url, 'name', 'unique')
 
 
 @fixtures.external_app()
 def test_put_errors(external_app):
     url = confd.external.apps(external_app['name']).put
-    for check in error_checks(url):
-        yield check
+    error_checks(url)
 
 
 def error_checks(url):
-    yield s.check_bogus_field_returns_error, url, 'label', True
-    yield s.check_bogus_field_returns_error, url, 'label', 1234
-    yield s.check_bogus_field_returns_error, url, 'label', s.random_string(257)
-    yield s.check_bogus_field_returns_error, url, 'label', []
-    yield s.check_bogus_field_returns_error, url, 'label', {}
-    yield s.check_bogus_field_returns_error, url, 'configuration', True
-    yield s.check_bogus_field_returns_error, url, 'configuration', json.dumps('invalid')
-    yield s.check_bogus_field_returns_error, url, 'configuration', json.dumps(1234)
-    yield s.check_bogus_field_returns_error, url, 'configuration', []
+    s.check_bogus_field_returns_error(url, 'label', True)
+    s.check_bogus_field_returns_error(url, 'label', 1234)
+    s.check_bogus_field_returns_error(url, 'label', s.random_string(257))
+    s.check_bogus_field_returns_error(url, 'label', [])
+    s.check_bogus_field_returns_error(url, 'label', {})
+    s.check_bogus_field_returns_error(url, 'configuration', True)
+    s.check_bogus_field_returns_error(url, 'configuration', json.dumps('invalid'))
+    s.check_bogus_field_returns_error(url, 'configuration', json.dumps(1234))
+    s.check_bogus_field_returns_error(url, 'configuration', [])
 
 
 @fixtures.external_app(wazo_tenant=MAIN_TENANT)
@@ -81,7 +79,7 @@ def test_search(external_app, hidden):
     searches = {'name': 'search'}
 
     for field, term in searches.items():
-        yield check_search, url, external_app, hidden, field, term
+        check_search(url, external_app, hidden, field, term)
 
 
 def check_search(url, external_app, hidden, field, term):
@@ -98,10 +96,10 @@ def check_search(url, external_app, hidden, field, term):
 @fixtures.external_app(name='sort2')
 def test_sort_offset_limit(external_app1, external_app2):
     url = confd.external.apps.get
-    yield s.check_sorting, url, external_app1, external_app2, 'name', 'sort', 'name'
+    s.check_sorting(url, external_app1, external_app2, 'name', 'sort', 'name')
 
-    yield s.check_offset, url, external_app1, external_app2, 'name', 'sort', 'name'
-    yield s.check_limit, url, external_app1, external_app2, 'name', 'sort', 'name'
+    s.check_offset(url, external_app1, external_app2, 'name', 'sort', 'name')
+    s.check_limit(url, external_app1, external_app2, 'name', 'sort', 'name')
 
 
 @fixtures.external_app()
@@ -213,6 +211,6 @@ def test_bus_events():
     url = confd.external.apps.myname
     headers = {'tenant_uuid': MAIN_TENANT}
 
-    yield s.check_event, 'external_app_created', headers, url.post
-    yield s.check_event, 'external_app_edited', headers, url.put
-    yield s.check_event, 'external_app_deleted', headers, url.delete
+    s.check_event('external_app_created', headers, url.post)
+    s.check_event('external_app_edited', headers, url.put)
+    s.check_event('external_app_deleted', headers, url.delete)

--- a/integration_tests/suite/base/test_features_applicationmap.py
+++ b/integration_tests/suite/base/test_features_applicationmap.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import assert_that, has_entries
@@ -12,23 +12,30 @@ REQUIRED_OPTIONS = {'togglerecord': '*3,self,AGI(localhost,...)'}
 
 def test_put_errors():
     url = confd.asterisk.features.applicationmap.put
-    for check in error_checks(url):
-        yield check
+    error_checks(url)
 
 
 def error_checks(url):
-    yield s.check_bogus_field_returns_error, url, 'options', 123
-    yield s.check_bogus_field_returns_error, url, 'options', None
-    yield s.check_bogus_field_returns_error, url, 'options', 'string'
-    yield s.check_bogus_field_returns_error, url, 'options', [['ordered', 'option']]
-    yield s.check_bogus_field_returns_error, url, 'options', {
-        'wrong_value': 23,
-        **REQUIRED_OPTIONS,
-    }
-    yield s.check_bogus_field_returns_error, url, 'options', {
-        'none_value': None,
-        **REQUIRED_OPTIONS,
-    }
+    s.check_bogus_field_returns_error(url, 'options', 123)
+    s.check_bogus_field_returns_error(url, 'options', None)
+    s.check_bogus_field_returns_error(url, 'options', 'string')
+    s.check_bogus_field_returns_error(url, 'options', [['ordered', 'option']])
+    s.check_bogus_field_returns_error(
+        url,
+        'options',
+        {
+            'wrong_value': 23,
+            **REQUIRED_OPTIONS,
+        },
+    )
+    s.check_bogus_field_returns_error(
+        url,
+        'options',
+        {
+            'none_value': None,
+            **REQUIRED_OPTIONS,
+        },
+    )
 
 
 def test_get():
@@ -58,6 +65,9 @@ def test_bus_event_when_edited():
     url = confd.asterisk.features.applicationmap
     headers = {}
 
-    yield s.check_event, 'features_applicationmap_edited', headers, url.put, {
-        'options': REQUIRED_OPTIONS
-    }
+    s.check_event(
+        'features_applicationmap_edited',
+        headers,
+        url.put,
+        {'options': REQUIRED_OPTIONS},
+    )

--- a/integration_tests/suite/base/test_features_featuremap.py
+++ b/integration_tests/suite/base/test_features_featuremap.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import assert_that, has_entries
@@ -13,32 +13,41 @@ REQUIRED_OPTIONS = {'atxfer': '*0', 'blindxfer': '9'}
 
 def test_put_errors():
     url = confd.asterisk.features.featuremap.put
-    for check in error_checks(url):
-        yield check
+    error_checks(url)
 
 
 def error_checks(url):
-    yield s.check_bogus_field_returns_error, url, 'options', 123
-    yield s.check_bogus_field_returns_error, url, 'options', None
-    yield s.check_bogus_field_returns_error, url, 'options', 'string'
-    yield s.check_bogus_field_returns_error, url, 'options', [['ordered', 'option']]
-    yield s.check_bogus_field_returns_error, url, 'options', dict(
-        wrong_value=23, **REQUIRED_OPTIONS
+    s.check_bogus_field_returns_error(url, 'options', 123)
+    s.check_bogus_field_returns_error(url, 'options', None)
+    s.check_bogus_field_returns_error(url, 'options', 'string')
+    s.check_bogus_field_returns_error(url, 'options', [['ordered', 'option']])
+    s.check_bogus_field_returns_error(
+        url, 'options', dict(wrong_value=23, **REQUIRED_OPTIONS)
     )
-    yield s.check_bogus_field_returns_error, url, 'options', dict(
-        none_value=None, **REQUIRED_OPTIONS
+    s.check_bogus_field_returns_error(
+        url, 'options', dict(none_value=None, **REQUIRED_OPTIONS)
     )
 
     regex = r'atxfer'
-    yield s.check_bogus_field_returns_error_matching_regex, url, 'options', {
-        'blindxfer': '1',
-        'automixmon': '1',
-    }, regex
+    s.check_bogus_field_returns_error_matching_regex(
+        url,
+        'options',
+        {
+            'blindxfer': '1',
+            'automixmon': '1',
+        },
+        regex,
+    )
     regex = r'blindxfer'
-    yield s.check_bogus_field_returns_error_matching_regex, url, 'options', {
-        'atxfer': '1',
-        'automixmon': '1',
-    }, regex
+    s.check_bogus_field_returns_error_matching_regex(
+        url,
+        'options',
+        {
+            'atxfer': '1',
+            'automixmon': '1',
+        },
+        regex,
+    )
 
 
 def test_get():
@@ -69,6 +78,6 @@ def test_bus_event_when_edited():
     url = confd.asterisk.features.featuremap
     headers = {}
 
-    yield s.check_event, 'features_featuremap_edited', headers, url.put, {
-        'options': REQUIRED_OPTIONS
-    }
+    s.check_event(
+        'features_featuremap_edited', headers, url.put, {'options': REQUIRED_OPTIONS}
+    )

--- a/integration_tests/suite/base/test_features_general.py
+++ b/integration_tests/suite/base/test_features_general.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import assert_that, has_entries
@@ -10,43 +10,30 @@ from ..helpers.config import TOKEN_SUB_TENANT
 
 def test_put_errors():
     url = confd.asterisk.features.general.put
-    for check in error_checks(url):
-        yield check
+    error_checks(url)
 
 
 def error_checks(url):
-    yield s.check_bogus_field_returns_error, url, 'options', 123
-    yield s.check_bogus_field_returns_error, url, 'options', None
-    yield s.check_bogus_field_returns_error, url, 'options', 'string'
-    yield s.check_bogus_field_returns_error, url, 'options', [['ordered', 'option']]
-    yield s.check_bogus_field_returns_error, url, 'options', {'wrong_value': 23}
-    yield s.check_bogus_field_returns_error, url, 'options', {'none_value': None}
+    s.check_bogus_field_returns_error(url, 'options', 123)
+    s.check_bogus_field_returns_error(url, 'options', None)
+    s.check_bogus_field_returns_error(url, 'options', 'string')
+    s.check_bogus_field_returns_error(url, 'options', [['ordered', 'option']])
+    s.check_bogus_field_returns_error(url, 'options', {'wrong_value': 23})
+    s.check_bogus_field_returns_error(url, 'options', {'none_value': None})
 
-    yield s.check_bogus_field_returns_error, url, 'options', {
-        'comebacktoorigin': 'value'
-    }
-    yield s.check_bogus_field_returns_error, url, 'options', {'courtesytone': 'value'}
-    yield s.check_bogus_field_returns_error, url, 'options', {'findslot': 'value'}
-    yield s.check_bogus_field_returns_error, url, 'options', {
-        'parkedcallhangup': 'value'
-    }
-    yield s.check_bogus_field_returns_error, url, 'options', {
-        'parkedcallrecording': 'value'
-    }
-    yield s.check_bogus_field_returns_error, url, 'options', {
-        'parkedcallreparking': 'value'
-    }
-    yield s.check_bogus_field_returns_error, url, 'options', {
-        'parkedcalltransfers': 'value'
-    }
-    yield s.check_bogus_field_returns_error, url, 'options', {'parkeddynamic': 'value'}
-    yield s.check_bogus_field_returns_error, url, 'options', {
-        'parkedmusicclass': 'value'
-    }
-    yield s.check_bogus_field_returns_error, url, 'options', {'parkedplay': 'value'}
-    yield s.check_bogus_field_returns_error, url, 'options', {'parkinghints': 'value'}
-    yield s.check_bogus_field_returns_error, url, 'options', {'parkingtime': 'value'}
-    yield s.check_bogus_field_returns_error, url, 'options', {'parkpos': 'value'}
+    s.check_bogus_field_returns_error(url, 'options', {'comebacktoorigin': 'value'})
+    s.check_bogus_field_returns_error(url, 'options', {'courtesytone': 'value'})
+    s.check_bogus_field_returns_error(url, 'options', {'findslot': 'value'})
+    s.check_bogus_field_returns_error(url, 'options', {'parkedcallhangup': 'value'})
+    s.check_bogus_field_returns_error(url, 'options', {'parkedcallrecording': 'value'})
+    s.check_bogus_field_returns_error(url, 'options', {'parkedcallreparking': 'value'})
+    s.check_bogus_field_returns_error(url, 'options', {'parkedcalltransfers': 'value'})
+    s.check_bogus_field_returns_error(url, 'options', {'parkeddynamic': 'value'})
+    s.check_bogus_field_returns_error(url, 'options', {'parkedmusicclass': 'value'})
+    s.check_bogus_field_returns_error(url, 'options', {'parkedplay': 'value'})
+    s.check_bogus_field_returns_error(url, 'options', {'parkinghints': 'value'})
+    s.check_bogus_field_returns_error(url, 'options', {'parkingtime': 'value'})
+    s.check_bogus_field_returns_error(url, 'options', {'parkpos': 'value'})
 
 
 def test_get():
@@ -85,4 +72,4 @@ def test_bus_event_when_edited():
     url = confd.asterisk.features.general
     headers = {}
 
-    yield s.check_event, 'features_general_edited', headers, url.put, {'options': {}}
+    s.check_event('features_general_edited', headers, url.put, {'options': {}})

--- a/integration_tests/suite/base/test_func_keys.py
+++ b/integration_tests/suite/base/test_func_keys.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2021 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import unittest
@@ -98,47 +98,41 @@ invalid_destinations = [
 
 
 def error_funckey_checks(url):
-    yield s.check_bogus_field_returns_error, url, 'blf', 123
-    yield s.check_bogus_field_returns_error, url, 'blf', 'string'
-    yield s.check_bogus_field_returns_error, url, 'blf', None
-    yield s.check_bogus_field_returns_error, url, 'label', 1234
+    s.check_bogus_field_returns_error(url, 'blf', 123)
+    s.check_bogus_field_returns_error(url, 'blf', 'string')
+    s.check_bogus_field_returns_error(url, 'blf', None)
+    s.check_bogus_field_returns_error(url, 'label', 1234)
 
     for destination in invalid_destinations:
-        yield s.check_bogus_field_returns_error, url, 'destination', destination
+        s.check_bogus_field_returns_error(url, 'destination', destination)
 
 
 def error_funckeys_checks(url):
     valid_funckey = {'destination': {'type': 'custom', 'exten': '1234'}}
 
-    yield s.check_bogus_field_returns_error, url, 'name', 123
-    yield s.check_bogus_field_returns_error, url, 'name', True
-    yield s.check_bogus_field_returns_error, url, 'name', s.random_string(129)
-    yield s.check_bogus_field_returns_error, url, 'keys', True
-    yield s.check_bogus_field_returns_error, url, 'keys', None
-    yield s.check_bogus_field_returns_error, url, 'keys', 'string'
-    yield s.check_bogus_field_returns_error, url, 'keys', 1234
-    yield s.check_bogus_field_returns_error, url, 'keys', {'not_integer': valid_funckey}
-    yield s.check_bogus_field_returns_error, url, 'keys', {None: valid_funckey}
+    s.check_bogus_field_returns_error(url, 'name', 123)
+    s.check_bogus_field_returns_error(url, 'name', True)
+    s.check_bogus_field_returns_error(url, 'name', s.random_string(129))
+    s.check_bogus_field_returns_error(url, 'keys', True)
+    s.check_bogus_field_returns_error(url, 'keys', None)
+    s.check_bogus_field_returns_error(url, 'keys', 'string')
+    s.check_bogus_field_returns_error(url, 'keys', 1234)
+    s.check_bogus_field_returns_error(url, 'keys', {'not_integer': valid_funckey})
+    s.check_bogus_field_returns_error(url, 'keys', {None: valid_funckey})
 
     regex = r'keys.*1.*destination'
     for destination in invalid_destinations:
-        yield s.check_bogus_field_returns_error_matching_regex, url, 'keys', {
-            '1': {'destination': destination}
-        }, regex
+        s.check_bogus_field_returns_error_matching_regex(
+            url, 'keys', {'1': {'destination': destination}}, regex
+        )
 
     regex = r'keys.*1'
-    yield s.check_bogus_field_returns_error_matching_regex, url, 'keys', {
-        '1': 'string'
-    }, regex
-    yield s.check_bogus_field_returns_error_matching_regex, url, 'keys', {
-        '1': 1234
-    }, regex
-    yield s.check_bogus_field_returns_error_matching_regex, url, 'keys', {
-        '1': True
-    }, regex
-    yield s.check_bogus_field_returns_error_matching_regex, url, 'keys', {
-        '1': None
-    }, regex
+    s.check_bogus_field_returns_error_matching_regex(
+        url, 'keys', {'1': 'string'}, regex
+    )
+    s.check_bogus_field_returns_error_matching_regex(url, 'keys', {'1': 1234}, regex)
+    s.check_bogus_field_returns_error_matching_regex(url, 'keys', {'1': True}, regex)
+    s.check_bogus_field_returns_error_matching_regex(url, 'keys', {'1': None}, regex)
 
 
 class BaseTestFuncKey(unittest.TestCase):

--- a/integration_tests/suite/base/test_func_keys_templates.py
+++ b/integration_tests/suite/base/test_func_keys_templates.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2020 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import (
@@ -34,42 +34,40 @@ invalid_template_destinations = [
 
 def test_get_errors():
     fake_get = confd.funckeys.templates(999999).get
-    yield s.check_resource_not_found, fake_get, 'FuncKeyTemplate'
+    s.check_resource_not_found(fake_get, 'FuncKeyTemplate')
 
 
 def test_post_errors():
     url = confd.funckeys.templates.post
-    for check in error_funckeys_checks(url):
-        yield check
+    error_funckeys_checks(url)
 
     regex = r'keys.*1.*destination.*type'
     for destination in invalid_template_destinations:
-        yield s.check_bogus_field_returns_error_matching_regex, url, 'keys', {
-            '1': {'destination': destination}
-        }, regex
+        s.check_bogus_field_returns_error_matching_regex(
+            url, 'keys', {'1': {'destination': destination}}, regex
+        )
 
 
 @fixtures.funckey_template()
 def test_get_position_errors(funckey_template):
     fake_get = confd.funckeys.templates(funckey_template['id'])(1).get
-    yield s.check_resource_not_found, fake_get, 'FuncKey'
+    s.check_resource_not_found(fake_get, 'FuncKey')
 
 
 # Should raise an error
 # @fixtures.funckey_template()
 # def test_delete_position_errors(funckey_template):
 #     fake_delete = confd.funckeys.templates(funckey_template['id'])(1).delete
-#     yield s.check_resource_not_found, fake_delete, 'FuncKey'
+#     s.check_resource_not_found(fake_delete, 'FuncKey')
 
 
 @fixtures.funckey_template()
 def test_put_position_errors(funckey_template):
     url = confd.funckeys.templates(funckey_template['id'])(1).put
-    for check in error_funckey_checks(url):
-        yield check
+    error_funckey_checks(url)
 
     for destination in invalid_template_destinations:
-        yield s.check_bogus_field_returns_error, url, 'destination', destination
+        s.check_bogus_field_returns_error(url, 'destination', destination)
 
 
 @fixtures.funckey_template(name="search")
@@ -79,7 +77,7 @@ def test_search_on_funckey_template(funckey_template, hidden):
     searches = {'name': 'search'}
 
     for field, term in searches.items():
-        yield check_search, url, funckey_template, hidden, field, term
+        check_search(url, funckey_template, hidden, field, term)
 
 
 def check_search(url, funckey_template, hidden, field, term):
@@ -91,7 +89,7 @@ def check_search(url, funckey_template, hidden, field, term):
 @fixtures.funckey_template(name='sort1')
 @fixtures.funckey_template(name='sort2')
 def test_funckey_template_sorting(funckey_template1, funckey_template2):
-    yield check_funckey_template_sorting, funckey_template1, funckey_template2, 'name', 'sort'
+    check_funckey_template_sorting(funckey_template1, funckey_template2, 'name', 'sort')
 
 
 def check_funckey_template_sorting(funckey_template1, funckey_template2, field, search):

--- a/integration_tests/suite/base/test_group_call_permission.py
+++ b/integration_tests/suite/base/test_group_call_permission.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import assert_that, contains, empty, has_entries
@@ -16,11 +16,11 @@ def test_associate_errors(group, call_permission):
     fake_group = confd.groups(FAKE_ID).callpermissions(call_permission['id']).put
     fake_call_permission = confd.groups(group['id']).callpermissions(FAKE_ID).put
 
-    yield s.check_resource_not_found, fake_group, 'Group'
-    yield s.check_resource_not_found, fake_call_permission, 'CallPermission'
+    s.check_resource_not_found(fake_group, 'Group')
+    s.check_resource_not_found(fake_call_permission, 'CallPermission')
 
     fake_call_permission = confd.groups(group['uuid']).callpermissions(FAKE_ID).put
-    yield s.check_resource_not_found, fake_call_permission, 'CallPermission'
+    s.check_resource_not_found(fake_call_permission, 'CallPermission')
 
 
 @fixtures.group()
@@ -29,11 +29,11 @@ def test_dissociate_errors(group, call_permission):
     fake_group = confd.groups(FAKE_ID).callpermissions(call_permission['id']).delete
     fake_call_permission = confd.groups(group['id']).callpermissions(FAKE_ID).delete
 
-    yield s.check_resource_not_found, fake_group, 'Group'
-    yield s.check_resource_not_found, fake_call_permission, 'CallPermission'
+    s.check_resource_not_found(fake_group, 'Group')
+    s.check_resource_not_found(fake_call_permission, 'CallPermission')
 
     fake_call_permission = confd.groups(group['uuid']).callpermissions(FAKE_ID).delete
-    yield s.check_resource_not_found, fake_call_permission, 'CallPermission'
+    s.check_resource_not_found(fake_call_permission, 'CallPermission')
 
 
 @fixtures.group()
@@ -217,14 +217,12 @@ def test_delete_call_permission_when_group_and_call_permission_associated_by_uui
 def test_bus_events(group, call_permission):
     headers = {'tenant_uuid': group['tenant_uuid']}
 
-    yield (
-        s.check_event,
+    s.check_event(
         'group_call_permission_associated',
         headers,
         confd.groups(group['uuid']).callpermissions(call_permission['id']).put,
     )
-    yield (
-        s.check_event,
+    s.check_event(
         'group_call_permission_dissociated',
         headers,
         confd.groups(group['uuid']).callpermissions(call_permission['id']).delete,

--- a/integration_tests/suite/base/test_group_extension.py
+++ b/integration_tests/suite/base/test_group_extension.py
@@ -23,12 +23,12 @@ def test_associate_errors(extension, group):
     fake_group = confd.groups(FAKE_ID).extensions(extension['id']).put
     fake_extension = confd.groups(group['id']).extensions(FAKE_ID).put
 
-    yield s.check_resource_not_found, fake_group, 'Group'
-    yield s.check_resource_not_found, fake_extension, 'Extension'
+    s.check_resource_not_found(fake_group, 'Group')
+    s.check_resource_not_found(fake_extension, 'Extension')
 
     fake_extension = confd.groups(group['uuid']).extensions(FAKE_ID).put
 
-    yield s.check_resource_not_found, fake_extension, 'Extension'
+    s.check_resource_not_found(fake_extension, 'Extension')
 
 
 @fixtures.extension(exten=gen_group_exten())
@@ -37,12 +37,12 @@ def test_dissociate_errors(extension, group):
     fake_group = confd.groups(FAKE_ID).extensions(extension['id']).delete
     fake_extension = confd.groups(group['id']).extensions(FAKE_ID).delete
 
-    yield s.check_resource_not_found, fake_group, 'Group'
-    yield s.check_resource_not_found, fake_extension, 'Extension'
+    s.check_resource_not_found(fake_group, 'Group')
+    s.check_resource_not_found(fake_extension, 'Extension')
 
     fake_extension = confd.groups(group['uuid']).extensions(FAKE_ID).delete
 
-    yield s.check_resource_not_found, fake_extension, 'Extension'
+    s.check_resource_not_found(fake_extension, 'Extension')
 
 
 @fixtures.extension(exten=gen_group_exten())
@@ -259,5 +259,5 @@ def test_bus_events(extension, group):
     url = confd.groups(group['uuid']).extensions(extension['id'])
     headers = {'tenant_uuid': MAIN_TENANT}
 
-    yield s.check_event, 'group_extension_associated', headers, url.put
-    yield s.check_event, 'group_extension_dissociated', headers, url.delete
+    s.check_event('group_extension_associated', headers, url.put)
+    s.check_event('group_extension_dissociated', headers, url.delete)

--- a/integration_tests/suite/base/test_group_fallback.py
+++ b/integration_tests/suite/base/test_group_fallback.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import assert_that, equal_to, has_entries
@@ -15,32 +15,36 @@ FAKE_ID = 999999999
 
 def test_get_errors():
     fake_group = confd.groups(FAKE_ID).fallbacks.get
-    yield s.check_resource_not_found, fake_group, 'Group'
+    s.check_resource_not_found(fake_group, 'Group')
 
 
 @fixtures.group()
 @fixtures.user()
 def test_put_errors(group, user):
     fake_group = confd.groups(FAKE_ID).fallbacks.put
-    yield s.check_resource_not_found, fake_group, 'Group'
+    s.check_resource_not_found(fake_group, 'Group')
 
     url = confd.groups(group['uuid']).fallbacks.put
-    for check in error_checks(url, user):
-        yield check
+    error_checks(url, user)
 
     url = confd.groups(group['id']).fallbacks.put
-    for check in error_checks(url, user):
-        yield check
+    error_checks(url, user)
 
 
 def error_checks(url, user):
     for destination in invalid_destinations():
-        yield s.check_bogus_field_returns_error, url, 'noanswer_destination', destination
-    yield s.check_bogus_field_returns_error, url, 'noanswer_destination', {
-        'type': 'user',
-        'user_id': user['id'],
-        'moh_uuid': '00000000-0000-0000-0000-000000000000',
-    }, {}, 'MOH was not found'
+        s.check_bogus_field_returns_error(url, 'noanswer_destination', destination)
+    s.check_bogus_field_returns_error(
+        url,
+        'noanswer_destination',
+        {
+            'type': 'user',
+            'user_id': user['id'],
+            'moh_uuid': '00000000-0000-0000-0000-000000000000',
+        },
+        {},
+        'MOH was not found',
+    )
 
 
 @fixtures.group()
@@ -102,7 +106,7 @@ def test_edit_to_none(group):
 @fixtures.moh()
 def test_valid_destinations(group, *destinations):
     for destination in valid_destinations(*destinations):
-        yield _update_group_fallbacks_with_destination, group['uuid'], destination
+        _update_group_fallbacks_with_destination(group['uuid'], destination)
 
 
 def _update_group_fallbacks_with_destination(group_uuid, destination):
@@ -144,17 +148,17 @@ def test_nonexistent_destinations(group, moh):
             'voicemail',
             'conference',
         ):
-            yield _update_user_fallbacks_with_nonexistent_destination, group[
-                'uuid'
-            ], destination
+            _update_user_fallbacks_with_nonexistent_destination(
+                group['uuid'], destination
+            )
 
         if (
             destination['type'] == 'application'
             and destination['application'] == 'custom'
         ):
-            yield _update_user_fallbacks_with_nonexistent_destination, group[
-                'uuid'
-            ], destination
+            _update_user_fallbacks_with_nonexistent_destination(
+                group['uuid'], destination
+            )
 
 
 def _update_user_fallbacks_with_nonexistent_destination(group_uuid, destination):
@@ -167,7 +171,7 @@ def test_bus_events(group):
     url = confd.groups(group['uuid']).fallbacks.put
     headers = {'tenant_uuid': MAIN_TENANT}
 
-    yield s.check_event, 'group_fallback_edited', headers, url
+    s.check_event('group_fallback_edited', headers, url)
 
 
 @fixtures.group()

--- a/integration_tests/suite/base/test_group_member_extension.py
+++ b/integration_tests/suite/base/test_group_member_extension.py
@@ -31,68 +31,66 @@ def test_associate_errors(group, extension):
     response.assert_status(404)
 
     url = confd.groups(group['id']).members.extensions.put
-    for check in error_checks(url):
-        yield check
+    error_checks(url)
 
     url = confd.groups(group['uuid']).members.extensions.put
-    for check in error_checks(url):
-        yield check
+    error_checks(url)
 
 
 def error_checks(url):
-    yield s.check_bogus_field_returns_error, url, 'extensions', 123
-    yield s.check_bogus_field_returns_error, url, 'extensions', None
-    yield s.check_bogus_field_returns_error, url, 'extensions', True
-    yield s.check_bogus_field_returns_error, url, 'extensions', 'string'
-    yield s.check_bogus_field_returns_error, url, 'extensions', [123]
-    yield s.check_bogus_field_returns_error, url, 'extensions', [None]
-    yield s.check_bogus_field_returns_error, url, 'extensions', ['string']
-    yield s.check_bogus_field_returns_error, url, 'extensions', [{}]
+    s.check_bogus_field_returns_error(url, 'extensions', 123)
+    s.check_bogus_field_returns_error(url, 'extensions', None)
+    s.check_bogus_field_returns_error(url, 'extensions', True)
+    s.check_bogus_field_returns_error(url, 'extensions', 'string')
+    s.check_bogus_field_returns_error(url, 'extensions', [123])
+    s.check_bogus_field_returns_error(url, 'extensions', [None])
+    s.check_bogus_field_returns_error(url, 'extensions', ['string'])
+    s.check_bogus_field_returns_error(url, 'extensions', [{}])
 
     regex = r'extensions.*priority'
-    yield s.check_bogus_field_returns_error_matching_regex, url, 'extensions', [
-        {'priority': None}
-    ], regex
-    yield s.check_bogus_field_returns_error_matching_regex, url, 'extensions', [
-        {'priority': 'string'}
-    ], regex
-    yield s.check_bogus_field_returns_error_matching_regex, url, 'extensions', [
-        {'priority': -1}
-    ], regex
-    yield s.check_bogus_field_returns_error_matching_regex, url, 'extensions', [
-        {'priority': []}
-    ], regex
-    yield s.check_bogus_field_returns_error_matching_regex, url, 'extensions', [
-        {'priority': {}}
-    ], regex
+    s.check_bogus_field_returns_error_matching_regex(
+        url, 'extensions', [{'priority': None}], regex
+    )
+    s.check_bogus_field_returns_error_matching_regex(
+        url, 'extensions', [{'priority': 'string'}], regex
+    )
+    s.check_bogus_field_returns_error_matching_regex(
+        url, 'extensions', [{'priority': -1}], regex
+    )
+    s.check_bogus_field_returns_error_matching_regex(
+        url, 'extensions', [{'priority': []}], regex
+    )
+    s.check_bogus_field_returns_error_matching_regex(
+        url, 'extensions', [{'priority': {}}], regex
+    )
 
     regex = r'extensions.*exten'
-    yield s.check_bogus_field_returns_error_matching_regex, url, 'extensions', [
-        {'exten': None}
-    ], regex
-    yield s.check_bogus_field_returns_error_matching_regex, url, 'extensions', [
-        {'exten': 123}
-    ], regex
-    yield s.check_bogus_field_returns_error_matching_regex, url, 'extensions', [
-        {'exten': []}
-    ], regex
-    yield s.check_bogus_field_returns_error_matching_regex, url, 'extensions', [
-        {'exten': {}}
-    ], regex
+    s.check_bogus_field_returns_error_matching_regex(
+        url, 'extensions', [{'exten': None}], regex
+    )
+    s.check_bogus_field_returns_error_matching_regex(
+        url, 'extensions', [{'exten': 123}], regex
+    )
+    s.check_bogus_field_returns_error_matching_regex(
+        url, 'extensions', [{'exten': []}], regex
+    )
+    s.check_bogus_field_returns_error_matching_regex(
+        url, 'extensions', [{'exten': {}}], regex
+    )
 
     regex = r'extensions.*context'
-    yield s.check_bogus_field_returns_error_matching_regex, url, 'extensions', [
-        {'context': None}
-    ], regex
-    yield s.check_bogus_field_returns_error_matching_regex, url, 'extensions', [
-        {'context': 123}
-    ], regex
-    yield s.check_bogus_field_returns_error_matching_regex, url, 'extensions', [
-        {'context': []}
-    ], regex
-    yield s.check_bogus_field_returns_error_matching_regex, url, 'extensions', [
-        {'context': {}}
-    ], regex
+    s.check_bogus_field_returns_error_matching_regex(
+        url, 'extensions', [{'context': None}], regex
+    )
+    s.check_bogus_field_returns_error_matching_regex(
+        url, 'extensions', [{'context': 123}], regex
+    )
+    s.check_bogus_field_returns_error_matching_regex(
+        url, 'extensions', [{'context': []}], regex
+    )
+    s.check_bogus_field_returns_error_matching_regex(
+        url, 'extensions', [{'context': {}}], regex
+    )
 
 
 @fixtures.group()
@@ -196,7 +194,7 @@ def test_delete_group_when_group_and_extension_associated(
         confd.groups(group['uuid']).delete().assert_deleted()
 
         deleted_group = confd.groups(group['uuid']).get
-        yield s.check_resource_not_found, deleted_group, 'Group'
+        s.check_resource_not_found(deleted_group, 'Group')
 
 
 @fixtures.group()
@@ -206,4 +204,4 @@ def test_bus_events(group, extension):
     body = {'extensions': [extension]}
     headers = {'tenant_uuid': MAIN_TENANT}
 
-    yield s.check_event, 'group_member_extensions_associated', headers, url, body
+    s.check_event('group_member_extensions_associated', headers, url, body)

--- a/integration_tests/suite/base/test_group_member_user.py
+++ b/integration_tests/suite/base/test_group_member_user.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import re
@@ -27,44 +27,42 @@ def test_associate_errors(group, user):
     response.assert_status(404)
 
     url = confd.groups(group['id']).members.users.put
-    for check in error_checks(url):
-        yield check
+    error_checks(url)
 
     url = confd.groups(group['uuid']).members.users.put
-    for check in error_checks(url):
-        yield check
+    error_checks(url)
 
 
 def error_checks(url):
-    yield s.check_bogus_field_returns_error, url, 'users', 123
-    yield s.check_bogus_field_returns_error, url, 'users', None
-    yield s.check_bogus_field_returns_error, url, 'users', True
-    yield s.check_bogus_field_returns_error, url, 'users', 'string'
-    yield s.check_bogus_field_returns_error, url, 'users', [123]
-    yield s.check_bogus_field_returns_error, url, 'users', [None]
-    yield s.check_bogus_field_returns_error, url, 'users', ['string']
-    yield s.check_bogus_field_returns_error, url, 'users', [{}]
-    yield s.check_bogus_field_returns_error, url, 'users', [{'uuid': None}]
-    yield s.check_bogus_field_returns_error, url, 'users', [{'uuid': 1}, {'uuid': None}]
-    yield s.check_bogus_field_returns_error, url, 'users', [{'not_uuid': 123}]
-    yield s.check_bogus_field_returns_error, url, 'users', [{'uuid': FAKE_UUID}]
+    s.check_bogus_field_returns_error(url, 'users', 123)
+    s.check_bogus_field_returns_error(url, 'users', None)
+    s.check_bogus_field_returns_error(url, 'users', True)
+    s.check_bogus_field_returns_error(url, 'users', 'string')
+    s.check_bogus_field_returns_error(url, 'users', [123])
+    s.check_bogus_field_returns_error(url, 'users', [None])
+    s.check_bogus_field_returns_error(url, 'users', ['string'])
+    s.check_bogus_field_returns_error(url, 'users', [{}])
+    s.check_bogus_field_returns_error(url, 'users', [{'uuid': None}])
+    s.check_bogus_field_returns_error(url, 'users', [{'uuid': 1}, {'uuid': None}])
+    s.check_bogus_field_returns_error(url, 'users', [{'not_uuid': 123}])
+    s.check_bogus_field_returns_error(url, 'users', [{'uuid': FAKE_UUID}])
 
     regex = r'users.*priority'
-    yield s.check_bogus_field_returns_error_matching_regex, url, 'users', [
-        {'priority': None}
-    ], regex
-    yield s.check_bogus_field_returns_error_matching_regex, url, 'users', [
-        {'priority': 'string'}
-    ], regex
-    yield s.check_bogus_field_returns_error_matching_regex, url, 'users', [
-        {'priority': -1}
-    ], regex
-    yield s.check_bogus_field_returns_error_matching_regex, url, 'users', [
-        {'priority': []}
-    ], regex
-    yield s.check_bogus_field_returns_error_matching_regex, url, 'users', [
-        {'priority': {}}
-    ], regex
+    s.check_bogus_field_returns_error_matching_regex(
+        url, 'users', [{'priority': None}], regex
+    )
+    s.check_bogus_field_returns_error_matching_regex(
+        url, 'users', [{'priority': 'string'}], regex
+    )
+    s.check_bogus_field_returns_error_matching_regex(
+        url, 'users', [{'priority': -1}], regex
+    )
+    s.check_bogus_field_returns_error_matching_regex(
+        url, 'users', [{'priority': []}], regex
+    )
+    s.check_bogus_field_returns_error_matching_regex(
+        url, 'users', [{'priority': {}}], regex
+    )
 
 
 @fixtures.group()
@@ -268,13 +266,13 @@ def test_delete_group_when_group_and_user_associated(group, user1, user2, line1,
         confd.groups(group['uuid']).delete().assert_deleted()
 
         deleted_group = confd.groups(group['uuid']).get
-        yield s.check_resource_not_found, deleted_group, 'Group'
+        s.check_resource_not_found(deleted_group, 'Group')
 
         response = confd.users(user1['uuid']).get()
-        yield assert_that, response.item['groups'], empty()
+        assert_that(response.item['groups'], empty())
 
         response = confd.users(user2['uuid']).get()
-        yield assert_that, response.item['groups'], empty()
+        assert_that(response.item['groups'], empty())
 
 
 @fixtures.group()
@@ -289,13 +287,13 @@ def test_delete_user_when_group_and_user_associated(group1, group2, user, line):
         confd.users(user['uuid']).delete().assert_deleted()
 
         deleted_user = confd.users(user['uuid']).get
-        yield s.check_resource_not_found, deleted_user, 'User'
+        s.check_resource_not_found(deleted_user, 'User')
 
         response = confd.groups(group1['uuid']).get()
-        yield assert_that, response.item['members']['users'], empty()
+        assert_that(response.item['members']['users'], empty())
 
         response = confd.groups(group2['uuid']).get()
-        yield assert_that, response.item['members']['users'], empty()
+        assert_that(response.item['members']['users'], empty())
 
 
 @fixtures.group()
@@ -307,4 +305,4 @@ def test_bus_events(group, user, line):
         body = {'users': [user]}
         headers = {'tenant_uuid': MAIN_TENANT}
 
-        yield s.check_event, 'group_member_users_associated', headers, url, body
+        s.check_event('group_member_users_associated', headers, url, body)

--- a/integration_tests/suite/base/test_group_schedule.py
+++ b/integration_tests/suite/base/test_group_schedule.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2021 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import assert_that, contains, has_entries
@@ -16,11 +16,11 @@ def test_associate_errors(group, schedule):
     fake_group = confd.groups(FAKE_ID).schedules(schedule['id']).put
     fake_schedule = confd.groups(group['id']).schedules(FAKE_ID).put
 
-    yield s.check_resource_not_found, fake_group, 'Group'
-    yield s.check_resource_not_found, fake_schedule, 'Schedule'
+    s.check_resource_not_found(fake_group, 'Group')
+    s.check_resource_not_found(fake_schedule, 'Schedule')
 
     fake_schedule = confd.groups(group['uuid']).schedules(FAKE_ID).put
-    yield s.check_resource_not_found, fake_schedule, 'Schedule'
+    s.check_resource_not_found(fake_schedule, 'Schedule')
 
 
 @fixtures.group()
@@ -29,11 +29,11 @@ def test_dissociate_errors(group, schedule):
     fake_group = confd.groups(FAKE_ID).schedules(schedule['id']).delete
     fake_schedule = confd.groups(group['id']).schedules(FAKE_ID).delete
 
-    yield s.check_resource_not_found, fake_group, 'Group'
-    yield s.check_resource_not_found, fake_schedule, 'Schedule'
+    s.check_resource_not_found(fake_group, 'Group')
+    s.check_resource_not_found(fake_schedule, 'Schedule')
 
     fake_schedule = confd.groups(group['uuid']).schedules(FAKE_ID).delete
-    yield s.check_resource_not_found, fake_schedule, 'Schedule'
+    s.check_resource_not_found(fake_schedule, 'Schedule')
 
 
 @fixtures.group()

--- a/integration_tests/suite/base/test_groups.py
+++ b/integration_tests/suite/base/test_groups.py
@@ -30,89 +30,84 @@ from ..helpers.config import (
 
 def test_get_errors():
     fake_group = confd.groups(999999).get
-    yield s.check_resource_not_found, fake_group, 'Group'
+    s.check_resource_not_found(fake_group, 'Group')
 
 
 def test_delete_errors():
     fake_group = confd.groups(999999).delete
-    yield s.check_resource_not_found, fake_group, 'Group'
+    s.check_resource_not_found(fake_group, 'Group')
 
 
 def test_post_errors():
     url = confd.groups.post
-    for check in error_checks(url):
-        yield check
+    error_checks(url)
 
 
 @fixtures.group()
 def test_put_errors(group):
     url = confd.groups(group['id']).put
-    for check in error_checks(url):
-        yield check
+    error_checks(url)
 
     url = confd.groups(group['uuid']).put
-    for check in error_checks(url):
-        yield check
+    error_checks(url)
 
 
 def error_checks(url):
-    yield s.check_bogus_field_returns_error, url, 'label', 123
-    yield s.check_bogus_field_returns_error, url, 'label', True
-    yield s.check_bogus_field_returns_error, url, 'label', None
-    yield s.check_bogus_field_returns_error, url, 'label', s.random_string(129)
-    yield s.check_bogus_field_returns_error, url, 'label', 'legitimate name\nconfig injection'
-    yield s.check_bogus_field_returns_error, url, 'label', []
-    yield s.check_bogus_field_returns_error, url, 'label', {}
-    yield s.check_bogus_field_returns_error, url, 'preprocess_subroutine', 123
-    yield s.check_bogus_field_returns_error, url, 'preprocess_subroutine', s.random_string(
-        80
-    )
-    yield s.check_bogus_field_returns_error, url, 'preprocess_subroutine', []
-    yield s.check_bogus_field_returns_error, url, 'preprocess_subroutine', {}
-    yield s.check_bogus_field_returns_error, url, 'ring_strategy', 123
-    yield s.check_bogus_field_returns_error, url, 'ring_strategy', 'invalid'
-    yield s.check_bogus_field_returns_error, url, 'ring_strategy', True
-    yield s.check_bogus_field_returns_error, url, 'ring_strategy', None
-    yield s.check_bogus_field_returns_error, url, 'ring_strategy', []
-    yield s.check_bogus_field_returns_error, url, 'ring_strategy', {}
-    yield s.check_bogus_field_returns_error, url, 'caller_id_mode', True
-    yield s.check_bogus_field_returns_error, url, 'caller_id_mode', 'invalid'
-    yield s.check_bogus_field_returns_error, url, 'caller_id_mode', 1234
-    yield s.check_bogus_field_returns_error, url, 'caller_id_mode', []
-    yield s.check_bogus_field_returns_error, url, 'caller_id_mode', {}
-    yield s.check_bogus_field_returns_error, url, 'caller_id_name', 1234
-    yield s.check_bogus_field_returns_error, url, 'caller_id_name', True
-    yield s.check_bogus_field_returns_error, url, 'caller_id_name', s.random_string(81)
-    yield s.check_bogus_field_returns_error, url, 'caller_id_name', []
-    yield s.check_bogus_field_returns_error, url, 'caller_id_name', {}
-    yield s.check_bogus_field_returns_error, url, 'music_on_hold', 123
-    yield s.check_bogus_field_returns_error, url, 'music_on_hold', s.random_string(129)
-    yield s.check_bogus_field_returns_error, url, 'music_on_hold', []
-    yield s.check_bogus_field_returns_error, url, 'music_on_hold', {}
-    yield s.check_bogus_field_returns_error, url, 'user_timeout', 'ten'
-    yield s.check_bogus_field_returns_error, url, 'user_timeout', -1
-    yield s.check_bogus_field_returns_error, url, 'user_timeout', {}
-    yield s.check_bogus_field_returns_error, url, 'user_timeout', []
-    yield s.check_bogus_field_returns_error, url, 'retry_delay', 'ten'
-    yield s.check_bogus_field_returns_error, url, 'retry_delay', -1
-    yield s.check_bogus_field_returns_error, url, 'retry_delay', {}
-    yield s.check_bogus_field_returns_error, url, 'retry_delay', []
-    yield s.check_bogus_field_returns_error, url, 'timeout', 'ten'
-    yield s.check_bogus_field_returns_error, url, 'timeout', -1
-    yield s.check_bogus_field_returns_error, url, 'timeout', {}
-    yield s.check_bogus_field_returns_error, url, 'timeout', []
-    yield s.check_bogus_field_returns_error, url, 'ring_in_use', 'yeah'
-    yield s.check_bogus_field_returns_error, url, 'ring_in_use', 123
-    yield s.check_bogus_field_returns_error, url, 'ring_in_use', {}
-    yield s.check_bogus_field_returns_error, url, 'ring_in_use', []
-    yield s.check_bogus_field_returns_error, url, 'mark_answered_elsewhere', 'yeah'
-    yield s.check_bogus_field_returns_error, url, 'mark_answered_elsewhere', 123
-    yield s.check_bogus_field_returns_error, url, 'mark_answered_elsewhere', {}
-    yield s.check_bogus_field_returns_error, url, 'mark_answered_elsewhere', []
-    yield s.check_bogus_field_returns_error, url, 'enabled', 'yeah'
-    yield s.check_bogus_field_returns_error, url, 'enabled', 123
-    yield s.check_bogus_field_returns_error, url, 'enabled', {}
-    yield s.check_bogus_field_returns_error, url, 'enabled', []
+    s.check_bogus_field_returns_error(url, 'label', 123)
+    s.check_bogus_field_returns_error(url, 'label', True)
+    s.check_bogus_field_returns_error(url, 'label', None)
+    s.check_bogus_field_returns_error(url, 'label', s.random_string(129))
+    s.check_bogus_field_returns_error(url, 'label', 'legitimate name\nconfig injection')
+    s.check_bogus_field_returns_error(url, 'label', [])
+    s.check_bogus_field_returns_error(url, 'label', {})
+    s.check_bogus_field_returns_error(url, 'preprocess_subroutine', 123)
+    s.check_bogus_field_returns_error(url, 'preprocess_subroutine', s.random_string(80))
+    s.check_bogus_field_returns_error(url, 'preprocess_subroutine', [])
+    s.check_bogus_field_returns_error(url, 'preprocess_subroutine', {})
+    s.check_bogus_field_returns_error(url, 'ring_strategy', 123)
+    s.check_bogus_field_returns_error(url, 'ring_strategy', 'invalid')
+    s.check_bogus_field_returns_error(url, 'ring_strategy', True)
+    s.check_bogus_field_returns_error(url, 'ring_strategy', None)
+    s.check_bogus_field_returns_error(url, 'ring_strategy', [])
+    s.check_bogus_field_returns_error(url, 'ring_strategy', {})
+    s.check_bogus_field_returns_error(url, 'caller_id_mode', True)
+    s.check_bogus_field_returns_error(url, 'caller_id_mode', 'invalid')
+    s.check_bogus_field_returns_error(url, 'caller_id_mode', 1234)
+    s.check_bogus_field_returns_error(url, 'caller_id_mode', [])
+    s.check_bogus_field_returns_error(url, 'caller_id_mode', {})
+    s.check_bogus_field_returns_error(url, 'caller_id_name', 1234)
+    s.check_bogus_field_returns_error(url, 'caller_id_name', True)
+    s.check_bogus_field_returns_error(url, 'caller_id_name', s.random_string(81))
+    s.check_bogus_field_returns_error(url, 'caller_id_name', [])
+    s.check_bogus_field_returns_error(url, 'caller_id_name', {})
+    s.check_bogus_field_returns_error(url, 'music_on_hold', 123)
+    s.check_bogus_field_returns_error(url, 'music_on_hold', s.random_string(129))
+    s.check_bogus_field_returns_error(url, 'music_on_hold', [])
+    s.check_bogus_field_returns_error(url, 'music_on_hold', {})
+    s.check_bogus_field_returns_error(url, 'user_timeout', 'ten')
+    s.check_bogus_field_returns_error(url, 'user_timeout', -1)
+    s.check_bogus_field_returns_error(url, 'user_timeout', {})
+    s.check_bogus_field_returns_error(url, 'user_timeout', [])
+    s.check_bogus_field_returns_error(url, 'retry_delay', 'ten')
+    s.check_bogus_field_returns_error(url, 'retry_delay', -1)
+    s.check_bogus_field_returns_error(url, 'retry_delay', {})
+    s.check_bogus_field_returns_error(url, 'retry_delay', [])
+    s.check_bogus_field_returns_error(url, 'timeout', 'ten')
+    s.check_bogus_field_returns_error(url, 'timeout', -1)
+    s.check_bogus_field_returns_error(url, 'timeout', {})
+    s.check_bogus_field_returns_error(url, 'timeout', [])
+    s.check_bogus_field_returns_error(url, 'ring_in_use', 'yeah')
+    s.check_bogus_field_returns_error(url, 'ring_in_use', 123)
+    s.check_bogus_field_returns_error(url, 'ring_in_use', {})
+    s.check_bogus_field_returns_error(url, 'ring_in_use', [])
+    s.check_bogus_field_returns_error(url, 'mark_answered_elsewhere', 'yeah')
+    s.check_bogus_field_returns_error(url, 'mark_answered_elsewhere', 123)
+    s.check_bogus_field_returns_error(url, 'mark_answered_elsewhere', {})
+    s.check_bogus_field_returns_error(url, 'mark_answered_elsewhere', [])
+    s.check_bogus_field_returns_error(url, 'enabled', 'yeah')
+    s.check_bogus_field_returns_error(url, 'enabled', 123)
+    s.check_bogus_field_returns_error(url, 'enabled', {})
+    s.check_bogus_field_returns_error(url, 'enabled', [])
 
 
 @fixtures.extension(exten=gen_group_exten())
@@ -123,12 +118,12 @@ def test_search(extension, hidden, group):
     searches = {'label': 'search', 'preprocess_subroutine': 'search'}
 
     for field, term in searches.items():
-        yield check_search, url, group, hidden, field, term
+        check_search(url, group, hidden, field, term)
 
     searches = {'exten': extension['exten']}
     with a.group_extension(group, extension):
         for field, term in searches.items():
-            yield check_relation_search, url, group, hidden, field, term
+            check_relation_search(url, group, hidden, field, term)
 
 
 def check_search(url, group, hidden, field, term):
@@ -168,11 +163,11 @@ def test_list_multi_tenant(main, sub):
 @fixtures.group(label='sort2', preprocess_subroutine='sort2')
 def test_sorting_offset_limit(group1, group2):
     url = confd.groups.get
-    yield s.check_sorting, url, group1, group2, 'label', 'sort'
-    yield s.check_sorting, url, group1, group2, 'preprocess_subroutine', 'sort'
+    s.check_sorting(url, group1, group2, 'label', 'sort')
+    s.check_sorting(url, group1, group2, 'preprocess_subroutine', 'sort')
 
-    yield s.check_offset, url, group1, group2, 'label', 'sort'
-    yield s.check_limit, url, group1, group2, 'label', 'sort'
+    s.check_offset(url, group1, group2, 'label', 'sort')
+    s.check_limit(url, group1, group2, 'label', 'sort')
 
 
 @fixtures.group()
@@ -477,19 +472,22 @@ def test_delete_multi_tenant_by_uuid(main, sub):
 def test_bus_events(group):
     headers = {'tenant_uuid': MAIN_TENANT}
 
-    yield s.check_event, 'group_created', headers, confd.groups.post, {
-        'label': 'group_bus_event'
-    }
-    yield s.check_event, 'group_edited', headers, confd.groups(group['id']).put
-    yield s.check_event, 'group_deleted', headers, confd.groups(group['id']).delete
+    s.check_event(
+        'group_created', headers, confd.groups.post, {'label': 'group_bus_event'}
+    )
+    s.check_event('group_edited', headers, confd.groups(group['id']).put)
+    s.check_event('group_deleted', headers, confd.groups(group['id']).delete)
 
 
 @fixtures.group()
 def test_bus_events_by_uuid(group):
     headers = {'tenant_uuid': MAIN_TENANT}
 
-    yield s.check_event, 'group_created', headers, confd.groups.post, {
-        'label': 'group_bus_event_with_uuid'
-    }
-    yield s.check_event, 'group_edited', headers, confd.groups(group['uuid']).put
-    yield s.check_event, 'group_deleted', headers, confd.groups(group['uuid']).delete
+    s.check_event(
+        'group_created',
+        headers,
+        confd.groups.post,
+        {'label': 'group_bus_event_with_uuid'},
+    )
+    s.check_event('group_edited', headers, confd.groups(group['uuid']).put)
+    s.check_event('group_deleted', headers, confd.groups(group['uuid']).delete)

--- a/integration_tests/suite/base/test_hep_general.py
+++ b/integration_tests/suite/base/test_hep_general.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import assert_that, has_entries
@@ -10,17 +10,16 @@ from ..helpers.config import TOKEN_SUB_TENANT
 
 def test_put_errors():
     url = confd.asterisk.hep.general.put
-    for check in error_checks(url):
-        yield check
+    error_checks(url)
 
 
 def error_checks(url):
-    yield s.check_bogus_field_returns_error, url, 'options', 123
-    yield s.check_bogus_field_returns_error, url, 'options', None
-    yield s.check_bogus_field_returns_error, url, 'options', 'string'
-    yield s.check_bogus_field_returns_error, url, 'options', [['ordered', 'option']]
-    yield s.check_bogus_field_returns_error, url, 'options', {'wrong_value': 23}
-    yield s.check_bogus_field_returns_error, url, 'options', {'none_value': None}
+    s.check_bogus_field_returns_error(url, 'options', 123)
+    s.check_bogus_field_returns_error(url, 'options', None)
+    s.check_bogus_field_returns_error(url, 'options', 'string')
+    s.check_bogus_field_returns_error(url, 'options', [['ordered', 'option']])
+    s.check_bogus_field_returns_error(url, 'options', {'wrong_value': 23})
+    s.check_bogus_field_returns_error(url, 'options', {'none_value': None})
 
 
 def test_get():
@@ -59,4 +58,4 @@ def test_bus_event_when_edited():
     url = confd.asterisk.hep.general
     headers = {}
 
-    yield s.check_event, 'hep_general_edited', headers, url.put, {'options': {}}
+    s.check_event('hep_general_edited', headers, url.put, {'options': {}})

--- a/integration_tests/suite/base/test_iax_callnumberlimits.py
+++ b/integration_tests/suite/base/test_iax_callnumberlimits.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import assert_that, has_entries
@@ -10,63 +10,62 @@ from ..helpers.config import TOKEN_SUB_TENANT
 
 def test_put_errors():
     url = confd.asterisk.iax.callnumberlimits.put
-    for check in error_checks(url):
-        yield check
+    error_checks(url)
 
 
 def error_checks(url):
-    yield s.check_bogus_field_returns_error, url, 'items', 123
-    yield s.check_bogus_field_returns_error, url, 'items', None
-    yield s.check_bogus_field_returns_error, url, 'items', {}
-    yield s.check_bogus_field_returns_error, url, 'items', 'string'
-    yield s.check_bogus_field_returns_error, url, 'items', ['string']
-    yield s.check_bogus_field_returns_error, url, 'items', [{'key': 'value'}]
+    s.check_bogus_field_returns_error(url, 'items', 123)
+    s.check_bogus_field_returns_error(url, 'items', None)
+    s.check_bogus_field_returns_error(url, 'items', {})
+    s.check_bogus_field_returns_error(url, 'items', 'string')
+    s.check_bogus_field_returns_error(url, 'items', ['string'])
+    s.check_bogus_field_returns_error(url, 'items', [{'key': 'value'}])
 
     regex = r'items.*ip_address'
-    yield s.check_bogus_field_returns_error_matching_regex, url, 'items', [
-        {'ip_address': 123}
-    ], regex
-    yield s.check_bogus_field_returns_error_matching_regex, url, 'items', [
-        {'ip_address': True}
-    ], regex
-    yield s.check_bogus_field_returns_error_matching_regex, url, 'items', [
-        {'ip_address': None}
-    ], regex
-    yield s.check_bogus_field_returns_error_matching_regex, url, 'items', [
-        {'ip_address': {}}
-    ], regex
-    yield s.check_bogus_field_returns_error_matching_regex, url, 'items', [
-        {'ip_address': []}
-    ], regex
+    s.check_bogus_field_returns_error_matching_regex(
+        url, 'items', [{'ip_address': 123}], regex
+    )
+    s.check_bogus_field_returns_error_matching_regex(
+        url, 'items', [{'ip_address': True}], regex
+    )
+    s.check_bogus_field_returns_error_matching_regex(
+        url, 'items', [{'ip_address': None}], regex
+    )
+    s.check_bogus_field_returns_error_matching_regex(
+        url, 'items', [{'ip_address': {}}], regex
+    )
+    s.check_bogus_field_returns_error_matching_regex(
+        url, 'items', [{'ip_address': []}], regex
+    )
     regex = r'items.*netmask'
-    yield s.check_bogus_field_returns_error_matching_regex, url, 'items', [
-        {'netmask': 123}
-    ], regex
-    yield s.check_bogus_field_returns_error_matching_regex, url, 'items', [
-        {'netmask': True}
-    ], regex
-    yield s.check_bogus_field_returns_error_matching_regex, url, 'items', [
-        {'netmask': None}
-    ], regex
-    yield s.check_bogus_field_returns_error_matching_regex, url, 'items', [
-        {'netmask': {}}
-    ], regex
-    yield s.check_bogus_field_returns_error_matching_regex, url, 'items', [
-        {'netmask': []}
-    ], regex
+    s.check_bogus_field_returns_error_matching_regex(
+        url, 'items', [{'netmask': 123}], regex
+    )
+    s.check_bogus_field_returns_error_matching_regex(
+        url, 'items', [{'netmask': True}], regex
+    )
+    s.check_bogus_field_returns_error_matching_regex(
+        url, 'items', [{'netmask': None}], regex
+    )
+    s.check_bogus_field_returns_error_matching_regex(
+        url, 'items', [{'netmask': {}}], regex
+    )
+    s.check_bogus_field_returns_error_matching_regex(
+        url, 'items', [{'netmask': []}], regex
+    )
     regex = r'items.*limit'
-    yield s.check_bogus_field_returns_error_matching_regex, url, 'items', [
-        {'limit': 'string'}
-    ], regex
-    yield s.check_bogus_field_returns_error_matching_regex, url, 'items', [
-        {'limit': None}
-    ], regex
-    yield s.check_bogus_field_returns_error_matching_regex, url, 'items', [
-        {'limit': {}}
-    ], regex
-    yield s.check_bogus_field_returns_error_matching_regex, url, 'items', [
-        {'limit': []}
-    ], regex
+    s.check_bogus_field_returns_error_matching_regex(
+        url, 'items', [{'limit': 'string'}], regex
+    )
+    s.check_bogus_field_returns_error_matching_regex(
+        url, 'items', [{'limit': None}], regex
+    )
+    s.check_bogus_field_returns_error_matching_regex(
+        url, 'items', [{'limit': {}}], regex
+    )
+    s.check_bogus_field_returns_error_matching_regex(
+        url, 'items', [{'limit': []}], regex
+    )
 
 
 def test_get():
@@ -107,4 +106,4 @@ def test_bus_event_when_edited():
     url = confd.asterisk.iax.callnumberlimits
     headers = {}
 
-    yield s.check_event, 'iax_callnumberlimits_edited', headers, url.put, {'items': []}
+    s.check_event('iax_callnumberlimits_edited', headers, url.put, {'items': []})

--- a/integration_tests/suite/base/test_iax_general.py
+++ b/integration_tests/suite/base/test_iax_general.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from ..helpers import scenarios as s
@@ -10,45 +10,42 @@ from ..helpers.config import TOKEN_SUB_TENANT
 
 def test_put_errors():
     url = confd.asterisk.iax.general.put
-    for check in error_checks(url):
-        yield check
+    error_checks(url)
 
 
 def error_checks(url):
-    yield s.check_bogus_field_returns_error, url, 'ordered_options', 123
-    yield s.check_bogus_field_returns_error, url, 'ordered_options', None
-    yield s.check_bogus_field_returns_error, url, 'ordered_options', {}
-    yield s.check_bogus_field_returns_error, url, 'ordered_options', 'string'
-    yield s.check_bogus_field_returns_error, url, 'ordered_options', [
-        'string',
-        'string',
-    ]
-    yield s.check_bogus_field_returns_error, url, 'ordered_options', [123, 123]
-    yield s.check_bogus_field_returns_error, url, 'ordered_options', ['string', 123]
-    yield s.check_bogus_field_returns_error, url, 'ordered_options', [[]]
-    yield s.check_bogus_field_returns_error, url, 'ordered_options', [{'key': 'value'}]
-    yield s.check_bogus_field_returns_error, url, 'ordered_options', [['missing_value']]
-    yield s.check_bogus_field_returns_error, url, 'ordered_options', [
-        ['too', 'much', 'value']
-    ]
-    yield s.check_bogus_field_returns_error, url, 'ordered_options', [
-        ['wrong_value', 1234]
-    ]
-    yield s.check_bogus_field_returns_error, url, 'ordered_options', [
-        ['none_value', None]
-    ]
+    s.check_bogus_field_returns_error(url, 'ordered_options', 123)
+    s.check_bogus_field_returns_error(url, 'ordered_options', None)
+    s.check_bogus_field_returns_error(url, 'ordered_options', {})
+    s.check_bogus_field_returns_error(url, 'ordered_options', 'string')
+    s.check_bogus_field_returns_error(
+        url,
+        'ordered_options',
+        [
+            'string',
+            'string',
+        ],
+    )
+    s.check_bogus_field_returns_error(url, 'ordered_options', [123, 123])
+    s.check_bogus_field_returns_error(url, 'ordered_options', ['string', 123])
+    s.check_bogus_field_returns_error(url, 'ordered_options', [[]])
+    s.check_bogus_field_returns_error(url, 'ordered_options', [{'key': 'value'}])
+    s.check_bogus_field_returns_error(url, 'ordered_options', [['missing_value']])
+    s.check_bogus_field_returns_error(
+        url, 'ordered_options', [['too', 'much', 'value']]
+    )
+    s.check_bogus_field_returns_error(url, 'ordered_options', [['wrong_value', 1234]])
+    s.check_bogus_field_returns_error(url, 'ordered_options', [['none_value', None]])
 
-    yield s.check_bogus_field_returns_error, url, 'options', 123
-    yield s.check_bogus_field_returns_error, url, 'options', None
-    yield s.check_bogus_field_returns_error, url, 'options', 'string'
-    yield s.check_bogus_field_returns_error, url, 'options', [['ordered', 'option']]
-    yield s.check_bogus_field_returns_error, url, 'options', {'wrong_value': 23}
-    yield s.check_bogus_field_returns_error, url, 'options', {'none_value': None}
+    s.check_bogus_field_returns_error(url, 'options', 123)
+    s.check_bogus_field_returns_error(url, 'options', None)
+    s.check_bogus_field_returns_error(url, 'options', 'string')
+    s.check_bogus_field_returns_error(url, 'options', [['ordered', 'option']])
+    s.check_bogus_field_returns_error(url, 'options', {'wrong_value': 23})
+    s.check_bogus_field_returns_error(url, 'options', {'none_value': None})
 
-    yield s.check_bogus_field_returns_error, url, 'options', {'register': 'value'}
-    yield s.check_bogus_field_returns_error, url, 'ordered_options', [
-        ['register', 'value']
-    ]
+    s.check_bogus_field_returns_error(url, 'options', {'register': 'value'})
+    s.check_bogus_field_returns_error(url, 'ordered_options', [['register', 'value']])
 
 
 def test_get():
@@ -105,7 +102,12 @@ def test_bus_event_when_edited():
     url = confd.asterisk.iax.general
     headers = {}
 
-    yield s.check_event, 'iax_general_edited', headers, url.put, {
-        'ordered_options': [],
-        'options': {},
-    }
+    s.check_event(
+        'iax_general_edited',
+        headers,
+        url.put,
+        {
+            'ordered_options': [],
+            'options': {},
+        },
+    )

--- a/integration_tests/suite/base/test_incall_extension.py
+++ b/integration_tests/suite/base/test_incall_extension.py
@@ -16,8 +16,8 @@ def test_associate_errors(incall, extension):
     fake_incall = confd.incalls(FAKE_ID).extensions(extension['id']).put
     fake_extension = confd.incalls(incall['id']).extensions(FAKE_ID).put
 
-    yield s.check_resource_not_found, fake_incall, 'Incall'
-    yield s.check_resource_not_found, fake_extension, 'Extension'
+    s.check_resource_not_found(fake_incall, 'Incall')
+    s.check_resource_not_found(fake_extension, 'Extension')
 
 
 @fixtures.incall()
@@ -26,8 +26,8 @@ def test_dissociate_errors(incall, extension):
     fake_incall = confd.incalls(FAKE_ID).extensions(extension['id']).delete
     fake_extension = confd.incalls(incall['id']).extensions(FAKE_ID).delete
 
-    yield s.check_resource_not_found, fake_incall, 'Incall'
-    yield s.check_resource_not_found, fake_extension, 'Extension'
+    s.check_resource_not_found(fake_incall, 'Incall')
+    s.check_resource_not_found(fake_extension, 'Extension')
 
 
 @fixtures.incall()

--- a/integration_tests/suite/base/test_incall_schedule.py
+++ b/integration_tests/suite/base/test_incall_schedule.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import assert_that, contains, has_entries
@@ -15,8 +15,8 @@ def test_associate_errors(incall, schedule):
     fake_incall = confd.incalls(FAKE_ID).schedules(schedule['id']).put
     fake_schedule = confd.incalls(incall['id']).schedules(FAKE_ID).put
 
-    yield s.check_resource_not_found, fake_incall, 'Incall'
-    yield s.check_resource_not_found, fake_schedule, 'Schedule'
+    s.check_resource_not_found(fake_incall, 'Incall')
+    s.check_resource_not_found(fake_schedule, 'Schedule')
 
 
 @fixtures.incall()
@@ -25,8 +25,8 @@ def test_dissociate_errors(incall, schedule):
     fake_incall = confd.incalls(FAKE_ID).schedules(schedule['id']).delete
     fake_schedule = confd.incalls(incall['id']).schedules(FAKE_ID).delete
 
-    yield s.check_resource_not_found, fake_incall, 'Incall'
-    yield s.check_resource_not_found, fake_schedule, 'Schedule'
+    s.check_resource_not_found(fake_incall, 'Incall')
+    s.check_resource_not_found(fake_schedule, 'Schedule')
 
 
 @fixtures.incall()

--- a/integration_tests/suite/base/test_incalls.py
+++ b/integration_tests/suite/base/test_incalls.py
@@ -27,63 +27,65 @@ from ..helpers.config import INCALL_CONTEXT, MAIN_TENANT, SUB_TENANT
 
 def test_get_errors():
     fake_incall = confd.incalls(999999).get
-    yield s.check_resource_not_found, fake_incall, 'Incall'
+    s.check_resource_not_found(fake_incall, 'Incall')
 
 
 def test_delete_errors():
     fake_incall = confd.incalls(999999).delete
-    yield s.check_resource_not_found, fake_incall, 'Incall'
+    s.check_resource_not_found(fake_incall, 'Incall')
 
 
 @fixtures.user()
 def test_post_errors(user):
     url = confd.incalls.post
-    for check in error_checks(url, user):
-        yield check
+    error_checks(url, user)
 
 
 @fixtures.incall()
 @fixtures.user()
 def test_put_errors(incall, user):
     url = confd.incalls(incall['id']).put
-    for check in error_checks(url, user):
-        yield check
+    error_checks(url, user)
 
 
 def error_checks(url, user):
-    yield s.check_bogus_field_returns_error, url, 'preprocess_subroutine', 123
-    yield s.check_bogus_field_returns_error, url, 'preprocess_subroutine', s.random_string(
-        80
-    )
-    yield s.check_bogus_field_returns_error, url, 'preprocess_subroutine', []
-    yield s.check_bogus_field_returns_error, url, 'preprocess_subroutine', {}
-    yield s.check_bogus_field_returns_error, url, 'greeting_sound', 123
-    yield s.check_bogus_field_returns_error, url, 'greeting_sound', s.random_string(256)
-    yield s.check_bogus_field_returns_error, url, 'greeting_sound', []
-    yield s.check_bogus_field_returns_error, url, 'greeting_sound', {}
-    yield s.check_bogus_field_returns_error, url, 'caller_id_mode', True
-    yield s.check_bogus_field_returns_error, url, 'caller_id_mode', 'invalid'
-    yield s.check_bogus_field_returns_error, url, 'caller_id_mode', 1234
-    yield s.check_bogus_field_returns_error, url, 'caller_id_mode', []
-    yield s.check_bogus_field_returns_error, url, 'caller_id_mode', {}
-    yield s.check_bogus_field_returns_error, url, 'caller_id_name', 1234
-    yield s.check_bogus_field_returns_error, url, 'caller_id_name', True
-    yield s.check_bogus_field_returns_error, url, 'caller_id_name', s.random_string(81)
-    yield s.check_bogus_field_returns_error, url, 'caller_id_name', []
-    yield s.check_bogus_field_returns_error, url, 'caller_id_name', {}
-    yield s.check_bogus_field_returns_error, url, 'description', 1234
-    yield s.check_bogus_field_returns_error, url, 'description', []
-    yield s.check_bogus_field_returns_error, url, 'destination', {}
-    yield s.check_bogus_field_returns_error, url, 'destination', None
+    s.check_bogus_field_returns_error(url, 'preprocess_subroutine', 123)
+    s.check_bogus_field_returns_error(url, 'preprocess_subroutine', s.random_string(80))
+    s.check_bogus_field_returns_error(url, 'preprocess_subroutine', [])
+    s.check_bogus_field_returns_error(url, 'preprocess_subroutine', {})
+    s.check_bogus_field_returns_error(url, 'greeting_sound', 123)
+    s.check_bogus_field_returns_error(url, 'greeting_sound', s.random_string(256))
+    s.check_bogus_field_returns_error(url, 'greeting_sound', [])
+    s.check_bogus_field_returns_error(url, 'greeting_sound', {})
+    s.check_bogus_field_returns_error(url, 'caller_id_mode', True)
+    s.check_bogus_field_returns_error(url, 'caller_id_mode', 'invalid')
+    s.check_bogus_field_returns_error(url, 'caller_id_mode', 1234)
+    s.check_bogus_field_returns_error(url, 'caller_id_mode', [])
+    s.check_bogus_field_returns_error(url, 'caller_id_mode', {})
+    s.check_bogus_field_returns_error(url, 'caller_id_name', 1234)
+    s.check_bogus_field_returns_error(url, 'caller_id_name', True)
+    s.check_bogus_field_returns_error(url, 'caller_id_name', s.random_string(81))
+    s.check_bogus_field_returns_error(url, 'caller_id_name', [])
+    s.check_bogus_field_returns_error(url, 'caller_id_name', {})
+    s.check_bogus_field_returns_error(url, 'description', 1234)
+    s.check_bogus_field_returns_error(url, 'description', [])
+    s.check_bogus_field_returns_error(url, 'destination', {})
+    s.check_bogus_field_returns_error(url, 'destination', None)
 
     for destination in invalid_destinations():
-        yield s.check_bogus_field_returns_error, url, 'destination', destination
+        s.check_bogus_field_returns_error(url, 'destination', destination)
 
-    yield s.check_bogus_field_returns_error, url, 'destination', {
-        'type': 'user',
-        'user_id': user['id'],
-        'moh_uuid': '00000000-0000-0000-0000-000000000000',
-    }, {}, 'MOH was not found'
+    s.check_bogus_field_returns_error(
+        url,
+        'destination',
+        {
+            'type': 'user',
+            'user_id': user['id'],
+            'moh_uuid': '00000000-0000-0000-0000-000000000000',
+        },
+        {},
+        'MOH was not found',
+    )
 
 
 @fixtures.extension(context=INCALL_CONTEXT)
@@ -94,12 +96,12 @@ def test_search(extension, incall, hidden):
     searches = {'description': 'search'}
 
     for field, term in searches.items():
-        yield check_search, url, incall, hidden, field, term
+        check_search(url, incall, hidden, field, term)
 
     searches = {'exten': extension['exten']}
     with a.incall_extension(incall, extension):
         for field, term in searches.items():
-            yield check_relation_search, url, incall, hidden, field, term
+            check_relation_search(url, incall, hidden, field, term)
 
 
 def check_search(url, incall, hidden, field, term):
@@ -139,10 +141,10 @@ def test_search_multi_tenant(main, sub):
 @fixtures.incall(description='sort2')
 def test_sorting_offset_limit(incall1, incall2):
     url = confd.incalls.get
-    yield s.check_sorting, url, incall1, incall2, 'description', 'sort'
+    s.check_sorting(url, incall1, incall2, 'description', 'sort')
 
-    yield s.check_offset, url, incall1, incall2, 'description', 'sort'
-    yield s.check_limit, url, incall1, incall2, 'description', 'sort'
+    s.check_offset(url, incall1, incall2, 'description', 'sort')
+    s.check_limit(url, incall1, incall2, 'description', 'sort')
 
 
 @fixtures.incall()
@@ -262,8 +264,8 @@ def test_edit_multi_tenant(main, sub):
 @fixtures.moh()
 def test_valid_destinations(incall, *destinations):
     for destination in valid_destinations(*destinations):
-        yield create_incall_with_destination, destination
-        yield update_incall_with_destination, incall['id'], destination
+        create_incall_with_destination(destination)
+        update_incall_with_destination(incall['id'], destination)
 
 
 def create_incall_with_destination(destination):

--- a/integration_tests/suite/base/test_ingress_http.py
+++ b/integration_tests/suite/base/test_ingress_http.py
@@ -1,4 +1,4 @@
-# Copyright 2021-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2021-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import (
@@ -22,17 +22,16 @@ FAKE_UUID = '99999999-9999-4999-9999-999999999999'
 
 def test_post_errors():
     url = confd.ingresses.http.post
-    for check in error_checks(url):
-        yield check
+    error_checks(url)
 
 
 def error_checks(url):
-    yield s.check_bogus_field_returns_error, url, 'uri', 123
-    yield s.check_bogus_field_returns_error, url, 'uri', None
-    yield s.check_bogus_field_returns_error, url, 'uri', True
-    yield s.check_bogus_field_returns_error, url, 'uri', {}
-    yield s.check_bogus_field_returns_error, url, 'uri', []
-    yield s.check_bogus_field_returns_error, url, 'uri', 'a' * 1025
+    s.check_bogus_field_returns_error(url, 'uri', 123)
+    s.check_bogus_field_returns_error(url, 'uri', None)
+    s.check_bogus_field_returns_error(url, 'uri', True)
+    s.check_bogus_field_returns_error(url, 'uri', {})
+    s.check_bogus_field_returns_error(url, 'uri', [])
+    s.check_bogus_field_returns_error(url, 'uri', 'a' * 1025)
 
 
 def test_create_all_parameters():
@@ -77,7 +76,7 @@ def test_search(ingress_http, hidden):
     searches = {'uri': 'search'}
 
     for field, term in searches.items():
-        yield check_search, url, ingress_http, hidden, field, term
+        check_search(url, ingress_http, hidden, field, term)
 
 
 @fixtures.ingress_http(wazo_tenant=MAIN_TENANT)
@@ -114,7 +113,7 @@ def test_sorting_offset_limit(ingress_http1, ingress_http2):
 
 def test_get_errors():
     fake_ingress_http = confd.ingresses.http(FAKE_UUID).get
-    yield s.check_resource_not_found, fake_ingress_http, 'IngressHTTP'
+    s.check_resource_not_found(fake_ingress_http, 'IngressHTTP')
 
 
 @fixtures.ingress_http()
@@ -146,8 +145,7 @@ def test_put_errors(ingress_http):
     response.assert_match(404, e.not_found(resource='IngressHTTP'))
 
     url = confd.ingresses.http(ingress_http['uuid']).put
-    for check in error_checks(url):
-        yield check
+    error_checks(url)
 
 
 @fixtures.ingress_http()
@@ -182,7 +180,7 @@ def test_edit_multi_tenant(main, sub):
 
 def test_delete_errors():
     fake_ingress_http = confd.ingresses.http(FAKE_UUID).delete
-    yield s.check_resource_not_found, fake_ingress_http, 'IngressHTTP'
+    s.check_resource_not_found(fake_ingress_http, 'IngressHTTP')
 
 
 @fixtures.ingress_http()
@@ -211,8 +209,8 @@ def test_bus_events():
         nonlocal res
         res = confd.ingresses.http.post(uri='post')
 
-    yield s.check_event, 'ingress_http_created', headers, post
+    s.check_event('ingress_http_created', headers, post)
 
     url = confd.ingresses.http(res.item['uuid'])
-    yield s.check_event, 'ingress_http_edited', headers, url.put, {'uri': 'put'}
-    yield s.check_event, 'ingress_http_deleted', headers, url.delete
+    s.check_event('ingress_http_edited', headers, url.put, {'uri': 'put'})
+    s.check_event('ingress_http_deleted', headers, url.delete)

--- a/integration_tests/suite/base/test_ivr.py
+++ b/integration_tests/suite/base/test_ivr.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import (
@@ -21,104 +21,120 @@ from ..helpers.helpers.destination import invalid_destinations, valid_destinatio
 
 def test_get_errors():
     fake_ivr = confd.ivr(999999).get
-    yield s.check_resource_not_found, fake_ivr, 'IVR'
+    s.check_resource_not_found(fake_ivr, 'IVR')
 
 
 def test_delete_errors():
     fake_ivr = confd.ivr(999999).delete
-    yield s.check_resource_not_found, fake_ivr, 'IVR'
+    s.check_resource_not_found(fake_ivr, 'IVR')
 
 
 @fixtures.user()
 def test_post_errors(user):
     url = confd.ivr.post
-    for check in error_checks(url, user):
-        yield check
+    error_checks(url, user)
 
 
 @fixtures.ivr()
 @fixtures.user()
 def test_put_errors(ivr, user):
     url = confd.ivr(ivr['id']).put
-    for check in error_checks(url, user):
-        yield check
+    error_checks(url, user)
 
 
 def error_checks(url, user):
-    yield s.check_bogus_field_returns_error, url, 'abort_sound', True
-    yield s.check_bogus_field_returns_error, url, 'abort_sound', 123
-    yield s.check_bogus_field_returns_error, url, 'abort_sound', s.random_string(256)
-    yield s.check_bogus_field_returns_error, url, 'abort_sound', []
-    yield s.check_bogus_field_returns_error, url, 'abort_sound', {}
-    yield s.check_bogus_field_returns_error, url, 'greeting_sound', True
-    yield s.check_bogus_field_returns_error, url, 'greeting_sound', 123
-    yield s.check_bogus_field_returns_error, url, 'greeting_sound', s.random_string(256)
-    yield s.check_bogus_field_returns_error, url, 'greeting_sound', []
-    yield s.check_bogus_field_returns_error, url, 'greeting_sound', {}
-    yield s.check_bogus_field_returns_error, url, 'invalid_sound', True
-    yield s.check_bogus_field_returns_error, url, 'invalid_sound', 123
-    yield s.check_bogus_field_returns_error, url, 'invalid_sound', s.random_string(256)
-    yield s.check_bogus_field_returns_error, url, 'invalid_sound', []
-    yield s.check_bogus_field_returns_error, url, 'invalid_sound', {}
-    yield s.check_bogus_field_returns_error, url, 'menu_sound', True
-    yield s.check_bogus_field_returns_error, url, 'menu_sound', 123
-    yield s.check_bogus_field_returns_error, url, 'menu_sound', s.random_string(256)
-    yield s.check_bogus_field_returns_error, url, 'menu_sound', []
-    yield s.check_bogus_field_returns_error, url, 'menu_sound', {}
-    yield s.check_bogus_field_returns_error, url, 'name', True
-    yield s.check_bogus_field_returns_error, url, 'name', None
-    yield s.check_bogus_field_returns_error, url, 'name', s.random_string(129)
-    yield s.check_bogus_field_returns_error, url, 'name', 123
-    yield s.check_bogus_field_returns_error, url, 'name', []
-    yield s.check_bogus_field_returns_error, url, 'name', {}
-    yield s.check_bogus_field_returns_error, url, 'max_tries', 'invalid'
-    yield s.check_bogus_field_returns_error, url, 'max_tries', 0
-    yield s.check_bogus_field_returns_error, url, 'max_tries', []
-    yield s.check_bogus_field_returns_error, url, 'max_tries', {}
-    yield s.check_bogus_field_returns_error, url, 'timeout', 'invalid'
-    yield s.check_bogus_field_returns_error, url, 'timeout', -1
-    yield s.check_bogus_field_returns_error, url, 'timeout', []
-    yield s.check_bogus_field_returns_error, url, 'timeout', {}
-    yield s.check_bogus_field_returns_error, url, 'description', 1234
-    yield s.check_bogus_field_returns_error, url, 'description', []
-    yield s.check_bogus_field_returns_error, url, 'choices', True
-    yield s.check_bogus_field_returns_error, url, 'choices', 123
-    yield s.check_bogus_field_returns_error, url, 'choices', {}
-    yield s.check_bogus_field_returns_error, url, 'choices', ['invalid']
-    yield s.check_bogus_field_returns_error, url, 'choices', [
-        {'destination': {'type': 'none'}}
-    ]
-    yield s.check_bogus_field_returns_error, url, 'choices', [{'exten': '1'}]
-    yield s.check_bogus_field_returns_error, url, 'choices', [
-        {'exten': 123, 'destination': {'type': 'none'}}
-    ]
-    yield s.check_bogus_field_returns_error, url, 'choices', [
-        {'exten': '1', 'destination': 'invalid'}
-    ]
+    s.check_bogus_field_returns_error(url, 'abort_sound', True)
+    s.check_bogus_field_returns_error(url, 'abort_sound', 123)
+    s.check_bogus_field_returns_error(url, 'abort_sound', s.random_string(256))
+    s.check_bogus_field_returns_error(url, 'abort_sound', [])
+    s.check_bogus_field_returns_error(url, 'abort_sound', {})
+    s.check_bogus_field_returns_error(url, 'greeting_sound', True)
+    s.check_bogus_field_returns_error(url, 'greeting_sound', 123)
+    s.check_bogus_field_returns_error(url, 'greeting_sound', s.random_string(256))
+    s.check_bogus_field_returns_error(url, 'greeting_sound', [])
+    s.check_bogus_field_returns_error(url, 'greeting_sound', {})
+    s.check_bogus_field_returns_error(url, 'invalid_sound', True)
+    s.check_bogus_field_returns_error(url, 'invalid_sound', 123)
+    s.check_bogus_field_returns_error(url, 'invalid_sound', s.random_string(256))
+    s.check_bogus_field_returns_error(url, 'invalid_sound', [])
+    s.check_bogus_field_returns_error(url, 'invalid_sound', {})
+    s.check_bogus_field_returns_error(url, 'menu_sound', True)
+    s.check_bogus_field_returns_error(url, 'menu_sound', 123)
+    s.check_bogus_field_returns_error(url, 'menu_sound', s.random_string(256))
+    s.check_bogus_field_returns_error(url, 'menu_sound', [])
+    s.check_bogus_field_returns_error(url, 'menu_sound', {})
+    s.check_bogus_field_returns_error(url, 'name', True)
+    s.check_bogus_field_returns_error(url, 'name', None)
+    s.check_bogus_field_returns_error(url, 'name', s.random_string(129))
+    s.check_bogus_field_returns_error(url, 'name', 123)
+    s.check_bogus_field_returns_error(url, 'name', [])
+    s.check_bogus_field_returns_error(url, 'name', {})
+    s.check_bogus_field_returns_error(url, 'max_tries', 'invalid')
+    s.check_bogus_field_returns_error(url, 'max_tries', 0)
+    s.check_bogus_field_returns_error(url, 'max_tries', [])
+    s.check_bogus_field_returns_error(url, 'max_tries', {})
+    s.check_bogus_field_returns_error(url, 'timeout', 'invalid')
+    s.check_bogus_field_returns_error(url, 'timeout', -1)
+    s.check_bogus_field_returns_error(url, 'timeout', [])
+    s.check_bogus_field_returns_error(url, 'timeout', {})
+    s.check_bogus_field_returns_error(url, 'description', 1234)
+    s.check_bogus_field_returns_error(url, 'description', [])
+    s.check_bogus_field_returns_error(url, 'choices', True)
+    s.check_bogus_field_returns_error(url, 'choices', 123)
+    s.check_bogus_field_returns_error(url, 'choices', {})
+    s.check_bogus_field_returns_error(url, 'choices', ['invalid'])
+    s.check_bogus_field_returns_error(
+        url, 'choices', [{'destination': {'type': 'none'}}]
+    )
+    s.check_bogus_field_returns_error(url, 'choices', [{'exten': '1'}])
+    s.check_bogus_field_returns_error(
+        url, 'choices', [{'exten': 123, 'destination': {'type': 'none'}}]
+    )
+    s.check_bogus_field_returns_error(
+        url, 'choices', [{'exten': '1', 'destination': 'invalid'}]
+    )
 
     for destination in invalid_destinations():
-        yield s.check_bogus_field_returns_error, url, 'invalid_destination', destination
-    yield s.check_bogus_field_returns_error, url, 'invalid_destination', {
-        'type': 'user',
-        'user_id': user['id'],
-        'moh_uuid': '00000000-0000-0000-0000-000000000000',
-    }, {'name': 'name', 'menu_sound': 'menu'}, 'MOH was not found'
+        s.check_bogus_field_returns_error(url, 'invalid_destination', destination)
+    s.check_bogus_field_returns_error(
+        url,
+        'invalid_destination',
+        {
+            'type': 'user',
+            'user_id': user['id'],
+            'moh_uuid': '00000000-0000-0000-0000-000000000000',
+        },
+        {'name': 'name', 'menu_sound': 'menu'},
+        'MOH was not found',
+    )
 
     for destination in invalid_destinations():
-        yield s.check_bogus_field_returns_error, url, 'timeout_destination', destination
-    yield s.check_bogus_field_returns_error, url, 'timeout_destination', {
-        'type': 'user',
-        'user_id': user['id'],
-        'moh_uuid': '00000000-0000-0000-0000-000000000000',
-    }, {'name': 'name', 'menu_sound': 'menu'}, 'MOH was not found'
+        s.check_bogus_field_returns_error(url, 'timeout_destination', destination)
+    s.check_bogus_field_returns_error(
+        url,
+        'timeout_destination',
+        {
+            'type': 'user',
+            'user_id': user['id'],
+            'moh_uuid': '00000000-0000-0000-0000-000000000000',
+        },
+        {'name': 'name', 'menu_sound': 'menu'},
+        'MOH was not found',
+    )
 
     for destination in invalid_destinations():
-        yield s.check_bogus_field_returns_error, url, 'abort_destination', destination
-    yield s.check_bogus_field_returns_error, url, 'abort_destination', {
-        'type': 'user',
-        'user_id': user['id'],
-        'moh_uuid': '00000000-0000-0000-0000-000000000000',
-    }, {'name': 'name', 'menu_sound': 'menu'}, 'MOH was not found'
+        s.check_bogus_field_returns_error(url, 'abort_destination', destination)
+    s.check_bogus_field_returns_error(
+        url,
+        'abort_destination',
+        {
+            'type': 'user',
+            'user_id': user['id'],
+            'moh_uuid': '00000000-0000-0000-0000-000000000000',
+        },
+        {'name': 'name', 'menu_sound': 'menu'},
+        'MOH was not found',
+    )
 
 
 @fixtures.ivr(wazo_tenant=MAIN_TENANT)
@@ -141,7 +157,7 @@ def test_search(ivr, hidden):
     searches = {'description': 'search'}
 
     for field, term in searches.items():
-        yield check_search, url, ivr, hidden, field, term
+        check_search(url, ivr, hidden, field, term)
 
 
 def check_search(url, ivr, hidden, field, term):
@@ -158,10 +174,10 @@ def check_search(url, ivr, hidden, field, term):
 @fixtures.ivr(description='sort2')
 def test_sorting_offset_limit(ivr1, ivr2):
     url = confd.ivr.get
-    yield s.check_sorting, url, ivr1, ivr2, 'description', 'sort'
+    s.check_sorting(url, ivr1, ivr2, 'description', 'sort')
 
-    yield s.check_offset, url, ivr1, ivr2, 'description', 'sort'
-    yield s.check_limit, url, ivr1, ivr2, 'description', 'sort'
+    s.check_offset(url, ivr1, ivr2, 'description', 'sort')
+    s.check_limit(url, ivr1, ivr2, 'description', 'sort')
 
 
 @fixtures.ivr()
@@ -290,8 +306,8 @@ def test_edit_all_parameters(ivr):
 @fixtures.moh()
 def test_valid_destinations(ivr, *destinations):
     for destination in valid_destinations(*destinations):
-        yield create_ivr_with_destination, destination
-        yield update_ivr_with_destination, ivr['id'], destination
+        create_ivr_with_destination(destination)
+        update_ivr_with_destination(ivr['id'], destination)
 
 
 def create_ivr_with_destination(destination):
@@ -345,9 +361,14 @@ def test_delete_multi_tenant(main, sub):
 def test_bus_events(ivr):
     headers = {'tenant_uuid': MAIN_TENANT}
 
-    yield s.check_event, 'ivr_created', headers, confd.ivr.post, {
-        'name': 'a',
-        'menu_sound': 'hello',
-    }
-    yield s.check_event, 'ivr_edited', headers, confd.ivr(ivr['id']).put
-    yield s.check_event, 'ivr_deleted', headers, confd.ivr(ivr['id']).delete
+    s.check_event(
+        'ivr_created',
+        headers,
+        confd.ivr.post,
+        {
+            'name': 'a',
+            'menu_sound': 'hello',
+        },
+    )
+    s.check_event('ivr_edited', headers, confd.ivr(ivr['id']).put)
+    s.check_event('ivr_deleted', headers, confd.ivr(ivr['id']).delete)

--- a/integration_tests/suite/base/test_line_application.py
+++ b/integration_tests/suite/base/test_line_application.py
@@ -17,8 +17,8 @@ def test_associate_errors(line, application):
     fake_line = confd.lines(FAKE_ID).applications(application['uuid']).put
     fake_application = confd.lines(line['id']).applications(FAKE_UUID).put
 
-    yield s.check_resource_not_found, fake_line, 'Line'
-    yield s.check_resource_not_found, fake_application, 'Application'
+    s.check_resource_not_found(fake_line, 'Line')
+    s.check_resource_not_found(fake_application, 'Application')
 
 
 @fixtures.line()
@@ -27,8 +27,8 @@ def test_dissociate_errors(line, application):
     fake_line = confd.lines(FAKE_ID).applications(application['uuid']).delete
     fake_application = confd.lines(line['id']).applications(FAKE_UUID).delete
 
-    yield s.check_resource_not_found, fake_line, 'Line'
-    yield s.check_resource_not_found, fake_application, 'Application'
+    s.check_resource_not_found(fake_line, 'Line')
+    s.check_resource_not_found(fake_application, 'Application')
 
 
 @fixtures.line()
@@ -184,5 +184,5 @@ def test_bus_events(line, application):
     url = confd.lines(line['id']).applications(application['uuid'])
     headers = {'tenant_uuid': MAIN_TENANT}
 
-    yield s.check_event, 'line_application_associated', headers, url.put
-    yield s.check_event, 'line_application_dissociated', headers, url.delete
+    s.check_event('line_application_associated', headers, url.put)
+    s.check_event('line_application_dissociated', headers, url.delete)

--- a/integration_tests/suite/base/test_line_device.py
+++ b/integration_tests/suite/base/test_line_device.py
@@ -51,8 +51,8 @@ def test_associate_errors(line, device):
     fake_line = confd.lines(999999999).devices(device['id']).put
     fake_device = confd.lines(line['id']).devices(999999999).put
 
-    yield s.check_resource_not_found, fake_line, 'Line'
-    yield s.check_resource_not_found, fake_device, 'Device'
+    s.check_resource_not_found(fake_line, 'Line')
+    s.check_resource_not_found(fake_device, 'Device')
 
 
 @fixtures.line()
@@ -61,23 +61,23 @@ def test_dissociate_errors(line, device):
     fake_line = confd.lines(999999999).devices(device['id']).delete
     fake_device = confd.lines(line['id']).devices(999999999).delete
 
-    yield s.check_resource_not_found, fake_line, 'Line'
-    yield s.check_resource_not_found, fake_device, 'Device'
+    s.check_resource_not_found(fake_line, 'Line')
+    s.check_resource_not_found(fake_device, 'Device')
 
 
 def test_get_errors():
     fake_line = confd.lines(999999999).devices.get
     fake_device = confd.devices(999999999).lines.get
 
-    yield s.check_resource_not_found, fake_line, 'Line'
-    yield s.check_resource_not_found, fake_device, 'Device'
+    s.check_resource_not_found(fake_line, 'Line')
+    s.check_resource_not_found(fake_device, 'Device')
 
 
 @fixtures.sip()
 @fixtures.sccp()
 def test_associate_without_required_resources_raises_error(sip, sccp):
-    yield check_associate_without_required_resources, sip, a.line_endpoint_sip
-    yield check_associate_without_required_resources, sccp, a.line_endpoint_sccp
+    check_associate_without_required_resources(sip, a.line_endpoint_sip)
+    check_associate_without_required_resources(sccp, a.line_endpoint_sccp)
 
 
 def check_associate_without_required_resources(endpoint, line_endpoint):
@@ -98,10 +98,10 @@ def check_associate_without_required_resources(endpoint, line_endpoint):
 @fixtures.line(position=1)
 def test_associate_2_lines_with_same_position_raises_error(extra_line):
     with line_and_device('sip') as (line, device):
-        yield check_2_lines_with_same_position_raises_error, line, extra_line, device
+        check_2_lines_with_same_position_raises_error(line, extra_line, device)
 
     with line_and_device('sccp') as (line, device):
-        yield check_2_lines_with_same_position_raises_error, line, extra_line, device
+        check_2_lines_with_same_position_raises_error(line, extra_line, device)
 
 
 def check_2_lines_with_same_position_raises_error(line, extra_line, device):
@@ -116,10 +116,10 @@ def check_2_lines_with_same_position_raises_error(line, extra_line, device):
 
 def test_get_device_associated_to_line():
     with line_and_device('sip') as (line, device):
-        yield check_get_device_associated_to_line, line, device
+        check_get_device_associated_to_line(line, device)
 
     with line_and_device('sccp') as (line, device):
-        yield check_get_device_associated_to_line, line, device
+        check_get_device_associated_to_line(line, device)
 
 
 def check_get_device_associated_to_line(line, device):
@@ -151,10 +151,10 @@ def test_get_device_associated_to_line_from_sub_tenant_errors():
 
 def test_get_device_after_dissociation():
     with line_and_device('sip') as (line, device):
-        yield check_get_device_after_dissociation, line, device
+        check_get_device_after_dissociation(line, device)
 
     with line_and_device('sccp') as (line, device):
-        yield check_get_device_after_dissociation, line, device
+        check_get_device_after_dissociation(line, device)
 
 
 def check_get_device_after_dissociation(line, device):
@@ -167,10 +167,10 @@ def check_get_device_after_dissociation(line, device):
 
 def test_get_line_associated_to_a_device():
     with line_and_device('sip') as (line, device):
-        yield check_get_line_associated_to_a_device, line, device
+        check_get_line_associated_to_a_device(line, device)
 
     with line_and_device('sccp') as (line, device):
-        yield check_get_line_associated_to_a_device, line, device
+        check_get_line_associated_to_a_device(line, device)
 
 
 def check_get_line_associated_to_a_device(line, device):
@@ -494,11 +494,11 @@ def test_associate_with_another_device_when_already_associated():
 
 def test_dissociate():
     with line_and_device('sip') as (line, device):
-        yield check_dissociate, line, device
+        check_dissociate(line, device)
 
     with line_and_device('sccp') as (line, device):
-        yield check_dissociate, line, device
-        yield check_dissociate_sccp, line, device
+        check_dissociate(line, device)
+        check_dissociate_sccp(line, device)
 
 
 def check_dissociate(line, device):
@@ -524,7 +524,7 @@ def test_reset_sccp_to_autoprov():
         confd.devices(device['id']).autoprov.get()
         provd_device = provd.devices.get(device['id'])
         assert_that(provd_device['config'], starts_with('autoprov'))
-        yield check_sccp_reset_to_autoprov, device
+        check_sccp_reset_to_autoprov(device)
 
 
 def check_sccp_reset_to_autoprov(device):
@@ -558,13 +558,13 @@ def test_dissociate_when_not_associated():
         line2,
         device2,
     ):
-        yield check_dissociate_when_not_associated, line1, device1, line2, device2
+        check_dissociate_when_not_associated(line1, device1, line2, device2)
 
     with line_and_device('sccp') as (line1, device1), line_and_device('sccp') as (
         line2,
         device2,
     ):
-        yield check_dissociate_when_not_associated, line1, device1, line2, device2
+        check_dissociate_when_not_associated(line1, device1, line2, device2)
 
 
 def check_dissociate_when_not_associated(line1, device1, line2, device2):
@@ -591,5 +591,5 @@ def test_bus_events(device):
         url = confd.lines(line['id']).devices(device['id'])
         headers = {'tenant_uuid': MAIN_TENANT}
 
-        yield s.check_event, 'line_device_associated', headers, url.put
-        yield s.check_event, 'line_device_dissociated', headers, url.delete
+        s.check_event('line_device_associated', headers, url.put)
+        s.check_event('line_device_dissociated', headers, url.delete)

--- a/integration_tests/suite/base/test_line_endpoint_custom.py
+++ b/integration_tests/suite/base/test_line_endpoint_custom.py
@@ -24,8 +24,8 @@ def test_associate_errors(line, custom):
     fake_line = confd.lines(999999999).endpoints.custom(custom['id']).put
     fake_custom = confd.lines(line['id']).endpoints.custom(999999999).put
 
-    yield s.check_resource_not_found, fake_line, 'Line'
-    yield s.check_resource_not_found, fake_custom, 'CustomEndpoint'
+    s.check_resource_not_found(fake_line, 'Line')
+    s.check_resource_not_found(fake_custom, 'CustomEndpoint')
 
 
 @fixtures.line()
@@ -34,8 +34,8 @@ def test_dissociate_errors(line, custom):
     fake_line = confd.lines(999999999).endpoints.custom(custom['id']).delete
     fake_custom = confd.lines(line['id']).endpoints.custom(999999999).delete
 
-    yield s.check_resource_not_found, fake_line, 'Line'
-    yield s.check_resource_not_found, fake_custom, 'CustomEndpoint'
+    s.check_resource_not_found(fake_line, 'Line')
+    s.check_resource_not_found(fake_custom, 'CustomEndpoint')
 
 
 @fixtures.line()
@@ -212,8 +212,8 @@ def test_bus_events(line, custom):
     url = confd.lines(line['id']).endpoints.custom(custom['id'])
     headers = {'tenant_uuid': MAIN_TENANT}
 
-    yield s.check_event, 'line_endpoint_custom_associated', headers, url.put
-    yield s.check_event, 'line_endpoint_custom_dissociated', headers, url.delete
+    s.check_event('line_endpoint_custom_associated', headers, url.put)
+    s.check_event('line_endpoint_custom_dissociated', headers, url.delete)
 
 
 @fixtures.registrar()

--- a/integration_tests/suite/base/test_line_endpoint_sccp.py
+++ b/integration_tests/suite/base/test_line_endpoint_sccp.py
@@ -26,8 +26,8 @@ def test_associate_errors(line, sccp):
     fake_line = confd.lines(999999999).endpoints.sccp(sccp['id']).put
     fake_sccp = confd.lines(line['id']).endpoints.sccp(999999999).put
 
-    yield s.check_resource_not_found, fake_line, 'Line'
-    yield s.check_resource_not_found, fake_sccp, 'SCCPEndpoint'
+    s.check_resource_not_found(fake_line, 'Line')
+    s.check_resource_not_found(fake_sccp, 'SCCPEndpoint')
 
 
 @fixtures.line()
@@ -36,8 +36,8 @@ def test_dissociate_errors(line, sccp):
     fake_line = confd.lines(999999999).endpoints.sccp(sccp['id']).delete
     fake_sccp = confd.lines(line['id']).endpoints.sccp(999999999).delete
 
-    yield s.check_resource_not_found, fake_line, 'Line'
-    yield s.check_resource_not_found, fake_sccp, 'SCCPEndpoint'
+    s.check_resource_not_found(fake_line, 'Line')
+    s.check_resource_not_found(fake_sccp, 'SCCPEndpoint')
 
 
 @fixtures.line()
@@ -198,8 +198,8 @@ def test_bus_events(line, sccp):
     url = confd.lines(line['id']).endpoints.sccp(sccp['id'])
     headers = {'tenant_uuid': MAIN_TENANT}
 
-    yield s.check_event, 'line_endpoint_sccp_associated', headers, url.put
-    yield s.check_event, 'line_endpoint_sccp_dissociated', headers, url.delete
+    s.check_event('line_endpoint_sccp_associated', headers, url.put)
+    s.check_event('line_endpoint_sccp_dissociated', headers, url.delete)
 
 
 @fixtures.registrar()

--- a/integration_tests/suite/base/test_line_endpoint_sip.py
+++ b/integration_tests/suite/base/test_line_endpoint_sip.py
@@ -30,8 +30,8 @@ def test_associate_errors(line, sip):
     fake_line = confd.lines(FAKE_ID).endpoints.sip(sip['uuid']).put
     fake_sip = confd.lines(line['id']).endpoints.sip(FAKE_UUID).put
 
-    yield s.check_resource_not_found, fake_line, 'Line'
-    yield s.check_resource_not_found, fake_sip, 'SIPEndpoint'
+    s.check_resource_not_found(fake_line, 'Line')
+    s.check_resource_not_found(fake_sip, 'SIPEndpoint')
 
 
 @fixtures.line()
@@ -40,8 +40,8 @@ def test_dissociate_errors(line, sip):
     fake_line = confd.lines(FAKE_ID).endpoints.sip(sip['uuid']).delete
     fake_sip = confd.lines(line['id']).endpoints.sip(FAKE_UUID).delete
 
-    yield s.check_resource_not_found, fake_line, 'Line'
-    yield s.check_resource_not_found, fake_sip, 'SIPEndpoint'
+    s.check_resource_not_found(fake_line, 'Line')
+    s.check_resource_not_found(fake_sip, 'SIPEndpoint')
 
 
 @fixtures.line()
@@ -232,8 +232,8 @@ def test_bus_events(line, sip):
     url = confd.lines(line['id']).endpoints.sip(sip['uuid'])
     headers = {'tenant_uuid': MAIN_TENANT}
 
-    yield s.check_event, 'line_endpoint_sip_associated', headers, url.put
-    yield s.check_event, 'line_endpoint_sip_dissociated', headers, url.delete
+    s.check_event('line_endpoint_sip_associated', headers, url.put)
+    s.check_event('line_endpoint_sip_dissociated', headers, url.delete)
 
 
 @fixtures.transport()

--- a/integration_tests/suite/base/test_line_extension.py
+++ b/integration_tests/suite/base/test_line_extension.py
@@ -38,8 +38,8 @@ def test_associate_errors(line, extension):
     fake_line = confd.lines(FAKE_ID).extensions(extension['id']).put
     fake_extension = confd.lines(line['id']).extensions(FAKE_ID).put
 
-    yield s.check_resource_not_found, fake_line, 'Line'
-    yield s.check_resource_not_found, fake_extension, 'Extension'
+    s.check_resource_not_found(fake_line, 'Line')
+    s.check_resource_not_found(fake_extension, 'Extension')
 
 
 @fixtures.context(wazo_tenant=MAIN_TENANT, label='main-internal')
@@ -80,8 +80,8 @@ def test_dissociate_errors(line, extension):
     fake_line = confd.lines(FAKE_ID).extensions(extension['id']).delete
     fake_extension = confd.lines(line['id']).extensions(FAKE_ID).delete
 
-    yield s.check_resource_not_found, fake_line, 'Line'
-    yield s.check_resource_not_found, fake_extension, 'Extension'
+    s.check_resource_not_found(fake_line, 'Line')
+    s.check_resource_not_found(fake_extension, 'Extension')
 
 
 @fixtures.context(wazo_tenant=MAIN_TENANT, label='main-internal')
@@ -143,8 +143,7 @@ def test_associate_line_and_create_extension_unknown_line():
 @fixtures.line_sip()
 def test_extension_creation_error(line):
     url = confd.lines(line['id']).extensions.post
-    for check in error_checks(url):
-        yield check
+    error_checks(url)
 
 
 @fixtures.context(label='sub_ctx', wazo_tenant=SUB_TENANT)

--- a/integration_tests/suite/base/test_lines.py
+++ b/integration_tests/suite/base/test_lines.py
@@ -24,64 +24,62 @@ from ..helpers.config import MAIN_TENANT, SUB_TENANT
 
 def test_get_errors():
     fake_line_get = confd.lines(999999).get
-    yield s.check_resource_not_found, fake_line_get, 'Line'
+    s.check_resource_not_found(fake_line_get, 'Line')
 
 
 def test_post_errors():
     url = confd.lines.post
-    for check in error_checks(url):
-        yield check
+    error_checks(url)
 
 
 @fixtures.line()
 def test_put_errors(line):
     url = confd.lines(line['id']).put
-    for check in error_checks(url):
-        yield check
+    error_checks(url)
 
-    yield s.check_bogus_field_returns_error, url, 'provisioning_code', None
-    yield s.check_bogus_field_returns_error, url, 'position', None
-    yield s.check_bogus_field_returns_error, url, 'registrar', None
-    yield s.check_bogus_field_returns_error, url, 'registrar', 'invalidregistrar'
+    s.check_bogus_field_returns_error(url, 'provisioning_code', None)
+    s.check_bogus_field_returns_error(url, 'position', None)
+    s.check_bogus_field_returns_error(url, 'registrar', None)
+    s.check_bogus_field_returns_error(url, 'registrar', 'invalidregistrar')
 
 
 def error_checks(url):
-    yield s.check_bogus_field_returns_error, url, 'context', 123
-    yield s.check_bogus_field_returns_error, url, 'context', 'undefined'
-    yield s.check_bogus_field_returns_error, url, 'context', ''
-    yield s.check_bogus_field_returns_error, url, 'context', {}
-    yield s.check_bogus_field_returns_error, url, 'context', []
-    yield s.check_bogus_field_returns_error, url, 'context', None
-    yield s.check_bogus_field_returns_error, url, 'provisioning_code', 123456
-    yield s.check_bogus_field_returns_error, url, 'provisioning_code', 'number'
-    yield s.check_bogus_field_returns_error, url, 'provisioning_code', '123'
-    yield s.check_bogus_field_returns_error, url, 'provisioning_code', '1234567'
-    yield s.check_bogus_field_returns_error, url, 'provisioning_code', ''
-    yield s.check_bogus_field_returns_error, url, 'provisioning_code', {}
-    yield s.check_bogus_field_returns_error, url, 'provisioning_code', []
-    yield s.check_bogus_field_returns_error, url, 'position', 'one'
-    yield s.check_bogus_field_returns_error, url, 'position', ''
-    yield s.check_bogus_field_returns_error, url, 'position', 0
-    yield s.check_bogus_field_returns_error, url, 'position', {}
-    yield s.check_bogus_field_returns_error, url, 'position', []
-    yield s.check_bogus_field_returns_error, url, 'registrar', 123
-    yield s.check_bogus_field_returns_error, url, 'registrar', s.random_string(129)
-    yield s.check_bogus_field_returns_error, url, 'registrar', {}
-    yield s.check_bogus_field_returns_error, url, 'registrar', []
-    yield s.check_bogus_field_returns_error, url, 'caller_id_name', 123456
-    yield s.check_bogus_field_returns_error, url, 'caller_id_name', {}
-    yield s.check_bogus_field_returns_error, url, 'caller_id_name', []
-    yield s.check_bogus_field_returns_error, url, 'caller_id_num', '123ABC'
-    yield s.check_bogus_field_returns_error, url, 'caller_id_num', ''
-    yield s.check_bogus_field_returns_error, url, 'caller_id_num', {}
-    yield s.check_bogus_field_returns_error, url, 'caller_id_num', []
+    s.check_bogus_field_returns_error(url, 'context', 123)
+    s.check_bogus_field_returns_error(url, 'context', 'undefined')
+    s.check_bogus_field_returns_error(url, 'context', '')
+    s.check_bogus_field_returns_error(url, 'context', {})
+    s.check_bogus_field_returns_error(url, 'context', [])
+    s.check_bogus_field_returns_error(url, 'context', None)
+    s.check_bogus_field_returns_error(url, 'provisioning_code', 123456)
+    s.check_bogus_field_returns_error(url, 'provisioning_code', 'number')
+    s.check_bogus_field_returns_error(url, 'provisioning_code', '123')
+    s.check_bogus_field_returns_error(url, 'provisioning_code', '1234567')
+    s.check_bogus_field_returns_error(url, 'provisioning_code', '')
+    s.check_bogus_field_returns_error(url, 'provisioning_code', {})
+    s.check_bogus_field_returns_error(url, 'provisioning_code', [])
+    s.check_bogus_field_returns_error(url, 'position', 'one')
+    s.check_bogus_field_returns_error(url, 'position', '')
+    s.check_bogus_field_returns_error(url, 'position', 0)
+    s.check_bogus_field_returns_error(url, 'position', {})
+    s.check_bogus_field_returns_error(url, 'position', [])
+    s.check_bogus_field_returns_error(url, 'registrar', 123)
+    s.check_bogus_field_returns_error(url, 'registrar', s.random_string(129))
+    s.check_bogus_field_returns_error(url, 'registrar', {})
+    s.check_bogus_field_returns_error(url, 'registrar', [])
+    s.check_bogus_field_returns_error(url, 'caller_id_name', 123456)
+    s.check_bogus_field_returns_error(url, 'caller_id_name', {})
+    s.check_bogus_field_returns_error(url, 'caller_id_name', [])
+    s.check_bogus_field_returns_error(url, 'caller_id_num', '123ABC')
+    s.check_bogus_field_returns_error(url, 'caller_id_num', '')
+    s.check_bogus_field_returns_error(url, 'caller_id_num', {})
+    s.check_bogus_field_returns_error(url, 'caller_id_num', [])
 
 
 @fixtures.line()
 def test_delete_errors(line):
     line_url = confd.lines(line['id'])
     line_url.delete()
-    yield s.check_resource_not_found, line_url.get, 'Line'
+    s.check_resource_not_found(line_url.get, 'Line')
 
 
 @fixtures.line(context=config.CONTEXT)

--- a/integration_tests/suite/base/test_meeting.py
+++ b/integration_tests/suite/base/test_meeting.py
@@ -248,10 +248,16 @@ def test_create_no_ingress_http_configured():
 
 
 @fixtures.ingress_http()
-def test_create_no_meetingjoin_extension_feature(_):
+def test_create_no_meetingjoin_extension_feature(_, request):
     extension = confd.extensions.features.get(feature='meetingjoin').items[0]
     extension['enabled'] = False
     response = confd.extensions.features(extension['uuid']).put(**extension)
+
+    def enable_meetingjoin():
+        extension['enabled'] = True
+        confd.extensions.features(extension['uuid']).put(**extension)
+
+    request.addfinalizer(enable_meetingjoin)
 
     response = confd.meetings.post(name='no exten')
     try:

--- a/integration_tests/suite/base/test_meeting_authorization.py
+++ b/integration_tests/suite/base/test_meeting_authorization.py
@@ -170,7 +170,9 @@ def test_list_search_authorizations_by_user(_, me, another_meeting):
         # Test search
         url = user_confd.users.me.meetings(meeting['uuid']).authorizations
         for field, term in searches.items():
-            yield check_authorization_search, url, authorization_found, authorization_hidden, field, term
+            check_authorization_search(
+                url, authorization_found, authorization_hidden, field, term
+            )
 
 
 def check_authorization_search(url, meeting, hidden, field, term):
@@ -201,10 +203,14 @@ def test_sorting_offset_limit_authorizations_by_user(_, me):
     ) as authorization2:
         url = user_confd.users.me.meetings(meeting['uuid']).authorizations.get
 
-        yield s.check_sorting, url, authorization1, authorization2, 'guest_name', 'sort', 'uuid'
+        s.check_sorting(
+            url, authorization1, authorization2, 'guest_name', 'sort', 'uuid'
+        )
 
-        yield s.check_offset, url, authorization1, authorization2, 'guest_name', 'sort', 'uuid'
-        yield s.check_limit, url, authorization1, authorization2, 'guest_name', 'sort', 'uuid'
+        s.check_offset(
+            url, authorization1, authorization2, 'guest_name', 'sort', 'uuid'
+        )
+        s.check_limit(url, authorization1, authorization2, 'guest_name', 'sort', 'uuid')
 
 
 @fixtures.ingress_http()

--- a/integration_tests/suite/base/test_moh.py
+++ b/integration_tests/suite/base/test_moh.py
@@ -66,52 +66,48 @@ with wave.open(INVALID_WAV_FILE_FRAMERATE, 'wb') as wav_file:
 
 def test_get_errors():
     fake_moh = confd.moh(NOT_FOUND_UUID).get
-    yield s.check_resource_not_found, fake_moh, 'MOH'
+    s.check_resource_not_found(fake_moh, 'MOH')
 
 
 def test_delete_errors():
     fake_moh = confd.moh(NOT_FOUND_UUID).delete
-    yield s.check_resource_not_found, fake_moh, 'MOH'
+    s.check_resource_not_found(fake_moh, 'MOH')
 
 
 def test_post_errors():
     url = confd.moh.post
-    for check in error_checks(url):
-        yield check
+    error_checks(url)
 
-    yield s.check_bogus_field_returns_error, url, 'name', s.random_string(
-        129
-    ), None, 'label'
+    s.check_bogus_field_returns_error(url, 'name', s.random_string(129), None, 'label')
 
 
 @fixtures.moh()
 def test_put_errors(moh):
     url = confd.moh(moh['uuid']).put
-    for check in error_checks(url):
-        yield check
+    error_checks(url)
 
 
 def error_checks(url):
-    yield s.check_bogus_field_returns_error, url, 'label', True
-    yield s.check_bogus_field_returns_error, url, 'label', 1234
-    yield s.check_bogus_field_returns_error, url, 'label', s.random_string(129)
-    yield s.check_bogus_field_returns_error, url, 'label', []
-    yield s.check_bogus_field_returns_error, url, 'label', {}
-    yield s.check_bogus_field_returns_error, url, 'mode', True
-    yield s.check_bogus_field_returns_error, url, 'mode', 1234
-    yield s.check_bogus_field_returns_error, url, 'mode', 'hello'
-    yield s.check_bogus_field_returns_error, url, 'mode', []
-    yield s.check_bogus_field_returns_error, url, 'mode', {}
-    yield s.check_bogus_field_returns_error, url, 'application', True
-    yield s.check_bogus_field_returns_error, url, 'application', 1234
-    yield s.check_bogus_field_returns_error, url, 'application', s.random_string(257)
-    yield s.check_bogus_field_returns_error, url, 'application', []
-    yield s.check_bogus_field_returns_error, url, 'application', {}
-    yield s.check_bogus_field_returns_error, url, 'sort', True
-    yield s.check_bogus_field_returns_error, url, 'sort', 1234
-    yield s.check_bogus_field_returns_error, url, 'sort', 'hello'
-    yield s.check_bogus_field_returns_error, url, 'sort', []
-    yield s.check_bogus_field_returns_error, url, 'sort', {}
+    s.check_bogus_field_returns_error(url, 'label', True)
+    s.check_bogus_field_returns_error(url, 'label', 1234)
+    s.check_bogus_field_returns_error(url, 'label', s.random_string(129))
+    s.check_bogus_field_returns_error(url, 'label', [])
+    s.check_bogus_field_returns_error(url, 'label', {})
+    s.check_bogus_field_returns_error(url, 'mode', True)
+    s.check_bogus_field_returns_error(url, 'mode', 1234)
+    s.check_bogus_field_returns_error(url, 'mode', 'hello')
+    s.check_bogus_field_returns_error(url, 'mode', [])
+    s.check_bogus_field_returns_error(url, 'mode', {})
+    s.check_bogus_field_returns_error(url, 'application', True)
+    s.check_bogus_field_returns_error(url, 'application', 1234)
+    s.check_bogus_field_returns_error(url, 'application', s.random_string(257))
+    s.check_bogus_field_returns_error(url, 'application', [])
+    s.check_bogus_field_returns_error(url, 'application', {})
+    s.check_bogus_field_returns_error(url, 'sort', True)
+    s.check_bogus_field_returns_error(url, 'sort', 1234)
+    s.check_bogus_field_returns_error(url, 'sort', 'hello')
+    s.check_bogus_field_returns_error(url, 'sort', [])
+    s.check_bogus_field_returns_error(url, 'sort', {})
 
 
 @fixtures.moh(label='visible')
@@ -121,7 +117,7 @@ def test_search(visible, hidden):
     searches = {'label': 'visible'}
 
     for field, term in searches.items():
-        yield check_search, url, visible, hidden, field, term
+        check_search(url, visible, hidden, field, term)
 
 
 def check_search(url, visible, hidden, field, term):
@@ -138,10 +134,10 @@ def check_search(url, visible, hidden, field, term):
 @fixtures.moh(label='sort2')
 def test_sorting_offset_limit(moh1, moh2):
     url = confd.moh.get
-    yield s.check_sorting, url, moh1, moh2, 'label', 'sort', 'uuid'
+    s.check_sorting(url, moh1, moh2, 'label', 'sort', 'uuid')
 
-    yield s.check_offset, url, moh1, moh2, 'label', 'sort', 'uuid'
-    yield s.check_limit, url, moh1, moh2, 'label', 'sort', 'uuid'
+    s.check_offset(url, moh1, moh2, 'label', 'sort', 'uuid')
+    s.check_limit(url, moh1, moh2, 'label', 'sort', 'uuid')
 
 
 @fixtures.moh(wazo_tenant=MAIN_TENANT)
@@ -448,9 +444,14 @@ def test_bus_events(moh):
     url = confd.moh(moh['uuid'])
     headers = {'tenant_uuid': moh['tenant_uuid']}
 
-    yield s.check_event, 'moh_created', headers, confd.moh.post, {
-        'name': 'bus_event',
-        'mode': 'files',
-    }
-    yield s.check_event, 'moh_edited', headers, url.put
-    yield s.check_event, 'moh_deleted', headers, url.delete
+    s.check_event(
+        'moh_created',
+        headers,
+        confd.moh.post,
+        {
+            'name': 'bus_event',
+            'mode': 'files',
+        },
+    )
+    s.check_event('moh_edited', headers, url.put)
+    s.check_event('moh_deleted', headers, url.delete)

--- a/integration_tests/suite/base/test_outcall_call_permission.py
+++ b/integration_tests/suite/base/test_outcall_call_permission.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import assert_that, contains, has_entries, empty
@@ -16,8 +16,8 @@ def test_associate_errors(outcall, call_permission):
     fake_outcall = confd.outcalls(FAKE_ID).callpermissions(call_permission['id']).put
     fake_call_permission = confd.outcalls(outcall['id']).callpermissions(FAKE_ID).put
 
-    yield s.check_resource_not_found, fake_outcall, 'Outcall'
-    yield s.check_resource_not_found, fake_call_permission, 'CallPermission'
+    s.check_resource_not_found(fake_outcall, 'Outcall')
+    s.check_resource_not_found(fake_call_permission, 'CallPermission')
 
 
 @fixtures.outcall()
@@ -26,8 +26,8 @@ def test_dissociate_errors(outcall, call_permission):
     fake_outcall = confd.outcalls(FAKE_ID).callpermissions(call_permission['id']).delete
     fake_call_permission = confd.outcalls(outcall['id']).callpermissions(FAKE_ID).delete
 
-    yield s.check_resource_not_found, fake_outcall, 'Outcall'
-    yield s.check_resource_not_found, fake_call_permission, 'CallPermission'
+    s.check_resource_not_found(fake_outcall, 'Outcall')
+    s.check_resource_not_found(fake_call_permission, 'CallPermission')
 
 
 @fixtures.outcall()
@@ -199,5 +199,5 @@ def test_bus_events(outcall, call_permission):
     url = confd.outcalls(outcall['id']).callpermissions(call_permission['id'])
     headers = {'tenant_uuid': outcall['tenant_uuid']}
 
-    yield (s.check_event, 'outcall_call_permission_associated', headers, url.put)
-    yield (s.check_event, 'outcall_call_permission_dissociated', headers, url.delete)
+    s.check_event('outcall_call_permission_associated', headers, url.put)
+    s.check_event('outcall_call_permission_dissociated', headers, url.delete)

--- a/integration_tests/suite/base/test_outcall_extension.py
+++ b/integration_tests/suite/base/test_outcall_extension.py
@@ -16,35 +16,34 @@ def test_associate_errors(outcall, extension):
     fake_outcall = confd.outcalls(FAKE_ID).extensions(extension['id']).put
     fake_extension = confd.outcalls(outcall['id']).extensions(FAKE_ID).put
 
-    yield s.check_resource_not_found, fake_outcall, 'Outcall'
-    yield s.check_resource_not_found, fake_extension, 'Extension'
+    s.check_resource_not_found(fake_outcall, 'Outcall')
+    s.check_resource_not_found(fake_extension, 'Extension')
 
     url = confd.outcalls(outcall['id']).extensions(extension['id']).put
-    for check in error_checks(url):
-        yield check
+    error_checks(url)
 
 
 def error_checks(url):
-    yield s.check_bogus_field_returns_error, url, 'caller_id', 123
-    yield s.check_bogus_field_returns_error, url, 'caller_id', True
-    yield s.check_bogus_field_returns_error, url, 'caller_id', {}
-    yield s.check_bogus_field_returns_error, url, 'caller_id', []
-    yield s.check_bogus_field_returns_error, url, 'caller_id', s.random_string(81)
-    yield s.check_bogus_field_returns_error, url, 'external_prefix', s.random_string(65)
-    yield s.check_bogus_field_returns_error, url, 'external_prefix', 'invalid_regex'
-    yield s.check_bogus_field_returns_error, url, 'external_prefix', True
-    yield s.check_bogus_field_returns_error, url, 'external_prefix', []
-    yield s.check_bogus_field_returns_error, url, 'external_prefix', {}
-    yield s.check_bogus_field_returns_error, url, 'prefix', s.random_string(33)
-    yield s.check_bogus_field_returns_error, url, 'prefix', 'invalid_regex'
-    yield s.check_bogus_field_returns_error, url, 'prefix', True
-    yield s.check_bogus_field_returns_error, url, 'prefix', []
-    yield s.check_bogus_field_returns_error, url, 'prefix', {}
-    yield s.check_bogus_field_returns_error, url, 'strip_digits', None
-    yield s.check_bogus_field_returns_error, url, 'strip_digits', 'string'
-    yield s.check_bogus_field_returns_error, url, 'strip_digits', -1
-    yield s.check_bogus_field_returns_error, url, 'strip_digits', []
-    yield s.check_bogus_field_returns_error, url, 'strip_digits', {}
+    s.check_bogus_field_returns_error(url, 'caller_id', 123)
+    s.check_bogus_field_returns_error(url, 'caller_id', True)
+    s.check_bogus_field_returns_error(url, 'caller_id', {})
+    s.check_bogus_field_returns_error(url, 'caller_id', [])
+    s.check_bogus_field_returns_error(url, 'caller_id', s.random_string(81))
+    s.check_bogus_field_returns_error(url, 'external_prefix', s.random_string(65))
+    s.check_bogus_field_returns_error(url, 'external_prefix', 'invalid_regex')
+    s.check_bogus_field_returns_error(url, 'external_prefix', True)
+    s.check_bogus_field_returns_error(url, 'external_prefix', [])
+    s.check_bogus_field_returns_error(url, 'external_prefix', {})
+    s.check_bogus_field_returns_error(url, 'prefix', s.random_string(33))
+    s.check_bogus_field_returns_error(url, 'prefix', 'invalid_regex')
+    s.check_bogus_field_returns_error(url, 'prefix', True)
+    s.check_bogus_field_returns_error(url, 'prefix', [])
+    s.check_bogus_field_returns_error(url, 'prefix', {})
+    s.check_bogus_field_returns_error(url, 'strip_digits', None)
+    s.check_bogus_field_returns_error(url, 'strip_digits', 'string')
+    s.check_bogus_field_returns_error(url, 'strip_digits', -1)
+    s.check_bogus_field_returns_error(url, 'strip_digits', [])
+    s.check_bogus_field_returns_error(url, 'strip_digits', {})
 
 
 @fixtures.outcall()
@@ -53,8 +52,8 @@ def test_dissociate_errors(outcall, extension):
     fake_outcall = confd.outcalls(FAKE_ID).extensions(extension['id']).delete
     fake_extension = confd.outcalls(outcall['id']).extensions(FAKE_ID).delete
 
-    yield s.check_resource_not_found, fake_outcall, 'Outcall'
-    yield s.check_resource_not_found, fake_extension, 'Extension'
+    s.check_resource_not_found(fake_outcall, 'Outcall')
+    s.check_resource_not_found(fake_extension, 'Extension')
 
 
 @fixtures.outcall()

--- a/integration_tests/suite/base/test_outcall_schedule.py
+++ b/integration_tests/suite/base/test_outcall_schedule.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import assert_that, contains, has_entries
@@ -15,8 +15,8 @@ def test_associate_errors(outcall, schedule):
     fake_outcall = confd.outcalls(FAKE_ID).schedules(schedule['id']).put
     fake_schedule = confd.outcalls(outcall['id']).schedules(FAKE_ID).put
 
-    yield s.check_resource_not_found, fake_outcall, 'Outcall'
-    yield s.check_resource_not_found, fake_schedule, 'Schedule'
+    s.check_resource_not_found(fake_outcall, 'Outcall')
+    s.check_resource_not_found(fake_schedule, 'Schedule')
 
 
 @fixtures.outcall()
@@ -25,8 +25,8 @@ def test_dissociate_errors(outcall, schedule):
     fake_outcall = confd.outcalls(FAKE_ID).schedules(schedule['id']).delete
     fake_schedule = confd.outcalls(outcall['id']).schedules(FAKE_ID).delete
 
-    yield s.check_resource_not_found, fake_outcall, 'Outcall'
-    yield s.check_resource_not_found, fake_schedule, 'Schedule'
+    s.check_resource_not_found(fake_outcall, 'Outcall')
+    s.check_resource_not_found(fake_schedule, 'Schedule')
 
 
 @fixtures.outcall()

--- a/integration_tests/suite/base/test_outcall_trunk.py
+++ b/integration_tests/suite/base/test_outcall_trunk.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import assert_that, contains, empty, has_entries, none
@@ -17,24 +17,23 @@ def test_associate_errors(outcall, trunk):
     response.assert_status(404)
 
     url = confd.outcalls(outcall['id']).trunks().put
-    for check in error_checks(url):
-        yield check
+    error_checks(url)
 
 
 def error_checks(url):
-    yield s.check_bogus_field_returns_error, url, 'trunks', 123
-    yield s.check_bogus_field_returns_error, url, 'trunks', None
-    yield s.check_bogus_field_returns_error, url, 'trunks', True
-    yield s.check_bogus_field_returns_error, url, 'trunks', 'string'
-    yield s.check_bogus_field_returns_error, url, 'trunks', [123]
-    yield s.check_bogus_field_returns_error, url, 'trunks', [None]
-    yield s.check_bogus_field_returns_error, url, 'trunks', ['string']
-    yield s.check_bogus_field_returns_error, url, 'trunks', [{}]
-    yield s.check_bogus_field_returns_error, url, 'trunks', [{'id': None}]
-    yield s.check_bogus_field_returns_error, url, 'trunks', [{'id': 'string'}]
-    yield s.check_bogus_field_returns_error, url, 'trunks', [{'id': 1}, {'id': None}]
-    yield s.check_bogus_field_returns_error, url, 'trunks', [{'not_id': 123}]
-    yield s.check_bogus_field_returns_error, url, 'trunks', [{'id': FAKE_ID}]
+    s.check_bogus_field_returns_error(url, 'trunks', 123)
+    s.check_bogus_field_returns_error(url, 'trunks', None)
+    s.check_bogus_field_returns_error(url, 'trunks', True)
+    s.check_bogus_field_returns_error(url, 'trunks', 'string')
+    s.check_bogus_field_returns_error(url, 'trunks', [123])
+    s.check_bogus_field_returns_error(url, 'trunks', [None])
+    s.check_bogus_field_returns_error(url, 'trunks', ['string'])
+    s.check_bogus_field_returns_error(url, 'trunks', [{}])
+    s.check_bogus_field_returns_error(url, 'trunks', [{'id': None}])
+    s.check_bogus_field_returns_error(url, 'trunks', [{'id': 'string'}])
+    s.check_bogus_field_returns_error(url, 'trunks', [{'id': 1}, {'id': None}])
+    s.check_bogus_field_returns_error(url, 'trunks', [{'not_id': 123}])
+    s.check_bogus_field_returns_error(url, 'trunks', [{'id': FAKE_ID}])
 
 
 @fixtures.outcall()
@@ -149,13 +148,13 @@ def test_delete_outcall_when_outcall_and_trunk_associated(outcall, trunk1, trunk
         confd.outcalls(outcall['id']).delete().assert_deleted()
 
         deleted_outcall = confd.outcalls(outcall['id']).get
-        yield s.check_resource_not_found, deleted_outcall, 'Outcall'
+        s.check_resource_not_found(deleted_outcall, 'Outcall')
 
         response = confd.trunks(trunk1['id']).get()
-        yield assert_that, response.item['outcalls'], empty()
+        assert_that(response.item['outcalls'], empty())
 
         response = confd.trunks(trunk2['id']).get()
-        yield assert_that, response.item['outcalls'], empty()
+        assert_that(response.item['outcalls'], empty())
 
 
 @fixtures.outcall()
@@ -168,10 +167,10 @@ def test_delete_trunk_when_outcall_and_trunk_associated(outcall1, outcall2, trun
         confd.trunks(trunk['id']).delete().assert_deleted()
 
         deleted_trunk = confd.trunks(trunk['id']).get
-        yield s.check_resource_not_found, deleted_trunk, 'Trunk'
+        s.check_resource_not_found(deleted_trunk, 'Trunk')
 
         response = confd.outcalls(outcall1['id']).get()
-        yield assert_that, response.item['trunks'], empty()
+        assert_that(response.item['trunks'], empty())
 
         response = confd.outcalls(outcall2['id']).get()
-        yield assert_that, response.item['trunks'], empty()
+        assert_that(response.item['trunks'], empty())

--- a/integration_tests/suite/base/test_outcalls.py
+++ b/integration_tests/suite/base/test_outcalls.py
@@ -19,63 +19,58 @@ from ..helpers.config import MAIN_TENANT, SUB_TENANT
 
 def test_get_errors():
     fake_outcall = confd.outcalls(999999).get
-    yield s.check_resource_not_found, fake_outcall, 'Outcall'
+    s.check_resource_not_found(fake_outcall, 'Outcall')
 
 
 def test_delete_errors():
     fake_outcall = confd.outcalls(999999).delete
-    yield s.check_resource_not_found, fake_outcall, 'Outcall'
+    s.check_resource_not_found(fake_outcall, 'Outcall')
 
 
 def test_post_errors():
     url = confd.outcalls.post
-    for check in error_checks(url):
-        yield check
+    error_checks(url)
 
 
 @fixtures.outcall()
 def test_put_errors(outcall):
     url = confd.outcalls(outcall['id']).put
-    for check in error_checks(url):
-        yield check
+    error_checks(url)
 
 
 def error_checks(url):
-    yield s.check_bogus_field_returns_error, url, 'preprocess_subroutine', 123
-    yield s.check_bogus_field_returns_error, url, 'preprocess_subroutine', s.random_string(
-        80
-    )
-    yield s.check_bogus_field_returns_error, url, 'preprocess_subroutine', []
-    yield s.check_bogus_field_returns_error, url, 'preprocess_subroutine', {}
-    yield s.check_bogus_field_returns_error, url, 'name', True
-    yield s.check_bogus_field_returns_error, url, 'name', None
-    yield s.check_bogus_field_returns_error, url, 'name', s.random_string(129)
-    yield s.check_bogus_field_returns_error, url, 'name', 1234
-    yield s.check_bogus_field_returns_error, url, 'name', []
-    yield s.check_bogus_field_returns_error, url, 'name', {}
-    yield s.check_bogus_field_returns_error, url, 'internal_caller_id', 1234
-    yield s.check_bogus_field_returns_error, url, 'internal_caller_id', 'invalid'
-    yield s.check_bogus_field_returns_error, url, 'internal_caller_id', None
-    yield s.check_bogus_field_returns_error, url, 'internal_caller_id', []
-    yield s.check_bogus_field_returns_error, url, 'internal_caller_id', {}
-    yield s.check_bogus_field_returns_error, url, 'ring_time', 'invalid'
-    yield s.check_bogus_field_returns_error, url, 'ring_time', []
-    yield s.check_bogus_field_returns_error, url, 'ring_time', {}
-    yield s.check_bogus_field_returns_error, url, 'description', 1234
-    yield s.check_bogus_field_returns_error, url, 'description', []
-    yield s.check_bogus_field_returns_error, url, 'description', {}
-    yield s.check_bogus_field_returns_error, url, 'enabled', 'invalid'
-    yield s.check_bogus_field_returns_error, url, 'enabled', None
-    yield s.check_bogus_field_returns_error, url, 'enabled', []
-    yield s.check_bogus_field_returns_error, url, 'enabled', {}
+    s.check_bogus_field_returns_error(url, 'preprocess_subroutine', 123)
+    s.check_bogus_field_returns_error(url, 'preprocess_subroutine', s.random_string(80))
+    s.check_bogus_field_returns_error(url, 'preprocess_subroutine', [])
+    s.check_bogus_field_returns_error(url, 'preprocess_subroutine', {})
+    s.check_bogus_field_returns_error(url, 'name', True)
+    s.check_bogus_field_returns_error(url, 'name', None)
+    s.check_bogus_field_returns_error(url, 'name', s.random_string(129))
+    s.check_bogus_field_returns_error(url, 'name', 1234)
+    s.check_bogus_field_returns_error(url, 'name', [])
+    s.check_bogus_field_returns_error(url, 'name', {})
+    s.check_bogus_field_returns_error(url, 'internal_caller_id', 1234)
+    s.check_bogus_field_returns_error(url, 'internal_caller_id', 'invalid')
+    s.check_bogus_field_returns_error(url, 'internal_caller_id', None)
+    s.check_bogus_field_returns_error(url, 'internal_caller_id', [])
+    s.check_bogus_field_returns_error(url, 'internal_caller_id', {})
+    s.check_bogus_field_returns_error(url, 'ring_time', 'invalid')
+    s.check_bogus_field_returns_error(url, 'ring_time', [])
+    s.check_bogus_field_returns_error(url, 'ring_time', {})
+    s.check_bogus_field_returns_error(url, 'description', 1234)
+    s.check_bogus_field_returns_error(url, 'description', [])
+    s.check_bogus_field_returns_error(url, 'description', {})
+    s.check_bogus_field_returns_error(url, 'enabled', 'invalid')
+    s.check_bogus_field_returns_error(url, 'enabled', None)
+    s.check_bogus_field_returns_error(url, 'enabled', [])
+    s.check_bogus_field_returns_error(url, 'enabled', {})
 
-    for check in unique_error_checks(url):
-        yield check
+    unique_error_checks(url)
 
 
 @fixtures.outcall(name='unique')
 def unique_error_checks(url, outcall):
-    yield s.check_bogus_field_returns_error, url, 'name', outcall['name']
+    s.check_bogus_field_returns_error(url, 'name', outcall['name'])
 
 
 @fixtures.outcall(description='search')
@@ -85,7 +80,7 @@ def test_search(outcall, hidden):
     searches = {'description': 'search'}
 
     for field, term in searches.items():
-        yield check_search, url, outcall, hidden, field, term
+        check_search(url, outcall, hidden, field, term)
 
 
 def check_search(url, outcall, hidden, field, term):
@@ -115,10 +110,10 @@ def test_list_multi_tenant(main, sub):
 @fixtures.outcall(description='sort2')
 def test_sorting_offset_limit(outcall1, outcall2):
     url = confd.outcalls.get
-    yield s.check_sorting, url, outcall1, outcall2, 'description', 'sort'
+    s.check_sorting(url, outcall1, outcall2, 'description', 'sort')
 
-    yield s.check_offset, url, outcall1, outcall2, 'description', 'sort'
-    yield s.check_limit, url, outcall1, outcall2, 'description', 'sort'
+    s.check_offset(url, outcall1, outcall2, 'description', 'sort')
+    s.check_limit(url, outcall1, outcall2, 'description', 'sort')
 
 
 @fixtures.outcall()
@@ -233,6 +228,6 @@ def test_bus_events(outcall):
     url = confd.outcalls(outcall['id'])
     headers = {'tenant_uuid': outcall['tenant_uuid']}
 
-    yield s.check_event, 'outcall_created', headers, confd.outcalls.post, {'name': 'a'}
-    yield s.check_event, 'outcall_edited', headers, url.put
-    yield s.check_event, 'outcall_deleted', headers, url.delete
+    s.check_event('outcall_created', headers, confd.outcalls.post, {'name': 'a'})
+    s.check_event('outcall_edited', headers, url.put)
+    s.check_event('outcall_deleted', headers, url.delete)

--- a/integration_tests/suite/base/test_paging_caller_user.py
+++ b/integration_tests/suite/base/test_paging_caller_user.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import assert_that, contains_inanyorder, empty, has_entries
@@ -18,23 +18,22 @@ def test_associate_errors(paging, user):
     response.assert_status(404)
 
     url = confd.pagings(paging['id']).callers.users.put
-    for check in error_checks(url):
-        yield check
+    error_checks(url)
 
 
 def error_checks(url):
-    yield s.check_bogus_field_returns_error, url, 'users', 123
-    yield s.check_bogus_field_returns_error, url, 'users', None
-    yield s.check_bogus_field_returns_error, url, 'users', True
-    yield s.check_bogus_field_returns_error, url, 'users', 'string'
-    yield s.check_bogus_field_returns_error, url, 'users', [123]
-    yield s.check_bogus_field_returns_error, url, 'users', [None]
-    yield s.check_bogus_field_returns_error, url, 'users', ['string']
-    yield s.check_bogus_field_returns_error, url, 'users', [{}]
-    yield s.check_bogus_field_returns_error, url, 'users', [{'uuid': None}]
-    yield s.check_bogus_field_returns_error, url, 'users', [{'uuid': 1}, {'uuid': None}]
-    yield s.check_bogus_field_returns_error, url, 'users', [{'not_uuid': 123}]
-    yield s.check_bogus_field_returns_error, url, 'users', [{'uuid': FAKE_UUID}]
+    s.check_bogus_field_returns_error(url, 'users', 123)
+    s.check_bogus_field_returns_error(url, 'users', None)
+    s.check_bogus_field_returns_error(url, 'users', True)
+    s.check_bogus_field_returns_error(url, 'users', 'string')
+    s.check_bogus_field_returns_error(url, 'users', [123])
+    s.check_bogus_field_returns_error(url, 'users', [None])
+    s.check_bogus_field_returns_error(url, 'users', ['string'])
+    s.check_bogus_field_returns_error(url, 'users', [{}])
+    s.check_bogus_field_returns_error(url, 'users', [{'uuid': None}])
+    s.check_bogus_field_returns_error(url, 'users', [{'uuid': 1}, {'uuid': None}])
+    s.check_bogus_field_returns_error(url, 'users', [{'not_uuid': 123}])
+    s.check_bogus_field_returns_error(url, 'users', [{'uuid': FAKE_UUID}])
 
 
 @fixtures.paging()
@@ -141,7 +140,7 @@ def test_delete_paging_when_paging_and_user_associated(paging, user1, user2):
         confd.pagings(paging['id']).delete().assert_deleted()
 
         deleted_paging = confd.pagings(paging['id']).get
-        yield s.check_resource_not_found, deleted_paging, 'Paging'
+        s.check_resource_not_found(deleted_paging, 'Paging')
 
         # When the relation will be added,
         # we should check if users have the key pagings to empty
@@ -157,10 +156,10 @@ def test_delete_user_when_paging_and_user_associated(paging1, paging2, user):
         confd.users(user['uuid']).delete().assert_deleted()
 
         response = confd.pagings(paging1['id']).get()
-        yield assert_that, response.item['callers']['users'], empty()
+        assert_that(response.item['callers']['users'], empty())
 
         response = confd.pagings(paging2['id']).get()
-        yield assert_that, response.item['callers']['users'], empty()
+        assert_that(response.item['callers']['users'], empty())
 
 
 @fixtures.paging()
@@ -170,4 +169,4 @@ def test_bus_events(paging, user):
     body = {'users': [user]}
     headers = {'tenant_uuid': paging['tenant_uuid']}
 
-    yield s.check_event, 'paging_caller_users_associated', headers, url, body
+    s.check_event('paging_caller_users_associated', headers, url, body)

--- a/integration_tests/suite/base/test_paging_member_user.py
+++ b/integration_tests/suite/base/test_paging_member_user.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import assert_that, contains_inanyorder, empty, has_entries
@@ -18,23 +18,22 @@ def test_associate_errors(paging, user):
     response.assert_status(404)
 
     url = confd.pagings(paging['id']).members.users.put
-    for check in error_checks(url):
-        yield check
+    error_checks(url)
 
 
 def error_checks(url):
-    yield s.check_bogus_field_returns_error, url, 'users', 123
-    yield s.check_bogus_field_returns_error, url, 'users', None
-    yield s.check_bogus_field_returns_error, url, 'users', True
-    yield s.check_bogus_field_returns_error, url, 'users', 'string'
-    yield s.check_bogus_field_returns_error, url, 'users', [123]
-    yield s.check_bogus_field_returns_error, url, 'users', [None]
-    yield s.check_bogus_field_returns_error, url, 'users', ['string']
-    yield s.check_bogus_field_returns_error, url, 'users', [{}]
-    yield s.check_bogus_field_returns_error, url, 'users', [{'uuid': None}]
-    yield s.check_bogus_field_returns_error, url, 'users', [{'uuid': 1}, {'uuid': None}]
-    yield s.check_bogus_field_returns_error, url, 'users', [{'not_uuid': 123}]
-    yield s.check_bogus_field_returns_error, url, 'users', [{'uuid': FAKE_UUID}]
+    s.check_bogus_field_returns_error(url, 'users', 123)
+    s.check_bogus_field_returns_error(url, 'users', None)
+    s.check_bogus_field_returns_error(url, 'users', True)
+    s.check_bogus_field_returns_error(url, 'users', 'string')
+    s.check_bogus_field_returns_error(url, 'users', [123])
+    s.check_bogus_field_returns_error(url, 'users', [None])
+    s.check_bogus_field_returns_error(url, 'users', ['string'])
+    s.check_bogus_field_returns_error(url, 'users', [{}])
+    s.check_bogus_field_returns_error(url, 'users', [{'uuid': None}])
+    s.check_bogus_field_returns_error(url, 'users', [{'uuid': 1}, {'uuid': None}])
+    s.check_bogus_field_returns_error(url, 'users', [{'not_uuid': 123}])
+    s.check_bogus_field_returns_error(url, 'users', [{'uuid': FAKE_UUID}])
 
 
 @fixtures.paging()
@@ -141,7 +140,7 @@ def test_delete_paging_when_paging_and_user_associated(paging, user1, user2):
         confd.pagings(paging['id']).delete().assert_deleted()
 
         deleted_paging = confd.pagings(paging['id']).get
-        yield s.check_resource_not_found, deleted_paging, 'Paging'
+        s.check_resource_not_found(deleted_paging, 'Paging')
 
         # When the relation will be added,
         # we should check if users have the key pagings to empty
@@ -157,10 +156,10 @@ def test_delete_user_when_paging_and_user_associated(paging1, paging2, user):
         confd.users(user['uuid']).delete().assert_deleted()
 
         response = confd.pagings(paging1['id']).get()
-        yield assert_that, response.item['members']['users'], empty()
+        assert_that(response.item['members']['users'], empty())
 
         response = confd.pagings(paging2['id']).get()
-        yield assert_that, response.item['members']['users'], empty()
+        assert_that(response.item['members']['users'], empty())
 
 
 @fixtures.paging()
@@ -170,4 +169,4 @@ def test_bus_events(paging, user):
     body = {'users': [user]}
     headers = {'tenant_uuid': paging['tenant_uuid']}
 
-    yield s.check_event, 'paging_member_users_associated', headers, url, body
+    s.check_event('paging_member_users_associated', headers, url, body)

--- a/integration_tests/suite/base/test_pagings.py
+++ b/integration_tests/suite/base/test_pagings.py
@@ -20,70 +20,67 @@ from ..helpers.config import MAIN_TENANT, SUB_TENANT
 
 def test_get_errors():
     fake_paging = confd.pagings(999999).get
-    yield s.check_resource_not_found, fake_paging, 'Paging'
+    s.check_resource_not_found(fake_paging, 'Paging')
 
 
 def test_delete_errors():
     fake_paging = confd.pagings(999999).delete
-    yield s.check_resource_not_found, fake_paging, 'Paging'
+    s.check_resource_not_found(fake_paging, 'Paging')
 
 
 def test_post_errors():
     url = confd.pagings.post
-    for check in error_checks(url):
-        yield check
+    error_checks(url)
 
 
 @fixtures.paging(number='724464')
 def test_put_errors(paging):
     url = confd.pagings(paging['id']).put
-    for check in error_checks(url):
-        yield check
+    error_checks(url)
 
 
 def error_checks(url):
-    yield s.check_bogus_field_returns_error, url, 'name', True
-    yield s.check_bogus_field_returns_error, url, 'name', 1234
-    yield s.check_bogus_field_returns_error, url, 'name', s.random_string(129)
-    yield s.check_bogus_field_returns_error, url, 'name', []
-    yield s.check_bogus_field_returns_error, url, 'name', {}
-    yield s.check_bogus_field_returns_error, url, 'number', True
-    yield s.check_bogus_field_returns_error, url, 'number', 123
-    yield s.check_bogus_field_returns_error, url, 'number', 'invalid'
-    yield s.check_bogus_field_returns_error, url, 'number', []
-    yield s.check_bogus_field_returns_error, url, 'number', {}
-    yield s.check_bogus_field_returns_error, url, 'announce_caller', 'invalid'
-    yield s.check_bogus_field_returns_error, url, 'announce_caller', None
-    yield s.check_bogus_field_returns_error, url, 'announce_caller', []
-    yield s.check_bogus_field_returns_error, url, 'announce_caller', {}
-    yield s.check_bogus_field_returns_error, url, 'announce_sound', True
-    yield s.check_bogus_field_returns_error, url, 'announce_sound', 1234
-    yield s.check_bogus_field_returns_error, url, 'announce_sound', []
-    yield s.check_bogus_field_returns_error, url, 'announce_sound', {}
-    yield s.check_bogus_field_returns_error, url, 'duplex', 'invalid'
-    yield s.check_bogus_field_returns_error, url, 'duplex', None
-    yield s.check_bogus_field_returns_error, url, 'duplex', []
-    yield s.check_bogus_field_returns_error, url, 'duplex', {}
-    yield s.check_bogus_field_returns_error, url, 'ignore_forward', 'invalid'
-    yield s.check_bogus_field_returns_error, url, 'ignore_forward', None
-    yield s.check_bogus_field_returns_error, url, 'ignore_forward', []
-    yield s.check_bogus_field_returns_error, url, 'ignore_forward', {}
-    yield s.check_bogus_field_returns_error, url, 'record', 'invalid'
-    yield s.check_bogus_field_returns_error, url, 'record', None
-    yield s.check_bogus_field_returns_error, url, 'record', []
-    yield s.check_bogus_field_returns_error, url, 'record', {}
-    yield s.check_bogus_field_returns_error, url, 'enabled', 'invalid'
-    yield s.check_bogus_field_returns_error, url, 'enabled', None
-    yield s.check_bogus_field_returns_error, url, 'enabled', []
-    yield s.check_bogus_field_returns_error, url, 'enabled', {}
+    s.check_bogus_field_returns_error(url, 'name', True)
+    s.check_bogus_field_returns_error(url, 'name', 1234)
+    s.check_bogus_field_returns_error(url, 'name', s.random_string(129))
+    s.check_bogus_field_returns_error(url, 'name', [])
+    s.check_bogus_field_returns_error(url, 'name', {})
+    s.check_bogus_field_returns_error(url, 'number', True)
+    s.check_bogus_field_returns_error(url, 'number', 123)
+    s.check_bogus_field_returns_error(url, 'number', 'invalid')
+    s.check_bogus_field_returns_error(url, 'number', [])
+    s.check_bogus_field_returns_error(url, 'number', {})
+    s.check_bogus_field_returns_error(url, 'announce_caller', 'invalid')
+    s.check_bogus_field_returns_error(url, 'announce_caller', None)
+    s.check_bogus_field_returns_error(url, 'announce_caller', [])
+    s.check_bogus_field_returns_error(url, 'announce_caller', {})
+    s.check_bogus_field_returns_error(url, 'announce_sound', True)
+    s.check_bogus_field_returns_error(url, 'announce_sound', 1234)
+    s.check_bogus_field_returns_error(url, 'announce_sound', [])
+    s.check_bogus_field_returns_error(url, 'announce_sound', {})
+    s.check_bogus_field_returns_error(url, 'duplex', 'invalid')
+    s.check_bogus_field_returns_error(url, 'duplex', None)
+    s.check_bogus_field_returns_error(url, 'duplex', [])
+    s.check_bogus_field_returns_error(url, 'duplex', {})
+    s.check_bogus_field_returns_error(url, 'ignore_forward', 'invalid')
+    s.check_bogus_field_returns_error(url, 'ignore_forward', None)
+    s.check_bogus_field_returns_error(url, 'ignore_forward', [])
+    s.check_bogus_field_returns_error(url, 'ignore_forward', {})
+    s.check_bogus_field_returns_error(url, 'record', 'invalid')
+    s.check_bogus_field_returns_error(url, 'record', None)
+    s.check_bogus_field_returns_error(url, 'record', [])
+    s.check_bogus_field_returns_error(url, 'record', {})
+    s.check_bogus_field_returns_error(url, 'enabled', 'invalid')
+    s.check_bogus_field_returns_error(url, 'enabled', None)
+    s.check_bogus_field_returns_error(url, 'enabled', [])
+    s.check_bogus_field_returns_error(url, 'enabled', {})
 
-    for check in unique_error_checks(url):
-        yield check
+    unique_error_checks(url)
 
 
 @fixtures.paging(number='123')
 def unique_error_checks(url, paging):
-    yield s.check_bogus_field_returns_error, url, 'number', paging['number']
+    s.check_bogus_field_returns_error(url, 'number', paging['number'])
 
 
 @fixtures.paging(name='search', number='123', announce_sound='search')
@@ -93,7 +90,7 @@ def test_search(paging, hidden):
     searches = {'name': 'search', 'number': '123', 'announce_sound': 'search'}
 
     for field, term in searches.items():
-        yield check_search, url, paging, hidden, field, term
+        check_search(url, paging, hidden, field, term)
 
 
 def check_search(url, paging, hidden, field, term):
@@ -110,10 +107,10 @@ def check_search(url, paging, hidden, field, term):
 @fixtures.paging(name='sort2')
 def test_sort_offset_limit(paging1, paging2):
     url = confd.pagings.get
-    yield s.check_sorting, url, paging1, paging2, 'name', 'sort'
+    s.check_sorting(url, paging1, paging2, 'name', 'sort')
 
-    yield s.check_offset, url, paging1, paging2, 'name', 'sort'
-    yield s.check_limit, url, paging1, paging2, 'name', 'sort'
+    s.check_offset(url, paging1, paging2, 'name', 'sort')
+    s.check_limit(url, paging1, paging2, 'name', 'sort')
 
 
 @fixtures.paging(wazo_tenant=MAIN_TENANT)
@@ -250,8 +247,6 @@ def test_bus_events(paging):
     url = confd.pagings(paging['id'])
     headers = {'tenant_uuid': paging['tenant_uuid']}
 
-    yield s.check_event, 'paging_created', headers, confd.pagings.post, {
-        'number': '666'
-    }
-    yield s.check_event, 'paging_edited', headers, url.put
-    yield s.check_event, 'paging_deleted', headers, url.delete
+    s.check_event('paging_created', headers, confd.pagings.post, {'number': '666'})
+    s.check_event('paging_edited', headers, url.put)
+    s.check_event('paging_deleted', headers, url.delete)

--- a/integration_tests/suite/base/test_parking_lot_extension.py
+++ b/integration_tests/suite/base/test_parking_lot_extension.py
@@ -16,8 +16,8 @@ def test_associate_errors(parking_lot, extension):
     fake_parking_lot = confd.parkinglots(FAKE_ID).extensions(extension['id']).put
     fake_extension = confd.parkinglots(parking_lot['id']).extensions(FAKE_ID).put
 
-    yield s.check_resource_not_found, fake_parking_lot, 'ParkingLot'
-    yield s.check_resource_not_found, fake_extension, 'Extension'
+    s.check_resource_not_found(fake_parking_lot, 'ParkingLot')
+    s.check_resource_not_found(fake_extension, 'Extension')
 
 
 @fixtures.parking_lot()
@@ -26,8 +26,8 @@ def test_dissociate_errors(parking_lot, extension):
     fake_parking_lot = confd.parkinglots(FAKE_ID).extensions(extension['id']).delete
     fake_extension = confd.parkinglots(parking_lot['id']).extensions(FAKE_ID).delete
 
-    yield s.check_resource_not_found, fake_parking_lot, 'ParkingLot'
-    yield s.check_resource_not_found, fake_extension, 'Extension'
+    s.check_resource_not_found(fake_parking_lot, 'ParkingLot')
+    s.check_resource_not_found(fake_extension, 'Extension')
 
 
 @fixtures.parking_lot()

--- a/integration_tests/suite/base/test_parking_lots.py
+++ b/integration_tests/suite/base/test_parking_lots.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import (
@@ -25,54 +25,52 @@ from ..helpers.config import MAIN_TENANT, SUB_TENANT
 
 def test_get_errors():
     fake_parking_lot = confd.parkinglots(999999).get
-    yield s.check_resource_not_found, fake_parking_lot, 'ParkingLot'
+    s.check_resource_not_found(fake_parking_lot, 'ParkingLot')
 
 
 def test_delete_errors():
     fake_parking_lot = confd.parkinglots(999999).delete
-    yield s.check_resource_not_found, fake_parking_lot, 'ParkingLot'
+    s.check_resource_not_found(fake_parking_lot, 'ParkingLot')
 
 
 def test_post_errors():
     url = confd.parkinglots.post
-    for check in error_checks(url):
-        yield check
+    error_checks(url)
 
 
 @fixtures.parking_lot()
 def test_put_errors(parking_lot):
     url = confd.parkinglots(parking_lot['id']).put
-    for check in error_checks(url):
-        yield check
+    error_checks(url)
 
 
 def error_checks(url):
-    yield s.check_bogus_field_returns_error, url, 'name', True
-    yield s.check_bogus_field_returns_error, url, 'name', 1234
-    yield s.check_bogus_field_returns_error, url, 'name', s.random_string(129)
-    yield s.check_bogus_field_returns_error, url, 'name', []
-    yield s.check_bogus_field_returns_error, url, 'name', {}
-    yield s.check_bogus_field_returns_error, url, 'slots_start', 'invalid'
-    yield s.check_bogus_field_returns_error, url, 'slots_start', '-1'
-    yield s.check_bogus_field_returns_error, url, 'slots_start', True
-    yield s.check_bogus_field_returns_error, url, 'slots_start', None
-    yield s.check_bogus_field_returns_error, url, 'slots_start', []
-    yield s.check_bogus_field_returns_error, url, 'slots_start', {}
-    yield s.check_bogus_field_returns_error, url, 'slots_end', 'invalid'
-    yield s.check_bogus_field_returns_error, url, 'slots_end', '-1'
-    yield s.check_bogus_field_returns_error, url, 'slots_end', True
-    yield s.check_bogus_field_returns_error, url, 'slots_end', None
-    yield s.check_bogus_field_returns_error, url, 'slots_end', []
-    yield s.check_bogus_field_returns_error, url, 'slots_end', {}
-    yield s.check_bogus_field_returns_error, url, 'timeout', 'string'
-    yield s.check_bogus_field_returns_error, url, 'timeout', -1
-    yield s.check_bogus_field_returns_error, url, 'timeout', []
-    yield s.check_bogus_field_returns_error, url, 'timeout', {}
-    yield s.check_bogus_field_returns_error, url, 'music_on_hold', 1234
-    yield s.check_bogus_field_returns_error, url, 'music_on_hold', True
-    yield s.check_bogus_field_returns_error, url, 'music_on_hold', s.random_string(129)
-    yield s.check_bogus_field_returns_error, url, 'music_on_hold', []
-    yield s.check_bogus_field_returns_error, url, 'music_on_hold', {}
+    s.check_bogus_field_returns_error(url, 'name', True)
+    s.check_bogus_field_returns_error(url, 'name', 1234)
+    s.check_bogus_field_returns_error(url, 'name', s.random_string(129))
+    s.check_bogus_field_returns_error(url, 'name', [])
+    s.check_bogus_field_returns_error(url, 'name', {})
+    s.check_bogus_field_returns_error(url, 'slots_start', 'invalid')
+    s.check_bogus_field_returns_error(url, 'slots_start', '-1')
+    s.check_bogus_field_returns_error(url, 'slots_start', True)
+    s.check_bogus_field_returns_error(url, 'slots_start', None)
+    s.check_bogus_field_returns_error(url, 'slots_start', [])
+    s.check_bogus_field_returns_error(url, 'slots_start', {})
+    s.check_bogus_field_returns_error(url, 'slots_end', 'invalid')
+    s.check_bogus_field_returns_error(url, 'slots_end', '-1')
+    s.check_bogus_field_returns_error(url, 'slots_end', True)
+    s.check_bogus_field_returns_error(url, 'slots_end', None)
+    s.check_bogus_field_returns_error(url, 'slots_end', [])
+    s.check_bogus_field_returns_error(url, 'slots_end', {})
+    s.check_bogus_field_returns_error(url, 'timeout', 'string')
+    s.check_bogus_field_returns_error(url, 'timeout', -1)
+    s.check_bogus_field_returns_error(url, 'timeout', [])
+    s.check_bogus_field_returns_error(url, 'timeout', {})
+    s.check_bogus_field_returns_error(url, 'music_on_hold', 1234)
+    s.check_bogus_field_returns_error(url, 'music_on_hold', True)
+    s.check_bogus_field_returns_error(url, 'music_on_hold', s.random_string(129))
+    s.check_bogus_field_returns_error(url, 'music_on_hold', [])
+    s.check_bogus_field_returns_error(url, 'music_on_hold', {})
 
 
 @fixtures.extension(exten='700')
@@ -103,12 +101,12 @@ def test_search(extension, moh_visible, moh_hidden, parking_lot, hidden):
     }
 
     for field, term in searches.items():
-        yield check_search, url, parking_lot, hidden, field, term
+        check_search(url, parking_lot, hidden, field, term)
 
     searches = {'exten': extension['exten']}
     with a.parking_lot_extension(parking_lot, extension):
         for field, term in searches.items():
-            yield check_relation_search, url, parking_lot, hidden, field, term
+            check_relation_search(url, parking_lot, hidden, field, term)
 
 
 def check_search(url, parking_lot, hidden, field, term):
@@ -135,10 +133,10 @@ def check_relation_search(url, parking_lot, hidden, field, term):
 @fixtures.parking_lot(name='sort2')
 def test_sorting_offset_limit(parking_lot1, parking_lot2):
     url = confd.parkinglots.get
-    yield s.check_sorting, url, parking_lot1, parking_lot2, 'name', 'sort'
+    s.check_sorting(url, parking_lot1, parking_lot2, 'name', 'sort')
 
-    yield s.check_offset, url, parking_lot1, parking_lot2, 'name', 'sort'
-    yield s.check_limit, url, parking_lot1, parking_lot2, 'name', 'sort'
+    s.check_offset(url, parking_lot1, parking_lot2, 'name', 'sort')
+    s.check_limit(url, parking_lot1, parking_lot2, 'name', 'sort')
 
 
 @fixtures.parking_lot(wazo_tenant=MAIN_TENANT)
@@ -317,9 +315,14 @@ def test_bus_events(parking_lot):
     url = confd.parkinglots(parking_lot['id'])
     headers = {'tenant_uuid': parking_lot['tenant_uuid']}
 
-    yield s.check_event, 'parking_lot_created', headers, confd.parkinglots.post, {
-        'slots_start': '999',
-        'slots_end': '999',
-    }
-    yield s.check_event, 'parking_lot_edited', headers, url.put
-    yield s.check_event, 'parking_lot_deleted', headers, url.delete
+    s.check_event(
+        'parking_lot_created',
+        headers,
+        confd.parkinglots.post,
+        {
+            'slots_start': '999',
+            'slots_end': '999',
+        },
+    )
+    s.check_event('parking_lot_edited', headers, url.put)
+    s.check_event('parking_lot_deleted', headers, url.delete)

--- a/integration_tests/suite/base/test_pjsip_global.py
+++ b/integration_tests/suite/base/test_pjsip_global.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2020-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import assert_that, has_entries
@@ -10,21 +10,20 @@ from ..helpers.config import TOKEN_SUB_TENANT
 
 def test_put_errors():
     url = confd.asterisk.pjsip.global_.put
-    for check in error_checks(url):
-        yield check
+    error_checks(url)
 
 
 def error_checks(url):
-    yield s.check_bogus_field_returns_error, url, 'options', 123
-    yield s.check_bogus_field_returns_error, url, 'options', None
-    yield s.check_bogus_field_returns_error, url, 'options', 'string'
-    yield s.check_bogus_field_returns_error, url, 'options', [['ordered', 'option']]
-    yield s.check_bogus_field_returns_error, url, 'options', {'wrong_value': 23}
-    yield s.check_bogus_field_returns_error, url, 'options', {'none_value': None}
+    s.check_bogus_field_returns_error(url, 'options', 123)
+    s.check_bogus_field_returns_error(url, 'options', None)
+    s.check_bogus_field_returns_error(url, 'options', 'string')
+    s.check_bogus_field_returns_error(url, 'options', [['ordered', 'option']])
+    s.check_bogus_field_returns_error(url, 'options', {'wrong_value': 23})
+    s.check_bogus_field_returns_error(url, 'options', {'none_value': None})
     # Not a global option
-    yield s.check_bogus_field_returns_error, url, 'options', {'compact_headers': 'yes'}
+    s.check_bogus_field_returns_error(url, 'options', {'compact_headers': 'yes'})
     # Type is an internal field
-    yield s.check_bogus_field_returns_error, url, 'options', {'type': 'endpoint'}
+    s.check_bogus_field_returns_error(url, 'options', {'type': 'endpoint'})
 
 
 def test_get():
@@ -63,4 +62,4 @@ def test_bus_event_when_edited():
     url = confd.asterisk.pjsip.global_
     headers = {}
 
-    yield s.check_event, 'pjsip_global_updated', headers, url.put, {'options': {}}
+    s.check_event('pjsip_global_updated', headers, url.put, {'options': {}})

--- a/integration_tests/suite/base/test_pjsip_system.py
+++ b/integration_tests/suite/base/test_pjsip_system.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2020-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import assert_that, has_entries
@@ -10,21 +10,20 @@ from ..helpers.config import TOKEN_SUB_TENANT
 
 def test_put_errors():
     url = confd.asterisk.pjsip.system.put
-    for check in error_checks(url):
-        yield check
+    error_checks(url)
 
 
 def error_checks(url):
-    yield s.check_bogus_field_returns_error, url, 'options', 123
-    yield s.check_bogus_field_returns_error, url, 'options', None
-    yield s.check_bogus_field_returns_error, url, 'options', 'string'
-    yield s.check_bogus_field_returns_error, url, 'options', [['ordered', 'option']]
-    yield s.check_bogus_field_returns_error, url, 'options', {'wrong_value': 23}
-    yield s.check_bogus_field_returns_error, url, 'options', {'none_value': None}
+    s.check_bogus_field_returns_error(url, 'options', 123)
+    s.check_bogus_field_returns_error(url, 'options', None)
+    s.check_bogus_field_returns_error(url, 'options', 'string')
+    s.check_bogus_field_returns_error(url, 'options', [['ordered', 'option']])
+    s.check_bogus_field_returns_error(url, 'options', {'wrong_value': 23})
+    s.check_bogus_field_returns_error(url, 'options', {'none_value': None})
     # Not a system option
-    yield s.check_bogus_field_returns_error, url, 'options', {'user_agent': 'yes'}
+    s.check_bogus_field_returns_error(url, 'options', {'user_agent': 'yes'})
     # Should not be modified
-    yield s.check_bogus_field_returns_error, url, 'options', {'type': 'endpoint'}
+    s.check_bogus_field_returns_error(url, 'options', {'type': 'endpoint'})
 
 
 def test_get():
@@ -63,4 +62,4 @@ def test_bus_event_when_edited():
     url = confd.asterisk.pjsip.system
     headers = {}
 
-    yield s.check_event, 'pjsip_system_updated', headers, url.put, {'options': {}}
+    s.check_event('pjsip_system_updated', headers, url.put, {'options': {}})

--- a/integration_tests/suite/base/test_pjsip_transports.py
+++ b/integration_tests/suite/base/test_pjsip_transports.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2020-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import (
@@ -24,42 +24,44 @@ FAKE_UUID = '99999999-9999-4999-9999-999999999999'
 
 def test_post_errors():
     url = confd.sip.transports.post
-    for check in error_checks(url):
-        yield check
+    error_checks(url)
 
-    for check in unique_error_checks(url):
-        yield check
+    unique_error_checks(url)
 
 
 def error_checks(url):
-    yield s.check_bogus_field_returns_error, url, 'name', 123
-    yield s.check_bogus_field_returns_error, url, 'name', True
-    yield s.check_bogus_field_returns_error, url, 'name', []
-    yield s.check_bogus_field_returns_error, url, 'name', {}
-    yield s.check_bogus_field_returns_error, url, 'options', 123, {'name': 'transport'}
-    yield s.check_bogus_field_returns_error, url, 'options', None, {'name': 'transport'}
-    yield s.check_bogus_field_returns_error, url, 'options', True, {'name': 'transport'}
-    yield s.check_bogus_field_returns_error, url, 'options', {}, {'name': 'transport'}
-    yield s.check_bogus_field_returns_error, url, 'options', {}, {'name': 'system'}
-    yield s.check_bogus_field_returns_error, url, 'options', {}, {'name': 'global'}
-    yield s.check_bogus_field_returns_error, url, 'options', [
-        ['not-a-transport-option', '42'],
-    ], {'name': 'transport'}
-    yield s.check_bogus_field_returns_error, url, 'options', [
-        ['one', 'two', 'three']
-    ], {'name': 'transport'}
+    s.check_bogus_field_returns_error(url, 'name', 123)
+    s.check_bogus_field_returns_error(url, 'name', True)
+    s.check_bogus_field_returns_error(url, 'name', [])
+    s.check_bogus_field_returns_error(url, 'name', {})
+    s.check_bogus_field_returns_error(url, 'options', 123, {'name': 'transport'})
+    s.check_bogus_field_returns_error(url, 'options', None, {'name': 'transport'})
+    s.check_bogus_field_returns_error(url, 'options', True, {'name': 'transport'})
+    s.check_bogus_field_returns_error(url, 'options', {}, {'name': 'transport'})
+    s.check_bogus_field_returns_error(url, 'options', {}, {'name': 'system'})
+    s.check_bogus_field_returns_error(url, 'options', {}, {'name': 'global'})
+    s.check_bogus_field_returns_error(
+        url,
+        'options',
+        [
+            ['not-a-transport-option', '42'],
+        ],
+        {'name': 'transport'},
+    )
+    s.check_bogus_field_returns_error(
+        url, 'options', [['one', 'two', 'three']], {'name': 'transport'}
+    )
 
-    for check in unique_error_checks(url):
-        yield check
+    unique_error_checks(url)
 
 
 @fixtures.transport(name='transport_unique')
 @fixtures.sip(name='endpoint_unique')
 @fixtures.sip_template(name='template_unique')
 def unique_error_checks(url, transport, sip, template):
-    yield s.check_bogus_field_returns_error, url, 'name', transport['name']
-    yield s.check_bogus_field_returns_error, url, 'name', template['name']
-    yield s.check_bogus_field_returns_error, url, 'name', sip['name']
+    s.check_bogus_field_returns_error(url, 'name', transport['name'])
+    s.check_bogus_field_returns_error(url, 'name', template['name'])
+    s.check_bogus_field_returns_error(url, 'name', sip['name'])
 
 
 def test_create_minimal_parameters():
@@ -98,11 +100,9 @@ def test_create_all_parameters():
 @fixtures.transport()
 def test_put_errors(transport):
     url = confd.sip.transports(transport['uuid']).put
-    for check in error_checks(url):
-        yield check
+    error_checks(url)
 
-    for check in unique_error_checks(url):
-        yield check
+    unique_error_checks(url)
 
 
 @fixtures.transport()
@@ -124,7 +124,7 @@ def test_edit_options_with_commas(transport):
 
 def test_get_errors():
     fake_transport = confd.sip.transports(FAKE_UUID).get
-    yield s.check_resource_not_found, fake_transport, 'Transport'
+    s.check_resource_not_found(fake_transport, 'Transport')
 
 
 @fixtures.transport()
@@ -142,7 +142,7 @@ def test_get(transport):
 
 def test_delete_errors():
     fake_transport = confd.sip.transports(FAKE_UUID).delete
-    yield s.check_resource_not_found, fake_transport, 'Transport'
+    s.check_resource_not_found(fake_transport, 'Transport')
 
 
 @fixtures.transport()
@@ -178,7 +178,7 @@ def test_search(hidden, transport):
     searches = {'name': 'search'}
 
     for field, term in searches.items():
-        yield check_search, url, transport, hidden, field, term
+        check_search(url, transport, hidden, field, term)
 
 
 def check_search(url, transport, hidden, field, term):
@@ -195,11 +195,11 @@ def check_search(url, transport, hidden, field, term):
 @fixtures.transport(name='sort2')
 def test_sorting_offset_limit(transport1, transport2):
     url = confd.sip.transports.get
-    yield s.check_sorting, url, transport1, transport2, 'name', 'sort', 'uuid'
+    s.check_sorting(url, transport1, transport2, 'name', 'sort', 'uuid')
 
-    yield s.check_offset, url, transport1, transport2, 'name', 'sort', 'uuid'
+    s.check_offset(url, transport1, transport2, 'name', 'sort', 'uuid')
 
-    yield s.check_limit, url, transport1, transport2, 'name', 'sort', 'uuid'
+    s.check_limit(url, transport1, transport2, 'name', 'sort', 'uuid')
 
 
 @fixtures.transport()
@@ -219,8 +219,13 @@ def test_bus_events(transport):
     url = confd.sip.transports(transport['uuid'])
     headers = {}
 
-    yield s.check_event, 'sip_transport_created', headers, confd.sip.transports.post, {
-        'name': 'a-leaked-transport',
-    }
-    yield s.check_event, 'sip_transport_edited', headers, url.put, {'name': 'new'}
-    yield s.check_event, 'sip_transport_deleted', headers, url.delete
+    s.check_event(
+        'sip_transport_created',
+        headers,
+        confd.sip.transports.post,
+        {
+            'name': 'a-leaked-transport',
+        },
+    )
+    s.check_event('sip_transport_edited', headers, url.put, {'name': 'new'})
+    s.check_event('sip_transport_deleted', headers, url.delete)

--- a/integration_tests/suite/base/test_provisioning_networking.py
+++ b/integration_tests/suite/base/test_provisioning_networking.py
@@ -25,19 +25,19 @@ def test_get():
 def test_put_errors():
     url = confd.provisioning.networking.put
 
-    yield s.check_bogus_field_returns_error, url, 'provision_http_base_url', 123
-    yield s.check_bogus_field_returns_error, url, 'provision_http_base_url', True
-    yield s.check_bogus_field_returns_error, url, 'provision_http_base_url', {}
-    yield s.check_bogus_field_returns_error, url, 'provision_http_base_url', []
-    yield s.check_bogus_field_returns_error, url, 'provision_http_base_url', s.random_string(
-        256
+    s.check_bogus_field_returns_error(url, 'provision_http_base_url', 123)
+    s.check_bogus_field_returns_error(url, 'provision_http_base_url', True)
+    s.check_bogus_field_returns_error(url, 'provision_http_base_url', {})
+    s.check_bogus_field_returns_error(url, 'provision_http_base_url', [])
+    s.check_bogus_field_returns_error(
+        url, 'provision_http_base_url', s.random_string(256)
     )
 
-    yield s.check_bogus_field_returns_error, url, 'provision_host', 123
-    yield s.check_bogus_field_returns_error, url, 'provision_host', True
-    yield s.check_bogus_field_returns_error, url, 'provision_host', {}
-    yield s.check_bogus_field_returns_error, url, 'provision_host', []
-    yield s.check_bogus_field_returns_error, url, 'provision_host', s.random_string(40)
+    s.check_bogus_field_returns_error(url, 'provision_host', 123)
+    s.check_bogus_field_returns_error(url, 'provision_host', True)
+    s.check_bogus_field_returns_error(url, 'provision_host', {})
+    s.check_bogus_field_returns_error(url, 'provision_host', [])
+    s.check_bogus_field_returns_error(url, 'provision_host', s.random_string(40))
 
 
 def test_put_minimal_parameters():

--- a/integration_tests/suite/base/test_queue_extension.py
+++ b/integration_tests/suite/base/test_queue_extension.py
@@ -22,8 +22,8 @@ def test_associate_errors(extension, queue):
     fake_queue = confd.queues(FAKE_ID).extensions(extension['id']).put
     fake_extension = confd.queues(queue['id']).extensions(FAKE_ID).put
 
-    yield s.check_resource_not_found, fake_queue, 'Queue'
-    yield s.check_resource_not_found, fake_extension, 'Extension'
+    s.check_resource_not_found(fake_queue, 'Queue')
+    s.check_resource_not_found(fake_extension, 'Extension')
 
 
 @fixtures.extension(exten=gen_queue_exten())
@@ -32,8 +32,8 @@ def test_dissociate_errors(extension, queue):
     fake_queue = confd.queues(FAKE_ID).extensions(extension['id']).delete
     fake_extension = confd.queues(queue['id']).extensions(FAKE_ID).delete
 
-    yield s.check_resource_not_found, fake_queue, 'Queue'
-    yield s.check_resource_not_found, fake_extension, 'Extension'
+    s.check_resource_not_found(fake_queue, 'Queue')
+    s.check_resource_not_found(fake_extension, 'Extension')
 
 
 @fixtures.extension(exten=gen_queue_exten())
@@ -235,5 +235,5 @@ def test_bus_events(extension, queue):
     url = confd.queues(queue['id']).extensions(extension['id'])
     headers = {'tenant_uuid': queue['tenant_uuid']}
 
-    yield s.check_event, 'queue_extension_associated', headers, url.put
-    yield s.check_event, 'queue_extension_dissociated', headers, url.delete
+    s.check_event('queue_extension_associated', headers, url.put)
+    s.check_event('queue_extension_dissociated', headers, url.delete)

--- a/integration_tests/suite/base/test_queue_fallback.py
+++ b/integration_tests/suite/base/test_queue_fallback.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import assert_that, equal_to, has_entries
@@ -12,28 +12,33 @@ FAKE_ID = 999999999
 
 def test_get_errors():
     fake_queue = confd.queues(FAKE_ID).fallbacks.get
-    yield s.check_resource_not_found, fake_queue, 'Queue'
+    s.check_resource_not_found(fake_queue, 'Queue')
 
 
 @fixtures.queue()
 @fixtures.user()
 def test_put_errors(queue, user):
     fake_queue = confd.queues(FAKE_ID).fallbacks.put
-    yield s.check_resource_not_found, fake_queue, 'Queue'
+    s.check_resource_not_found(fake_queue, 'Queue')
 
     url = confd.queues(queue['id']).fallbacks.put
-    for check in error_checks(url, user):
-        yield check
+    error_checks(url, user)
 
 
 def error_checks(url, user):
     for destination in invalid_destinations():
-        yield s.check_bogus_field_returns_error, url, 'noanswer_destination', destination
-    yield s.check_bogus_field_returns_error, url, 'noanswer_destination', {
-        'type': 'user',
-        'user_id': user['id'],
-        'moh_uuid': '00000000-0000-0000-0000-000000000000',
-    }, {}, 'MOH was not found'
+        s.check_bogus_field_returns_error(url, 'noanswer_destination', destination)
+    s.check_bogus_field_returns_error(
+        url,
+        'noanswer_destination',
+        {
+            'type': 'user',
+            'user_id': user['id'],
+            'moh_uuid': '00000000-0000-0000-0000-000000000000',
+        },
+        {},
+        'MOH was not found',
+    )
 
 
 @fixtures.queue()
@@ -117,7 +122,7 @@ def test_edit_to_none(queue):
 @fixtures.moh()
 def test_valid_destinations(queue, *destinations):
     for destination in valid_destinations(*destinations):
-        yield _update_queue_fallbacks_with_destination, queue['id'], destination
+        _update_queue_fallbacks_with_destination(queue['id'], destination)
 
 
 def _update_queue_fallbacks_with_destination(queue_id, destination):
@@ -159,17 +164,17 @@ def test_nonexistent_destinations(queue, moh):
             'voicemail',
             'conference',
         ):
-            yield _update_user_fallbacks_with_nonexistent_destination, queue[
-                'id'
-            ], destination
+            _update_user_fallbacks_with_nonexistent_destination(
+                queue['id'], destination
+            )
 
         if (
             destination['type'] == 'application'
             and destination['application'] == 'custom'
         ):
-            yield _update_user_fallbacks_with_nonexistent_destination, queue[
-                'id'
-            ], destination
+            _update_user_fallbacks_with_nonexistent_destination(
+                queue['id'], destination
+            )
 
 
 def _update_user_fallbacks_with_nonexistent_destination(queue_id, destination):
@@ -182,4 +187,4 @@ def test_bus_events(queue):
     url = confd.queues(queue['id']).fallbacks.put
     headers = {'tenant_uuid': queue['tenant_uuid']}
 
-    yield s.check_event, 'queue_fallback_edited', headers, url
+    s.check_event('queue_fallback_edited', headers, url)

--- a/integration_tests/suite/base/test_queue_member_agent.py
+++ b/integration_tests/suite/base/test_queue_member_agent.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import (
@@ -26,25 +26,24 @@ def test_associate_errors(queue, agent):
     fake_queue = confd.queues(FAKE_ID).members.agents(agent['id']).put
     fake_agent = confd.queues(queue['id']).members.agents(FAKE_ID).put
 
-    yield s.check_resource_not_found, fake_queue, 'Queue'
-    yield s.check_resource_not_found, fake_agent, 'Agent'
+    s.check_resource_not_found(fake_queue, 'Queue')
+    s.check_resource_not_found(fake_agent, 'Agent')
 
     url = confd.queues(queue['id']).members.agents(agent['id']).put
-    for check in error_checks(url):
-        yield check
+    error_checks(url)
 
 
 def error_checks(url):
-    yield s.check_bogus_field_returns_error, url, 'penalty', -1
-    yield s.check_bogus_field_returns_error, url, 'penalty', None
-    yield s.check_bogus_field_returns_error, url, 'penalty', 'string'
-    yield s.check_bogus_field_returns_error, url, 'penalty', []
-    yield s.check_bogus_field_returns_error, url, 'penalty', {}
-    yield s.check_bogus_field_returns_error, url, 'priority', -1
-    yield s.check_bogus_field_returns_error, url, 'priority', None
-    yield s.check_bogus_field_returns_error, url, 'priority', 'string'
-    yield s.check_bogus_field_returns_error, url, 'priority', []
-    yield s.check_bogus_field_returns_error, url, 'priority', {}
+    s.check_bogus_field_returns_error(url, 'penalty', -1)
+    s.check_bogus_field_returns_error(url, 'penalty', None)
+    s.check_bogus_field_returns_error(url, 'penalty', 'string')
+    s.check_bogus_field_returns_error(url, 'penalty', [])
+    s.check_bogus_field_returns_error(url, 'penalty', {})
+    s.check_bogus_field_returns_error(url, 'priority', -1)
+    s.check_bogus_field_returns_error(url, 'priority', None)
+    s.check_bogus_field_returns_error(url, 'priority', 'string')
+    s.check_bogus_field_returns_error(url, 'priority', [])
+    s.check_bogus_field_returns_error(url, 'priority', {})
 
 
 @fixtures.queue()
@@ -53,8 +52,8 @@ def test_dissociate_errors(queue, agent):
     fake_queue = confd.queues(FAKE_ID).members.agents(agent['id']).delete
     fake_agent = confd.queues(queue['id']).members.agents(FAKE_ID).delete
 
-    yield s.check_resource_not_found, fake_queue, 'Queue'
-    yield s.check_resource_not_found, fake_agent, 'Agent'
+    s.check_resource_not_found(fake_queue, 'Queue')
+    s.check_resource_not_found(fake_agent, 'Agent')
 
 
 @fixtures.queue()
@@ -247,5 +246,5 @@ def test_bus_events(queue, agent):
     url = confd.queues(queue['id']).members.agents(agent['id'])
     headers = {'tenant_uuid': queue['tenant_uuid']}
 
-    yield s.check_event, 'queue_member_agent_associated', headers, url.put
-    yield s.check_event, 'queue_member_agent_dissociated', headers, url.delete
+    s.check_event('queue_member_agent_associated', headers, url.put)
+    s.check_event('queue_member_agent_dissociated', headers, url.delete)

--- a/integration_tests/suite/base/test_queue_member_user.py
+++ b/integration_tests/suite/base/test_queue_member_user.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import re
@@ -19,20 +19,19 @@ def test_associate_errors(queue, user):
     fake_queue = confd.queues(FAKE_ID).members.users(user['id']).put
     fake_user = confd.queues(queue['id']).members.users(FAKE_UUID).put
 
-    yield s.check_resource_not_found, fake_queue, 'Queue'
-    yield s.check_resource_not_found, fake_user, 'User'
+    s.check_resource_not_found(fake_queue, 'Queue')
+    s.check_resource_not_found(fake_user, 'User')
 
     url = confd.queues(queue['id']).members.users(user['id']).put
-    for check in error_checks(url):
-        yield check
+    error_checks(url)
 
 
 def error_checks(url):
-    yield s.check_bogus_field_returns_error, url, 'priority', -1
-    yield s.check_bogus_field_returns_error, url, 'priority', None
-    yield s.check_bogus_field_returns_error, url, 'priority', 'string'
-    yield s.check_bogus_field_returns_error, url, 'priority', []
-    yield s.check_bogus_field_returns_error, url, 'priority', {}
+    s.check_bogus_field_returns_error(url, 'priority', -1)
+    s.check_bogus_field_returns_error(url, 'priority', None)
+    s.check_bogus_field_returns_error(url, 'priority', 'string')
+    s.check_bogus_field_returns_error(url, 'priority', [])
+    s.check_bogus_field_returns_error(url, 'priority', {})
 
 
 @fixtures.queue()
@@ -41,8 +40,8 @@ def test_dissociate_errors(queue, user):
     fake_queue = confd.queues(FAKE_ID).members.users(user['id']).delete
     fake_user = confd.queues(queue['id']).members.users(FAKE_UUID).delete
 
-    yield s.check_resource_not_found, fake_queue, 'Queue'
-    yield s.check_resource_not_found, fake_user, 'User'
+    s.check_resource_not_found(fake_queue, 'Queue')
+    s.check_resource_not_found(fake_user, 'User')
 
 
 @fixtures.queue()
@@ -255,5 +254,5 @@ def test_bus_events(queue, user, line):
         url = confd.queues(queue['id']).members.users(user['uuid'])
         headers = {'tenant_uuid': queue['tenant_uuid']}
 
-        yield s.check_event, 'queue_member_user_associated', headers, url.put
-        yield s.check_event, 'queue_member_user_dissociated', headers, url.delete
+        s.check_event('queue_member_user_associated', headers, url.put)
+        s.check_event('queue_member_user_dissociated', headers, url.delete)

--- a/integration_tests/suite/base/test_queue_schedule.py
+++ b/integration_tests/suite/base/test_queue_schedule.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import assert_that, contains, has_entries
@@ -16,8 +16,8 @@ def test_associate_errors(queue, schedule):
     fake_queue = confd.queues(FAKE_ID).schedules(schedule['id']).put
     fake_schedule = confd.queues(queue['id']).schedules(FAKE_ID).put
 
-    yield s.check_resource_not_found, fake_queue, 'Queue'
-    yield s.check_resource_not_found, fake_schedule, 'Schedule'
+    s.check_resource_not_found(fake_queue, 'Queue')
+    s.check_resource_not_found(fake_schedule, 'Schedule')
 
 
 @fixtures.queue()
@@ -26,8 +26,8 @@ def test_dissociate_errors(queue, schedule):
     fake_queue = confd.queues(FAKE_ID).schedules(schedule['id']).delete
     fake_schedule = confd.queues(queue['id']).schedules(FAKE_ID).delete
 
-    yield s.check_resource_not_found, fake_queue, 'Queue'
-    yield s.check_resource_not_found, fake_schedule, 'Schedule'
+    s.check_resource_not_found(fake_queue, 'Queue')
+    s.check_resource_not_found(fake_schedule, 'Schedule')
 
 
 @fixtures.queue()

--- a/integration_tests/suite/base/test_queues.py
+++ b/integration_tests/suite/base/test_queues.py
@@ -76,168 +76,175 @@ ALL_OPTIONS = [
 
 def test_get_errors():
     fake_queue = confd.queues(999999).get
-    yield s.check_resource_not_found, fake_queue, 'Queue'
+    s.check_resource_not_found(fake_queue, 'Queue')
 
 
 def test_delete_errors():
     fake_queue = confd.queues(999999).delete
-    yield s.check_resource_not_found, fake_queue, 'Queue'
+    s.check_resource_not_found(fake_queue, 'Queue')
 
 
 @fixtures.user()
 def test_post_errors(user):
     url = confd.queues.post
-    for check in error_checks(url, user):
-        yield check
+    error_checks(url, user)
 
-    yield s.check_bogus_field_returns_error, url, 'name', 123
-    yield s.check_bogus_field_returns_error, url, 'name', 'invalid regex'
-    yield s.check_bogus_field_returns_error, url, 'name', 'general'
-    yield s.check_bogus_field_returns_error, url, 'name', True
-    yield s.check_bogus_field_returns_error, url, 'name', None
-    yield s.check_bogus_field_returns_error, url, 'name', s.random_string(129)
-    yield s.check_bogus_field_returns_error, url, 'name', []
-    yield s.check_bogus_field_returns_error, url, 'name', {}
+    s.check_bogus_field_returns_error(url, 'name', 123)
+    s.check_bogus_field_returns_error(url, 'name', 'invalid regex')
+    s.check_bogus_field_returns_error(url, 'name', 'general')
+    s.check_bogus_field_returns_error(url, 'name', True)
+    s.check_bogus_field_returns_error(url, 'name', None)
+    s.check_bogus_field_returns_error(url, 'name', s.random_string(129))
+    s.check_bogus_field_returns_error(url, 'name', [])
+    s.check_bogus_field_returns_error(url, 'name', {})
 
-    for check in unique_error_checks(url):
-        yield check
+    unique_error_checks(url)
 
 
 @fixtures.queue()
 @fixtures.user()
 def test_put_errors(queue, user):
     url = confd.queues(queue['id']).put
-    for check in error_checks(url, user):
-        yield check
+    error_checks(url, user)
 
 
 def error_checks(url, user):
-    yield s.check_bogus_field_returns_error, url, 'label', 123
-    yield s.check_bogus_field_returns_error, url, 'label', True
-    yield s.check_bogus_field_returns_error, url, 'label', s.random_string(129)
-    yield s.check_bogus_field_returns_error, url, 'label', []
-    yield s.check_bogus_field_returns_error, url, 'label', {}
-    yield s.check_bogus_field_returns_error, url, 'data_quality', 'yeah'
-    yield s.check_bogus_field_returns_error, url, 'data_quality', 123
-    yield s.check_bogus_field_returns_error, url, 'data_quality', {}
-    yield s.check_bogus_field_returns_error, url, 'data_quality', []
-    yield s.check_bogus_field_returns_error, url, 'dtmf_hangup_callee_enabled', 'yeah'
-    yield s.check_bogus_field_returns_error, url, 'dtmf_hangup_callee_enabled', 123
-    yield s.check_bogus_field_returns_error, url, 'dtmf_hangup_callee_enabled', {}
-    yield s.check_bogus_field_returns_error, url, 'dtmf_hangup_callee_enabled', []
-    yield s.check_bogus_field_returns_error, url, 'dtmf_hangup_caller_enabled', 'yeah'
-    yield s.check_bogus_field_returns_error, url, 'dtmf_hangup_caller_enabled', 123
-    yield s.check_bogus_field_returns_error, url, 'dtmf_hangup_caller_enabled', {}
-    yield s.check_bogus_field_returns_error, url, 'dtmf_hangup_caller_enabled', []
-    yield s.check_bogus_field_returns_error, url, 'dtmf_transfer_callee_enabled', 'yeah'
-    yield s.check_bogus_field_returns_error, url, 'dtmf_transfer_callee_enabled', 123
-    yield s.check_bogus_field_returns_error, url, 'dtmf_transfer_callee_enabled', {}
-    yield s.check_bogus_field_returns_error, url, 'dtmf_transfer_callee_enabled', []
-    yield s.check_bogus_field_returns_error, url, 'dtmf_transfer_caller_enabled', 'yeah'
-    yield s.check_bogus_field_returns_error, url, 'dtmf_transfer_caller_enabled', 123
-    yield s.check_bogus_field_returns_error, url, 'dtmf_transfer_caller_enabled', {}
-    yield s.check_bogus_field_returns_error, url, 'dtmf_transfer_caller_enabled', []
-    yield s.check_bogus_field_returns_error, url, 'dtmf_record_callee_enabled', 'yeah'
-    yield s.check_bogus_field_returns_error, url, 'dtmf_record_callee_enabled', 123
-    yield s.check_bogus_field_returns_error, url, 'dtmf_record_callee_enabled', {}
-    yield s.check_bogus_field_returns_error, url, 'dtmf_record_callee_enabled', []
-    yield s.check_bogus_field_returns_error, url, 'dtmf_record_caller_enabled', 'yeah'
-    yield s.check_bogus_field_returns_error, url, 'dtmf_record_caller_enabled', 123
-    yield s.check_bogus_field_returns_error, url, 'dtmf_record_caller_enabled', {}
-    yield s.check_bogus_field_returns_error, url, 'dtmf_record_caller_enabled', []
-    yield s.check_bogus_field_returns_error, url, 'retry_on_timeout', 'yeah'
-    yield s.check_bogus_field_returns_error, url, 'retry_on_timeout', 123
-    yield s.check_bogus_field_returns_error, url, 'retry_on_timeout', {}
-    yield s.check_bogus_field_returns_error, url, 'retry_on_timeout', []
-    yield s.check_bogus_field_returns_error, url, 'ring_on_hold', 'yeah'
-    yield s.check_bogus_field_returns_error, url, 'ring_on_hold', 123
-    yield s.check_bogus_field_returns_error, url, 'ring_on_hold', {}
-    yield s.check_bogus_field_returns_error, url, 'ring_on_hold', []
-    yield s.check_bogus_field_returns_error, url, 'announce_hold_time_on_entry', 'yeah'
-    yield s.check_bogus_field_returns_error, url, 'announce_hold_time_on_entry', 123
-    yield s.check_bogus_field_returns_error, url, 'announce_hold_time_on_entry', {}
-    yield s.check_bogus_field_returns_error, url, 'announce_hold_time_on_entry', []
-    yield s.check_bogus_field_returns_error, url, 'ignore_forward', 'yeah'
-    yield s.check_bogus_field_returns_error, url, 'ignore_forward', 123
-    yield s.check_bogus_field_returns_error, url, 'ignore_forward', {}
-    yield s.check_bogus_field_returns_error, url, 'ignore_forward', []
-    yield s.check_bogus_field_returns_error, url, 'mark_answered_elsewhere', 'yeah'
-    yield s.check_bogus_field_returns_error, url, 'mark_answered_elsewhere', 123
-    yield s.check_bogus_field_returns_error, url, 'mark_answered_elsewhere', {}
-    yield s.check_bogus_field_returns_error, url, 'mark_answered_elsewhere', []
-    yield s.check_bogus_field_returns_error, url, 'preprocess_subroutine', 123
-    yield s.check_bogus_field_returns_error, url, 'preprocess_subroutine', s.random_string(
-        80
+    s.check_bogus_field_returns_error(url, 'label', 123)
+    s.check_bogus_field_returns_error(url, 'label', True)
+    s.check_bogus_field_returns_error(url, 'label', s.random_string(129))
+    s.check_bogus_field_returns_error(url, 'label', [])
+    s.check_bogus_field_returns_error(url, 'label', {})
+    s.check_bogus_field_returns_error(url, 'data_quality', 'yeah')
+    s.check_bogus_field_returns_error(url, 'data_quality', 123)
+    s.check_bogus_field_returns_error(url, 'data_quality', {})
+    s.check_bogus_field_returns_error(url, 'data_quality', [])
+    s.check_bogus_field_returns_error(url, 'dtmf_hangup_callee_enabled', 'yeah')
+    s.check_bogus_field_returns_error(url, 'dtmf_hangup_callee_enabled', 123)
+    s.check_bogus_field_returns_error(url, 'dtmf_hangup_callee_enabled', {})
+    s.check_bogus_field_returns_error(url, 'dtmf_hangup_callee_enabled', [])
+    s.check_bogus_field_returns_error(url, 'dtmf_hangup_caller_enabled', 'yeah')
+    s.check_bogus_field_returns_error(url, 'dtmf_hangup_caller_enabled', 123)
+    s.check_bogus_field_returns_error(url, 'dtmf_hangup_caller_enabled', {})
+    s.check_bogus_field_returns_error(url, 'dtmf_hangup_caller_enabled', [])
+    s.check_bogus_field_returns_error(url, 'dtmf_transfer_callee_enabled', 'yeah')
+    s.check_bogus_field_returns_error(url, 'dtmf_transfer_callee_enabled', 123)
+    s.check_bogus_field_returns_error(url, 'dtmf_transfer_callee_enabled', {})
+    s.check_bogus_field_returns_error(url, 'dtmf_transfer_callee_enabled', [])
+    s.check_bogus_field_returns_error(url, 'dtmf_transfer_caller_enabled', 'yeah')
+    s.check_bogus_field_returns_error(url, 'dtmf_transfer_caller_enabled', 123)
+    s.check_bogus_field_returns_error(url, 'dtmf_transfer_caller_enabled', {})
+    s.check_bogus_field_returns_error(url, 'dtmf_transfer_caller_enabled', [])
+    s.check_bogus_field_returns_error(url, 'dtmf_record_callee_enabled', 'yeah')
+    s.check_bogus_field_returns_error(url, 'dtmf_record_callee_enabled', 123)
+    s.check_bogus_field_returns_error(url, 'dtmf_record_callee_enabled', {})
+    s.check_bogus_field_returns_error(url, 'dtmf_record_callee_enabled', [])
+    s.check_bogus_field_returns_error(url, 'dtmf_record_caller_enabled', 'yeah')
+    s.check_bogus_field_returns_error(url, 'dtmf_record_caller_enabled', 123)
+    s.check_bogus_field_returns_error(url, 'dtmf_record_caller_enabled', {})
+    s.check_bogus_field_returns_error(url, 'dtmf_record_caller_enabled', [])
+    s.check_bogus_field_returns_error(url, 'retry_on_timeout', 'yeah')
+    s.check_bogus_field_returns_error(url, 'retry_on_timeout', 123)
+    s.check_bogus_field_returns_error(url, 'retry_on_timeout', {})
+    s.check_bogus_field_returns_error(url, 'retry_on_timeout', [])
+    s.check_bogus_field_returns_error(url, 'ring_on_hold', 'yeah')
+    s.check_bogus_field_returns_error(url, 'ring_on_hold', 123)
+    s.check_bogus_field_returns_error(url, 'ring_on_hold', {})
+    s.check_bogus_field_returns_error(url, 'ring_on_hold', [])
+    s.check_bogus_field_returns_error(url, 'announce_hold_time_on_entry', 'yeah')
+    s.check_bogus_field_returns_error(url, 'announce_hold_time_on_entry', 123)
+    s.check_bogus_field_returns_error(url, 'announce_hold_time_on_entry', {})
+    s.check_bogus_field_returns_error(url, 'announce_hold_time_on_entry', [])
+    s.check_bogus_field_returns_error(url, 'ignore_forward', 'yeah')
+    s.check_bogus_field_returns_error(url, 'ignore_forward', 123)
+    s.check_bogus_field_returns_error(url, 'ignore_forward', {})
+    s.check_bogus_field_returns_error(url, 'ignore_forward', [])
+    s.check_bogus_field_returns_error(url, 'mark_answered_elsewhere', 'yeah')
+    s.check_bogus_field_returns_error(url, 'mark_answered_elsewhere', 123)
+    s.check_bogus_field_returns_error(url, 'mark_answered_elsewhere', {})
+    s.check_bogus_field_returns_error(url, 'mark_answered_elsewhere', [])
+    s.check_bogus_field_returns_error(url, 'preprocess_subroutine', 123)
+    s.check_bogus_field_returns_error(url, 'preprocess_subroutine', s.random_string(80))
+    s.check_bogus_field_returns_error(url, 'preprocess_subroutine', [])
+    s.check_bogus_field_returns_error(url, 'preprocess_subroutine', {})
+    s.check_bogus_field_returns_error(url, 'caller_id_mode', True)
+    s.check_bogus_field_returns_error(url, 'caller_id_mode', 'invalid')
+    s.check_bogus_field_returns_error(url, 'caller_id_mode', 1234)
+    s.check_bogus_field_returns_error(url, 'caller_id_mode', [])
+    s.check_bogus_field_returns_error(url, 'caller_id_mode', {})
+    s.check_bogus_field_returns_error(url, 'caller_id_name', 1234)
+    s.check_bogus_field_returns_error(url, 'caller_id_name', True)
+    s.check_bogus_field_returns_error(url, 'caller_id_name', s.random_string(81))
+    s.check_bogus_field_returns_error(url, 'caller_id_name', [])
+    s.check_bogus_field_returns_error(url, 'caller_id_name', {})
+    s.check_bogus_field_returns_error(url, 'music_on_hold', 123)
+    s.check_bogus_field_returns_error(url, 'music_on_hold', s.random_string(129))
+    s.check_bogus_field_returns_error(url, 'music_on_hold', [])
+    s.check_bogus_field_returns_error(url, 'music_on_hold', {})
+    s.check_bogus_field_returns_error(url, 'timeout', 'ten')
+    s.check_bogus_field_returns_error(url, 'timeout', -1)
+    s.check_bogus_field_returns_error(url, 'timeout', {})
+    s.check_bogus_field_returns_error(url, 'timeout', [])
+    s.check_bogus_field_returns_error(url, 'wait_time_threshold', 'ten')
+    s.check_bogus_field_returns_error(url, 'wait_time_threshold', -1)
+    s.check_bogus_field_returns_error(url, 'wait_time_threshold', {})
+    s.check_bogus_field_returns_error(url, 'wait_time_threshold', [])
+    s.check_bogus_field_returns_error(url, 'wait_ratio_threshold', 'ten')
+    s.check_bogus_field_returns_error(url, 'wait_ratio_threshold', -1)
+    s.check_bogus_field_returns_error(url, 'wait_ratio_threshold', {})
+    s.check_bogus_field_returns_error(url, 'wait_ratio_threshold', [])
+    s.check_bogus_field_returns_error(url, 'options', 123)
+    s.check_bogus_field_returns_error(url, 'options', None)
+    s.check_bogus_field_returns_error(url, 'options', {})
+    s.check_bogus_field_returns_error(url, 'options', 'string')
+    s.check_bogus_field_returns_error(url, 'options', [None])
+    s.check_bogus_field_returns_error(url, 'options', ['string', 'string'])
+    s.check_bogus_field_returns_error(url, 'options', [123, 123])
+    s.check_bogus_field_returns_error(url, 'options', ['string', 123])
+    s.check_bogus_field_returns_error(url, 'options', [[]])
+    s.check_bogus_field_returns_error(url, 'options', [{'key': 'value'}])
+    s.check_bogus_field_returns_error(url, 'options', [['missing_value']])
+    s.check_bogus_field_returns_error(url, 'options', [['too', 'much', 'value']])
+    s.check_bogus_field_returns_error(url, 'options', [['wrong_value', 1234]])
+    s.check_bogus_field_returns_error(url, 'options', [['none_value', None]])
+    s.check_bogus_field_returns_error(url, 'enabled', 'yeah')
+    s.check_bogus_field_returns_error(url, 'enabled', 123)
+    s.check_bogus_field_returns_error(url, 'enabled', {})
+    s.check_bogus_field_returns_error(url, 'enabled', [])
+
+    for destination in invalid_destinations():
+        s.check_bogus_field_returns_error(url, 'wait_time_destination', destination)
+    s.check_bogus_field_returns_error(
+        url,
+        'wait_time_destination',
+        {
+            'type': 'user',
+            'user_id': user['id'],
+            'moh_uuid': '00000000-0000-0000-0000-000000000000',
+        },
+        {'name': 'foo'},
+        'MOH was not found',
     )
-    yield s.check_bogus_field_returns_error, url, 'preprocess_subroutine', []
-    yield s.check_bogus_field_returns_error, url, 'preprocess_subroutine', {}
-    yield s.check_bogus_field_returns_error, url, 'caller_id_mode', True
-    yield s.check_bogus_field_returns_error, url, 'caller_id_mode', 'invalid'
-    yield s.check_bogus_field_returns_error, url, 'caller_id_mode', 1234
-    yield s.check_bogus_field_returns_error, url, 'caller_id_mode', []
-    yield s.check_bogus_field_returns_error, url, 'caller_id_mode', {}
-    yield s.check_bogus_field_returns_error, url, 'caller_id_name', 1234
-    yield s.check_bogus_field_returns_error, url, 'caller_id_name', True
-    yield s.check_bogus_field_returns_error, url, 'caller_id_name', s.random_string(81)
-    yield s.check_bogus_field_returns_error, url, 'caller_id_name', []
-    yield s.check_bogus_field_returns_error, url, 'caller_id_name', {}
-    yield s.check_bogus_field_returns_error, url, 'music_on_hold', 123
-    yield s.check_bogus_field_returns_error, url, 'music_on_hold', s.random_string(129)
-    yield s.check_bogus_field_returns_error, url, 'music_on_hold', []
-    yield s.check_bogus_field_returns_error, url, 'music_on_hold', {}
-    yield s.check_bogus_field_returns_error, url, 'timeout', 'ten'
-    yield s.check_bogus_field_returns_error, url, 'timeout', -1
-    yield s.check_bogus_field_returns_error, url, 'timeout', {}
-    yield s.check_bogus_field_returns_error, url, 'timeout', []
-    yield s.check_bogus_field_returns_error, url, 'wait_time_threshold', 'ten'
-    yield s.check_bogus_field_returns_error, url, 'wait_time_threshold', -1
-    yield s.check_bogus_field_returns_error, url, 'wait_time_threshold', {}
-    yield s.check_bogus_field_returns_error, url, 'wait_time_threshold', []
-    yield s.check_bogus_field_returns_error, url, 'wait_ratio_threshold', 'ten'
-    yield s.check_bogus_field_returns_error, url, 'wait_ratio_threshold', -1
-    yield s.check_bogus_field_returns_error, url, 'wait_ratio_threshold', {}
-    yield s.check_bogus_field_returns_error, url, 'wait_ratio_threshold', []
-    yield s.check_bogus_field_returns_error, url, 'options', 123
-    yield s.check_bogus_field_returns_error, url, 'options', None
-    yield s.check_bogus_field_returns_error, url, 'options', {}
-    yield s.check_bogus_field_returns_error, url, 'options', 'string'
-    yield s.check_bogus_field_returns_error, url, 'options', [None]
-    yield s.check_bogus_field_returns_error, url, 'options', ['string', 'string']
-    yield s.check_bogus_field_returns_error, url, 'options', [123, 123]
-    yield s.check_bogus_field_returns_error, url, 'options', ['string', 123]
-    yield s.check_bogus_field_returns_error, url, 'options', [[]]
-    yield s.check_bogus_field_returns_error, url, 'options', [{'key': 'value'}]
-    yield s.check_bogus_field_returns_error, url, 'options', [['missing_value']]
-    yield s.check_bogus_field_returns_error, url, 'options', [['too', 'much', 'value']]
-    yield s.check_bogus_field_returns_error, url, 'options', [['wrong_value', 1234]]
-    yield s.check_bogus_field_returns_error, url, 'options', [['none_value', None]]
-    yield s.check_bogus_field_returns_error, url, 'enabled', 'yeah'
-    yield s.check_bogus_field_returns_error, url, 'enabled', 123
-    yield s.check_bogus_field_returns_error, url, 'enabled', {}
-    yield s.check_bogus_field_returns_error, url, 'enabled', []
 
     for destination in invalid_destinations():
-        yield s.check_bogus_field_returns_error, url, 'wait_time_destination', destination
-    yield s.check_bogus_field_returns_error, url, 'wait_time_destination', {
-        'type': 'user',
-        'user_id': user['id'],
-        'moh_uuid': '00000000-0000-0000-0000-000000000000',
-    }, {'name': 'foo'}, 'MOH was not found'
-
-    for destination in invalid_destinations():
-        yield s.check_bogus_field_returns_error, url, 'wait_ratio_destination', destination
-    yield s.check_bogus_field_returns_error, url, 'wait_ratio_destination', {
-        'type': 'user',
-        'user_id': user['id'],
-        'moh_uuid': '00000000-0000-0000-0000-000000000000',
-    }, {'name': 'foo'}, 'MOH was not found'
+        s.check_bogus_field_returns_error(url, 'wait_ratio_destination', destination)
+    s.check_bogus_field_returns_error(
+        url,
+        'wait_ratio_destination',
+        {
+            'type': 'user',
+            'user_id': user['id'],
+            'moh_uuid': '00000000-0000-0000-0000-000000000000',
+        },
+        {'name': 'foo'},
+        'MOH was not found',
+    )
 
 
 @fixtures.queue(name='unique')
 @fixtures.group(name='queue_name')
 def unique_error_checks(url, queue, group):
-    yield s.check_bogus_field_returns_error, url, 'name', queue['name']
-    yield s.check_bogus_field_returns_error, url, 'name', group['name']
+    s.check_bogus_field_returns_error(url, 'name', queue['name'])
+    s.check_bogus_field_returns_error(url, 'name', group['name'])
 
 
 @fixtures.extension(exten=gen_queue_exten())
@@ -248,12 +255,12 @@ def test_search(extension, hidden, queue):
     searches = {'name': 'search', 'label': 'search', 'preprocess_subroutine': 'search'}
 
     for field, term in searches.items():
-        yield check_search, url, queue, hidden, field, term
+        check_search(url, queue, hidden, field, term)
 
     searches = {'exten': extension['exten']}
     with a.queue_extension(queue, extension):
         for field, term in searches.items():
-            yield check_relation_search, url, queue, hidden, field, term
+            check_relation_search(url, queue, hidden, field, term)
 
 
 def check_search(url, queue, hidden, field, term):
@@ -308,11 +315,11 @@ def test_list_multi_tenant(main, sub):
 @fixtures.queue(name='sort2', preprocess_subroutine='sort2')
 def test_sorting_offset_limit(queue1, queue2):
     url = confd.queues.get
-    yield s.check_sorting, url, queue1, queue2, 'name', 'sort'
-    yield s.check_sorting, url, queue1, queue2, 'preprocess_subroutine', 'sort'
+    s.check_sorting(url, queue1, queue2, 'name', 'sort')
+    s.check_sorting(url, queue1, queue2, 'preprocess_subroutine', 'sort')
 
-    yield s.check_offset, url, queue1, queue2, 'name', 'sort'
-    yield s.check_limit, url, queue1, queue2, 'name', 'sort'
+    s.check_offset(url, queue1, queue2, 'name', 'sort')
+    s.check_limit(url, queue1, queue2, 'name', 'sort')
 
 
 @fixtures.queue()
@@ -418,6 +425,8 @@ def test_create_multi_tenant():
 
     assert_that(response.item, has_entries(tenant_uuid=SUB_TENANT))
 
+    confd.queues(response.item['id']).delete().assert_deleted()
+
 
 @fixtures.moh(wazo_tenant=MAIN_TENANT)
 @fixtures.moh(wazo_tenant=SUB_TENANT)
@@ -457,8 +466,8 @@ def test_create_multi_tenant_moh(main_moh, sub_moh):
 @fixtures.moh()
 def test_valid_destinations(queue, *destinations):
     for destination in valid_destinations(*destinations):
-        yield create_queue_with_destination, destination
-        yield update_queue_with_destination, queue['id'], destination
+        create_queue_with_destination(destination)
+        update_queue_with_destination(queue['id'], destination)
 
 
 def create_queue_with_destination(destination):
@@ -587,8 +596,8 @@ def test_bus_events(queue):
     url = confd.queues(queue['id'])
     headers = {'tenant_uuid': queue['tenant_uuid']}
 
-    yield s.check_event, 'queue_created', headers, confd.queues.post, {
-        'name': 'queue_bus_event'
-    }
-    yield s.check_event, 'queue_edited', headers, url.put
-    yield s.check_event, 'queue_deleted', headers, url.delete
+    s.check_event(
+        'queue_created', headers, confd.queues.post, {'name': 'queue_bus_event'}
+    )
+    s.check_event('queue_edited', headers, url.put)
+    s.check_event('queue_deleted', headers, url.delete)

--- a/integration_tests/suite/base/test_queues_general.py
+++ b/integration_tests/suite/base/test_queues_general.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import assert_that, has_entries
@@ -10,17 +10,16 @@ from ..helpers.config import TOKEN_SUB_TENANT
 
 def test_put_errors():
     url = confd.asterisk.queues.general.put
-    for check in error_checks(url):
-        yield check
+    error_checks(url)
 
 
 def error_checks(url):
-    yield s.check_bogus_field_returns_error, url, 'options', 123
-    yield s.check_bogus_field_returns_error, url, 'options', None
-    yield s.check_bogus_field_returns_error, url, 'options', 'string'
-    yield s.check_bogus_field_returns_error, url, 'options', [['ordered', 'option']]
-    yield s.check_bogus_field_returns_error, url, 'options', {'wrong_value': 23}
-    yield s.check_bogus_field_returns_error, url, 'options', {'none_value': None}
+    s.check_bogus_field_returns_error(url, 'options', 123)
+    s.check_bogus_field_returns_error(url, 'options', None)
+    s.check_bogus_field_returns_error(url, 'options', 'string')
+    s.check_bogus_field_returns_error(url, 'options', [['ordered', 'option']])
+    s.check_bogus_field_returns_error(url, 'options', {'wrong_value': 23})
+    s.check_bogus_field_returns_error(url, 'options', {'none_value': None})
 
 
 def test_get():
@@ -69,4 +68,4 @@ def test_bus_event_when_edited():
     url = confd.asterisk.queues.general
     headers = {}
 
-    yield s.check_event, 'queue_general_edited', headers, url.put, {'options': {}}
+    s.check_event('queue_general_edited', headers, url.put, {'options': {}})

--- a/integration_tests/suite/base/test_registers_iax.py
+++ b/integration_tests/suite/base/test_registers_iax.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import assert_that, empty, has_entries, none, not_
@@ -10,67 +10,65 @@ from ..helpers import scenarios as s
 
 def test_get_errors():
     fake_register_iax = confd.registers.iax(999999).get
-    yield s.check_resource_not_found, fake_register_iax, 'IAXRegister'
+    s.check_resource_not_found(fake_register_iax, 'IAXRegister')
 
 
 def test_delete_errors():
     fake_register_iax = confd.registers.iax(999999).delete
-    yield s.check_resource_not_found, fake_register_iax, 'IAXRegister'
+    s.check_resource_not_found(fake_register_iax, 'IAXRegister')
 
 
 def test_post_errors():
     url = confd.registers.iax.post
-    for check in error_checks(url):
-        yield check
+    error_checks(url)
 
 
 @fixtures.register_iax()
 def test_put_errors(register_iax):
     url = confd.registers.iax(register_iax['id']).put
-    for check in error_checks(url):
-        yield check
+    error_checks(url)
 
 
 def error_checks(url):
-    yield s.check_bogus_field_returns_error, url, 'auth_username', ':'
-    yield s.check_bogus_field_returns_error, url, 'auth_username', '/'
-    yield s.check_bogus_field_returns_error, url, 'auth_username', 'value with space'
-    yield s.check_bogus_field_returns_error, url, 'auth_username', 123
-    yield s.check_bogus_field_returns_error, url, 'auth_username', True
-    yield s.check_bogus_field_returns_error, url, 'auth_username', []
-    yield s.check_bogus_field_returns_error, url, 'auth_username', {}
-    yield s.check_bogus_field_returns_error, url, 'auth_password', ':'
-    yield s.check_bogus_field_returns_error, url, 'auth_password', '/'
-    yield s.check_bogus_field_returns_error, url, 'auth_password', 'value with space'
-    yield s.check_bogus_field_returns_error, url, 'auth_password', 123
-    yield s.check_bogus_field_returns_error, url, 'auth_password', True
-    yield s.check_bogus_field_returns_error, url, 'auth_password', []
-    yield s.check_bogus_field_returns_error, url, 'auth_password', {}
-    yield s.check_bogus_field_returns_error, url, 'remote_host', ':'
-    yield s.check_bogus_field_returns_error, url, 'remote_host', '/'
-    yield s.check_bogus_field_returns_error, url, 'remote_host', '?'
-    yield s.check_bogus_field_returns_error, url, 'remote_host', 'value with space'
-    yield s.check_bogus_field_returns_error, url, 'remote_host', 123
-    yield s.check_bogus_field_returns_error, url, 'remote_host', True
-    yield s.check_bogus_field_returns_error, url, 'remote_host', []
-    yield s.check_bogus_field_returns_error, url, 'remote_host', {}
-    yield s.check_bogus_field_returns_error, url, 'remote_port', 'invalid'
-    yield s.check_bogus_field_returns_error, url, 'remote_port', []
-    yield s.check_bogus_field_returns_error, url, 'remote_port', {}
-    yield s.check_bogus_field_returns_error, url, 'callback_extension', '?'
-    yield s.check_bogus_field_returns_error, url, 'callback_extension', 'value with space'
-    yield s.check_bogus_field_returns_error, url, 'callback_extension', 123
-    yield s.check_bogus_field_returns_error, url, 'callback_extension', True
-    yield s.check_bogus_field_returns_error, url, 'callback_extension', []
-    yield s.check_bogus_field_returns_error, url, 'callback_extension', {}
-    yield s.check_bogus_field_returns_error, url, 'callback_context', 123
-    yield s.check_bogus_field_returns_error, url, 'callback_context', True
-    yield s.check_bogus_field_returns_error, url, 'callback_context', []
-    yield s.check_bogus_field_returns_error, url, 'callback_context', {}
-    yield s.check_bogus_field_returns_error, url, 'enabled', 'string'
-    yield s.check_bogus_field_returns_error, url, 'enabled', 123
-    yield s.check_bogus_field_returns_error, url, 'enabled', {}
-    yield s.check_bogus_field_returns_error, url, 'enabled', []
+    s.check_bogus_field_returns_error(url, 'auth_username', ':')
+    s.check_bogus_field_returns_error(url, 'auth_username', '/')
+    s.check_bogus_field_returns_error(url, 'auth_username', 'value with space')
+    s.check_bogus_field_returns_error(url, 'auth_username', 123)
+    s.check_bogus_field_returns_error(url, 'auth_username', True)
+    s.check_bogus_field_returns_error(url, 'auth_username', [])
+    s.check_bogus_field_returns_error(url, 'auth_username', {})
+    s.check_bogus_field_returns_error(url, 'auth_password', ':')
+    s.check_bogus_field_returns_error(url, 'auth_password', '/')
+    s.check_bogus_field_returns_error(url, 'auth_password', 'value with space')
+    s.check_bogus_field_returns_error(url, 'auth_password', 123)
+    s.check_bogus_field_returns_error(url, 'auth_password', True)
+    s.check_bogus_field_returns_error(url, 'auth_password', [])
+    s.check_bogus_field_returns_error(url, 'auth_password', {})
+    s.check_bogus_field_returns_error(url, 'remote_host', ':')
+    s.check_bogus_field_returns_error(url, 'remote_host', '/')
+    s.check_bogus_field_returns_error(url, 'remote_host', '?')
+    s.check_bogus_field_returns_error(url, 'remote_host', 'value with space')
+    s.check_bogus_field_returns_error(url, 'remote_host', 123)
+    s.check_bogus_field_returns_error(url, 'remote_host', True)
+    s.check_bogus_field_returns_error(url, 'remote_host', [])
+    s.check_bogus_field_returns_error(url, 'remote_host', {})
+    s.check_bogus_field_returns_error(url, 'remote_port', 'invalid')
+    s.check_bogus_field_returns_error(url, 'remote_port', [])
+    s.check_bogus_field_returns_error(url, 'remote_port', {})
+    s.check_bogus_field_returns_error(url, 'callback_extension', '?')
+    s.check_bogus_field_returns_error(url, 'callback_extension', 'value with space')
+    s.check_bogus_field_returns_error(url, 'callback_extension', 123)
+    s.check_bogus_field_returns_error(url, 'callback_extension', True)
+    s.check_bogus_field_returns_error(url, 'callback_extension', [])
+    s.check_bogus_field_returns_error(url, 'callback_extension', {})
+    s.check_bogus_field_returns_error(url, 'callback_context', 123)
+    s.check_bogus_field_returns_error(url, 'callback_context', True)
+    s.check_bogus_field_returns_error(url, 'callback_context', [])
+    s.check_bogus_field_returns_error(url, 'callback_context', {})
+    s.check_bogus_field_returns_error(url, 'enabled', 'string')
+    s.check_bogus_field_returns_error(url, 'enabled', 123)
+    s.check_bogus_field_returns_error(url, 'enabled', {})
+    s.check_bogus_field_returns_error(url, 'enabled', [])
 
 
 @fixtures.register_iax()
@@ -153,8 +151,11 @@ def test_bus_events(register_iax):
     url = confd.registers.iax(register_iax['id'])
     headers = {}
 
-    yield s.check_event, 'register_iax_created', headers, confd.registers.iax.post, {
-        'remote_host': 'bus-event'
-    }
-    yield s.check_event, 'register_iax_edited', headers, url.put
-    yield s.check_event, 'register_iax_deleted', headers, url.delete
+    s.check_event(
+        'register_iax_created',
+        headers,
+        confd.registers.iax.post,
+        {'remote_host': 'bus-event'},
+    )
+    s.check_event('register_iax_edited', headers, url.put)
+    s.check_event('register_iax_deleted', headers, url.delete)

--- a/integration_tests/suite/base/test_registrars.py
+++ b/integration_tests/suite/base/test_registrars.py
@@ -35,43 +35,40 @@ def line_device(endpoint_type='sip', registrar=None):
 
 def test_search_errors():
     url = confd.registrars.get
-    for check in s.search_error_checks(url):
-        yield check
+    s.search_error_checks(url)
 
 
 def test_get_errors():
     fake_get = confd.registrars(999999).get
-    yield s.check_resource_not_found, fake_get, 'Registrar'
+    s.check_resource_not_found(fake_get, 'Registrar')
 
 
 def test_post_errors():
     url = confd.registrars.post
-    for check in error_checks(url):
-        yield check
+    error_checks(url)
 
 
 @fixtures.registrar()
 def test_put_errors(registrar):
     url = confd.registrars(registrar['id']).put
-    for check in error_checks(url):
-        yield check
+    error_checks(url)
 
 
 def error_checks(url):
-    yield s.check_bogus_field_returns_error, url, 'main_host', None
-    yield s.check_bogus_field_returns_error, url, 'deletable', 123
-    yield s.check_bogus_field_returns_error, url, 'deletable', 'wrong'
-    yield s.check_bogus_field_returns_error, url, 'main_host', 123
-    yield s.check_bogus_field_returns_error, url, 'main_port', 'wrong'
-    yield s.check_bogus_field_returns_error, url, 'backup_host', 123
-    yield s.check_bogus_field_returns_error, url, 'backup_port', 'wrong'
-    yield s.check_bogus_field_returns_error, url, 'proxy_main_host', None
-    yield s.check_bogus_field_returns_error, url, 'proxy_main_host', 123
-    yield s.check_bogus_field_returns_error, url, 'proxy_main_port', 'wrong'
-    yield s.check_bogus_field_returns_error, url, 'proxy_backup_host', 123
-    yield s.check_bogus_field_returns_error, url, 'proxy_backup_port', 'wrong'
-    yield s.check_bogus_field_returns_error, url, 'outbound_proxy_host', 123
-    yield s.check_bogus_field_returns_error, url, 'outbound_proxy_port', 'wrong'
+    s.check_bogus_field_returns_error(url, 'main_host', None)
+    s.check_bogus_field_returns_error(url, 'deletable', 123)
+    s.check_bogus_field_returns_error(url, 'deletable', 'wrong')
+    s.check_bogus_field_returns_error(url, 'main_host', 123)
+    s.check_bogus_field_returns_error(url, 'main_port', 'wrong')
+    s.check_bogus_field_returns_error(url, 'backup_host', 123)
+    s.check_bogus_field_returns_error(url, 'backup_port', 'wrong')
+    s.check_bogus_field_returns_error(url, 'proxy_main_host', None)
+    s.check_bogus_field_returns_error(url, 'proxy_main_host', 123)
+    s.check_bogus_field_returns_error(url, 'proxy_main_port', 'wrong')
+    s.check_bogus_field_returns_error(url, 'proxy_backup_host', 123)
+    s.check_bogus_field_returns_error(url, 'proxy_backup_port', 'wrong')
+    s.check_bogus_field_returns_error(url, 'outbound_proxy_host', 123)
+    s.check_bogus_field_returns_error(url, 'outbound_proxy_port', 'wrong')
 
 
 @fixtures.registrar(
@@ -96,7 +93,7 @@ def test_search(registrar, hidden):
     }
 
     for field, term in searches.items():
-        yield check_search, url, registrar, hidden, field, term
+        check_search(url, registrar, hidden, field, term)
 
 
 def check_search(url, registrar, hidden, field, term):
@@ -117,12 +114,12 @@ def check_search(url, registrar, hidden, field, term):
 )
 def test_sorting_offset_limit(registrar1, registrar2):
     url = confd.registrars.get
-    yield s.check_sorting, url, registrar1, registrar2, 'proxy_main_host', '99.20.30.'
-    yield s.check_sorting, url, registrar1, registrar2, 'name', 'SortRegistrar'
-    yield s.check_sorting, url, registrar1, registrar2, 'main_port', 'SortRegistrar'
+    s.check_sorting(url, registrar1, registrar2, 'proxy_main_host', '99.20.30.')
+    s.check_sorting(url, registrar1, registrar2, 'name', 'SortRegistrar')
+    s.check_sorting(url, registrar1, registrar2, 'main_port', 'SortRegistrar')
 
-    yield s.check_offset, url, registrar1, registrar2, 'name', 'Sort'
-    yield s.check_limit, url, registrar1, registrar2, 'name', 'Sort'
+    s.check_offset(url, registrar1, registrar2, 'name', 'Sort')
+    s.check_limit(url, registrar1, registrar2, 'name', 'Sort')
 
 
 @fixtures.registrar()
@@ -489,6 +486,6 @@ def test_bus_events(registrar):
     body = {'name': 'a', 'main_host': '1.2.3.4', 'proxy_main_host': '1.2.3.4'}
     headers = {}
 
-    yield s.check_event, 'registrar_created', headers, confd.registrars.post, body
-    yield s.check_event, 'registrar_edited', headers, url.put
-    yield s.check_event, 'registrar_deleted', headers, url.delete
+    s.check_event('registrar_created', headers, confd.registrars.post, body)
+    s.check_event('registrar_edited', headers, url.put)
+    s.check_event('registrar_deleted', headers, url.delete)

--- a/integration_tests/suite/base/test_rtp_general.py
+++ b/integration_tests/suite/base/test_rtp_general.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import assert_that, has_entries
@@ -10,17 +10,16 @@ from ..helpers.config import TOKEN_SUB_TENANT
 
 def test_put_errors():
     url = confd.asterisk.rtp.general.put
-    for check in error_checks(url):
-        yield check
+    error_checks(url)
 
 
 def error_checks(url):
-    yield s.check_bogus_field_returns_error, url, 'options', 123
-    yield s.check_bogus_field_returns_error, url, 'options', None
-    yield s.check_bogus_field_returns_error, url, 'options', 'string'
-    yield s.check_bogus_field_returns_error, url, 'options', [['ordered', 'option']]
-    yield s.check_bogus_field_returns_error, url, 'options', {'wrong_value': 23}
-    yield s.check_bogus_field_returns_error, url, 'options', {'none_value': None}
+    s.check_bogus_field_returns_error(url, 'options', 123)
+    s.check_bogus_field_returns_error(url, 'options', None)
+    s.check_bogus_field_returns_error(url, 'options', 'string')
+    s.check_bogus_field_returns_error(url, 'options', [['ordered', 'option']])
+    s.check_bogus_field_returns_error(url, 'options', {'wrong_value': 23})
+    s.check_bogus_field_returns_error(url, 'options', {'none_value': None})
 
 
 def test_get():
@@ -59,4 +58,4 @@ def test_bus_event_when_edited():
     url = confd.asterisk.rtp.general
     headers = {}
 
-    yield s.check_event, 'rtp_general_edited', headers, url.put, {'options': {}}
+    s.check_event('rtp_general_edited', headers, url.put, {'options': {}})

--- a/integration_tests/suite/base/test_rtp_ice_host_candidates.py
+++ b/integration_tests/suite/base/test_rtp_ice_host_candidates.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import assert_that, has_entries
@@ -10,17 +10,16 @@ from ..helpers.config import TOKEN_SUB_TENANT
 
 def test_put_errors():
     url = confd.asterisk.rtp.ice_host_candidates.put
-    for check in error_checks(url):
-        yield check
+    error_checks(url)
 
 
 def error_checks(url):
-    yield s.check_bogus_field_returns_error, url, 'options', 123
-    yield s.check_bogus_field_returns_error, url, 'options', None
-    yield s.check_bogus_field_returns_error, url, 'options', 'string'
-    yield s.check_bogus_field_returns_error, url, 'options', [['ordered', 'option']]
-    yield s.check_bogus_field_returns_error, url, 'options', {'wrong_value': 23}
-    yield s.check_bogus_field_returns_error, url, 'options', {'none_value': None}
+    s.check_bogus_field_returns_error(url, 'options', 123)
+    s.check_bogus_field_returns_error(url, 'options', None)
+    s.check_bogus_field_returns_error(url, 'options', 'string')
+    s.check_bogus_field_returns_error(url, 'options', [['ordered', 'option']])
+    s.check_bogus_field_returns_error(url, 'options', {'wrong_value': 23})
+    s.check_bogus_field_returns_error(url, 'options', {'none_value': None})
 
 
 def test_get():
@@ -59,6 +58,4 @@ def test_bus_event_when_edited():
     url = confd.asterisk.rtp.ice_host_candidates
     headers = {}
 
-    yield s.check_event, 'rtp_ice_host_candidates_edited', headers, url.put, {
-        'options': {}
-    }
+    s.check_event('rtp_ice_host_candidates_edited', headers, url.put, {'options': {}})

--- a/integration_tests/suite/base/test_sccp_general.py
+++ b/integration_tests/suite/base/test_sccp_general.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import assert_that, has_entries
@@ -10,17 +10,16 @@ from ..helpers.config import TOKEN_SUB_TENANT
 
 def test_put_errors():
     url = confd.asterisk.sccp.general.put
-    for check in error_checks(url):
-        yield check
+    error_checks(url)
 
 
 def error_checks(url):
-    yield s.check_bogus_field_returns_error, url, 'options', 123
-    yield s.check_bogus_field_returns_error, url, 'options', None
-    yield s.check_bogus_field_returns_error, url, 'options', 'string'
-    yield s.check_bogus_field_returns_error, url, 'options', [['ordered', 'option']]
-    yield s.check_bogus_field_returns_error, url, 'options', {'wrong_value': 23}
-    yield s.check_bogus_field_returns_error, url, 'options', {'none_value': None}
+    s.check_bogus_field_returns_error(url, 'options', 123)
+    s.check_bogus_field_returns_error(url, 'options', None)
+    s.check_bogus_field_returns_error(url, 'options', 'string')
+    s.check_bogus_field_returns_error(url, 'options', [['ordered', 'option']])
+    s.check_bogus_field_returns_error(url, 'options', {'wrong_value': 23})
+    s.check_bogus_field_returns_error(url, 'options', {'none_value': None})
 
 
 def test_get():
@@ -59,4 +58,4 @@ def test_bus_event_when_edited():
     url = confd.asterisk.sccp.general
     headers = {}
 
-    yield s.check_event, 'sccp_general_edited', headers, url.put, {'options': {}}
+    s.check_event('sccp_general_edited', headers, url.put, {'options': {}})

--- a/integration_tests/suite/base/test_schedules.py
+++ b/integration_tests/suite/base/test_schedules.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import (
@@ -22,176 +22,182 @@ from ..helpers.helpers.destination import invalid_destinations, valid_destinatio
 
 def test_get_errors():
     fake_schedule = confd.schedules(999999).get
-    yield s.check_resource_not_found, fake_schedule, 'Schedule'
+    s.check_resource_not_found(fake_schedule, 'Schedule')
 
 
 def test_delete_errors():
     fake_schedule = confd.schedules(999999).delete
-    yield s.check_resource_not_found, fake_schedule, 'Schedule'
+    s.check_resource_not_found(fake_schedule, 'Schedule')
 
 
 @fixtures.user()
 def test_post_errors(user):
     url = confd.schedules.post
-    for check in error_checks(url, user):
-        yield check
+    error_checks(url, user)
 
 
 @fixtures.schedule()
 @fixtures.user()
 def test_put_errors(schedule, user):
     url = confd.schedules(schedule['id']).put
-    for check in error_checks(url, user):
-        yield check
+    error_checks(url, user)
 
 
 def error_checks(url, user):
-    yield s.check_bogus_field_returns_error, url, 'name', True
-    yield s.check_bogus_field_returns_error, url, 'name', 1234
-    yield s.check_bogus_field_returns_error, url, 'name', s.random_string(129)
-    yield s.check_bogus_field_returns_error, url, 'name', []
-    yield s.check_bogus_field_returns_error, url, 'name', {}
-    yield s.check_bogus_field_returns_error, url, 'timezone', True
-    yield s.check_bogus_field_returns_error, url, 'timezone', 1234
-    yield s.check_bogus_field_returns_error, url, 'timezone', s.random_string(129)
-    yield s.check_bogus_field_returns_error, url, 'timezone', []
-    yield s.check_bogus_field_returns_error, url, 'timezone', {}
-    yield s.check_bogus_field_returns_error, url, 'enabled', 'invalid'
-    yield s.check_bogus_field_returns_error, url, 'enabled', None
-    yield s.check_bogus_field_returns_error, url, 'enabled', []
-    yield s.check_bogus_field_returns_error, url, 'enabled', {}
-    yield s.check_bogus_field_returns_error, url, 'open_periods', True
-    yield s.check_bogus_field_returns_error, url, 'open_periods', 1234
-    yield s.check_bogus_field_returns_error, url, 'open_periods', 'invalid'
-    yield s.check_bogus_field_returns_error, url, 'open_periods', {}
-    yield s.check_bogus_field_returns_error, url, 'exceptional_periods', True
-    yield s.check_bogus_field_returns_error, url, 'exceptional_periods', None
-    yield s.check_bogus_field_returns_error, url, 'exceptional_periods', 1234
-    yield s.check_bogus_field_returns_error, url, 'exceptional_periods', 'invalid'
-    yield s.check_bogus_field_returns_error, url, 'exceptional_periods', {}
+    s.check_bogus_field_returns_error(url, 'name', True)
+    s.check_bogus_field_returns_error(url, 'name', 1234)
+    s.check_bogus_field_returns_error(url, 'name', s.random_string(129))
+    s.check_bogus_field_returns_error(url, 'name', [])
+    s.check_bogus_field_returns_error(url, 'name', {})
+    s.check_bogus_field_returns_error(url, 'timezone', True)
+    s.check_bogus_field_returns_error(url, 'timezone', 1234)
+    s.check_bogus_field_returns_error(url, 'timezone', s.random_string(129))
+    s.check_bogus_field_returns_error(url, 'timezone', [])
+    s.check_bogus_field_returns_error(url, 'timezone', {})
+    s.check_bogus_field_returns_error(url, 'enabled', 'invalid')
+    s.check_bogus_field_returns_error(url, 'enabled', None)
+    s.check_bogus_field_returns_error(url, 'enabled', [])
+    s.check_bogus_field_returns_error(url, 'enabled', {})
+    s.check_bogus_field_returns_error(url, 'open_periods', True)
+    s.check_bogus_field_returns_error(url, 'open_periods', 1234)
+    s.check_bogus_field_returns_error(url, 'open_periods', 'invalid')
+    s.check_bogus_field_returns_error(url, 'open_periods', {})
+    s.check_bogus_field_returns_error(url, 'exceptional_periods', True)
+    s.check_bogus_field_returns_error(url, 'exceptional_periods', None)
+    s.check_bogus_field_returns_error(url, 'exceptional_periods', 1234)
+    s.check_bogus_field_returns_error(url, 'exceptional_periods', 'invalid')
+    s.check_bogus_field_returns_error(url, 'exceptional_periods', {})
 
     for key in ('open_periods', 'exceptional_periods'):
         regex = r'{}.*0.*hours_start'.format(key)
-        yield s.check_bogus_field_returns_error_matching_regex, url, key, [
-            {'hours_start': 7}
-        ], regex
-        yield s.check_bogus_field_returns_error_matching_regex, url, key, [
-            {'hours_start': '7:15'}
-        ], regex
-        yield s.check_bogus_field_returns_error_matching_regex, url, key, [
-            {'hours_start': 'abcd'}
-        ], regex
-        yield s.check_bogus_field_returns_error_matching_regex, url, key, [
-            {'hours_start': None}
-        ], regex
-        yield s.check_bogus_field_returns_error_matching_regex, url, key, [
-            {'hours_start': '24:00'}
-        ], regex
-        yield s.check_bogus_field_returns_error_matching_regex, url, key, [
-            {'hours_start': '10:60'}
-        ], regex
+        s.check_bogus_field_returns_error_matching_regex(
+            url, key, [{'hours_start': 7}], regex
+        )
+        s.check_bogus_field_returns_error_matching_regex(
+            url, key, [{'hours_start': '7:15'}], regex
+        )
+        s.check_bogus_field_returns_error_matching_regex(
+            url, key, [{'hours_start': 'abcd'}], regex
+        )
+        s.check_bogus_field_returns_error_matching_regex(
+            url, key, [{'hours_start': None}], regex
+        )
+        s.check_bogus_field_returns_error_matching_regex(
+            url, key, [{'hours_start': '24:00'}], regex
+        )
+        s.check_bogus_field_returns_error_matching_regex(
+            url, key, [{'hours_start': '10:60'}], regex
+        )
 
         regex = r'{}.*0.*hours_end'.format(key)
-        yield s.check_bogus_field_returns_error_matching_regex, url, key, [
-            {'hours_end': 8}
-        ], regex
-        yield s.check_bogus_field_returns_error_matching_regex, url, key, [
-            {'hours_end': '8:15'}
-        ], regex
-        yield s.check_bogus_field_returns_error_matching_regex, url, key, [
-            {'hours_end': 'abcd'}
-        ], regex
-        yield s.check_bogus_field_returns_error_matching_regex, url, key, [
-            {'hours_end': None}
-        ], regex
-        yield s.check_bogus_field_returns_error_matching_regex, url, key, [
-            {'hours_end': '24:00'}
-        ], regex
-        yield s.check_bogus_field_returns_error_matching_regex, url, key, [
-            {'hours_end': '10:60'}
-        ], regex
+        s.check_bogus_field_returns_error_matching_regex(
+            url, key, [{'hours_end': 8}], regex
+        )
+        s.check_bogus_field_returns_error_matching_regex(
+            url, key, [{'hours_end': '8:15'}], regex
+        )
+        s.check_bogus_field_returns_error_matching_regex(
+            url, key, [{'hours_end': 'abcd'}], regex
+        )
+        s.check_bogus_field_returns_error_matching_regex(
+            url, key, [{'hours_end': None}], regex
+        )
+        s.check_bogus_field_returns_error_matching_regex(
+            url, key, [{'hours_end': '24:00'}], regex
+        )
+        s.check_bogus_field_returns_error_matching_regex(
+            url, key, [{'hours_end': '10:60'}], regex
+        )
 
         regex = r'{}.*0.*week_days'.format(key)
-        yield s.check_bogus_field_returns_error_matching_regex, url, key, [
-            {'week_days': None}
-        ], regex
-        yield s.check_bogus_field_returns_error_matching_regex, url, key, [
-            {'week_days': 1}
-        ], regex
-        yield s.check_bogus_field_returns_error_matching_regex, url, key, [
-            {'week_days': []}
-        ], regex
-        yield s.check_bogus_field_returns_error_matching_regex, url, key, [
-            {'week_days': ['1-2']}
-        ], regex
-        yield s.check_bogus_field_returns_error_matching_regex, url, key, [
-            {'week_days': [None]}
-        ], regex
-        yield s.check_bogus_field_returns_error_matching_regex, url, key, [
-            {'week_days': [-1]}
-        ], regex
-        yield s.check_bogus_field_returns_error_matching_regex, url, key, [
-            {'week_days': [8]}
-        ], regex
+        s.check_bogus_field_returns_error_matching_regex(
+            url, key, [{'week_days': None}], regex
+        )
+        s.check_bogus_field_returns_error_matching_regex(
+            url, key, [{'week_days': 1}], regex
+        )
+        s.check_bogus_field_returns_error_matching_regex(
+            url, key, [{'week_days': []}], regex
+        )
+        s.check_bogus_field_returns_error_matching_regex(
+            url, key, [{'week_days': ['1-2']}], regex
+        )
+        s.check_bogus_field_returns_error_matching_regex(
+            url, key, [{'week_days': [None]}], regex
+        )
+        s.check_bogus_field_returns_error_matching_regex(
+            url, key, [{'week_days': [-1]}], regex
+        )
+        s.check_bogus_field_returns_error_matching_regex(
+            url, key, [{'week_days': [8]}], regex
+        )
 
         regex = r'{}.*0.*month_days'.format(key)
-        yield s.check_bogus_field_returns_error_matching_regex, url, key, [
-            {'month_days': None}
-        ], regex
-        yield s.check_bogus_field_returns_error_matching_regex, url, key, [
-            {'month_days': 1}
-        ], regex
-        yield s.check_bogus_field_returns_error_matching_regex, url, key, [
-            {'month_days': []}
-        ], regex
-        yield s.check_bogus_field_returns_error_matching_regex, url, key, [
-            {'month_days': ['1-2']}
-        ], regex
-        yield s.check_bogus_field_returns_error_matching_regex, url, key, [
-            {'month_days': [None]}
-        ], regex
-        yield s.check_bogus_field_returns_error_matching_regex, url, key, [
-            {'month_days': [-1]}
-        ], regex
-        yield s.check_bogus_field_returns_error_matching_regex, url, key, [
-            {'month_days': [32]}
-        ], regex
+        s.check_bogus_field_returns_error_matching_regex(
+            url, key, [{'month_days': None}], regex
+        )
+        s.check_bogus_field_returns_error_matching_regex(
+            url, key, [{'month_days': 1}], regex
+        )
+        s.check_bogus_field_returns_error_matching_regex(
+            url, key, [{'month_days': []}], regex
+        )
+        s.check_bogus_field_returns_error_matching_regex(
+            url, key, [{'month_days': ['1-2']}], regex
+        )
+        s.check_bogus_field_returns_error_matching_regex(
+            url, key, [{'month_days': [None]}], regex
+        )
+        s.check_bogus_field_returns_error_matching_regex(
+            url, key, [{'month_days': [-1]}], regex
+        )
+        s.check_bogus_field_returns_error_matching_regex(
+            url, key, [{'month_days': [32]}], regex
+        )
 
         regex = r'{}.*0.*months'.format(key)
-        yield s.check_bogus_field_returns_error_matching_regex, url, key, [
-            {'months': None}
-        ], regex
-        yield s.check_bogus_field_returns_error_matching_regex, url, key, [
-            {'months': 1}
-        ], regex
-        yield s.check_bogus_field_returns_error_matching_regex, url, key, [
-            {'months': []}
-        ], regex
-        yield s.check_bogus_field_returns_error_matching_regex, url, key, [
-            {'months': ['1-2']}
-        ], regex
-        yield s.check_bogus_field_returns_error_matching_regex, url, key, [
-            {'months': [None]}
-        ], regex
-        yield s.check_bogus_field_returns_error_matching_regex, url, key, [
-            {'months': [-1]}
-        ], regex
-        yield s.check_bogus_field_returns_error_matching_regex, url, key, [
-            {'months': [13]}
-        ], regex
+        s.check_bogus_field_returns_error_matching_regex(
+            url, key, [{'months': None}], regex
+        )
+        s.check_bogus_field_returns_error_matching_regex(
+            url, key, [{'months': 1}], regex
+        )
+        s.check_bogus_field_returns_error_matching_regex(
+            url, key, [{'months': []}], regex
+        )
+        s.check_bogus_field_returns_error_matching_regex(
+            url, key, [{'months': ['1-2']}], regex
+        )
+        s.check_bogus_field_returns_error_matching_regex(
+            url, key, [{'months': [None]}], regex
+        )
+        s.check_bogus_field_returns_error_matching_regex(
+            url, key, [{'months': [-1]}], regex
+        )
+        s.check_bogus_field_returns_error_matching_regex(
+            url, key, [{'months': [13]}], regex
+        )
 
     for destination in invalid_destinations():
-        yield s.check_bogus_field_returns_error, url, 'closed_destination', destination
-    yield s.check_bogus_field_returns_error, url, 'closed_destination', {
-        'type': 'user',
-        'user_id': user['id'],
-        'moh_uuid': '00000000-0000-0000-0000-000000000000',
-    }, {}, 'MOH was not found'
+        s.check_bogus_field_returns_error(url, 'closed_destination', destination)
+    s.check_bogus_field_returns_error(
+        url,
+        'closed_destination',
+        {
+            'type': 'user',
+            'user_id': user['id'],
+            'moh_uuid': '00000000-0000-0000-0000-000000000000',
+        },
+        {},
+        'MOH was not found',
+    )
 
     for destination in invalid_destinations():
         regex = r'exceptional_periods.*0.*destination'
         body = [{'destination': destination}]
-        yield s.check_bogus_field_returns_error_matching_regex, url, 'exceptional_periods', body, regex
+        s.check_bogus_field_returns_error_matching_regex(
+            url, 'exceptional_periods', body, regex
+        )
 
 
 @fixtures.schedule(wazo_tenant=MAIN_TENANT)
@@ -214,7 +220,7 @@ def test_search(schedule, hidden):
     searches = {'name': 'search', 'timezone': 'search'}
 
     for field, term in searches.items():
-        yield check_search, url, schedule, hidden, field, term
+        check_search(url, schedule, hidden, field, term)
 
 
 def check_search(url, schedule, hidden, field, term):
@@ -231,10 +237,10 @@ def check_search(url, schedule, hidden, field, term):
 @fixtures.schedule(name='sort2')
 def test_sort_offset_limit(schedule1, schedule2):
     url = confd.schedules.get
-    yield s.check_sorting, url, schedule1, schedule2, 'name', 'sort'
+    s.check_sorting(url, schedule1, schedule2, 'name', 'sort')
 
-    yield s.check_offset, url, schedule1, schedule2, 'name', 'sort'
-    yield s.check_limit, url, schedule1, schedule2, 'name', 'sort'
+    s.check_offset(url, schedule1, schedule2, 'name', 'sort')
+    s.check_limit(url, schedule1, schedule2, 'name', 'sort')
 
 
 @fixtures.schedule()
@@ -488,8 +494,8 @@ def test_edit_all_parameters(schedule):
 @fixtures.moh()
 def test_valid_destinations(schedule, *destinations):
     for destination in valid_destinations(*destinations):
-        yield create_schedule_with_destination, destination
-        yield update_schedule_with_destination, schedule['id'], destination
+        create_schedule_with_destination(destination)
+        update_schedule_with_destination(schedule['id'], destination)
 
 
 def create_schedule_with_destination(destination):
@@ -567,6 +573,6 @@ def test_bus_events(schedule):
     body = {'closed_destination': {'type': 'none'}}
     headers = {'tenant_uuid': schedule['tenant_uuid']}
 
-    yield s.check_event, 'schedule_created', headers, confd.schedules.post, body
-    yield s.check_event, 'schedule_edited', headers, url.put
-    yield s.check_event, 'schedule_deleted', headers, url.delete
+    s.check_event('schedule_created', headers, confd.schedules.post, body)
+    s.check_event('schedule_edited', headers, url.put)
+    s.check_event('schedule_deleted', headers, url.delete)

--- a/integration_tests/suite/base/test_skill_rules.py
+++ b/integration_tests/suite/base/test_skill_rules.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import (
@@ -21,54 +21,52 @@ from ..helpers.config import MAIN_TENANT, SUB_TENANT
 
 def test_get_errors():
     fake_skill = confd.queues.skillrules(999999).get
-    yield s.check_resource_not_found, fake_skill, 'SkillRule'
+    s.check_resource_not_found(fake_skill, 'SkillRule')
 
 
 def test_delete_errors():
     fake_skill = confd.queues.skillrules(999999).delete
-    yield s.check_resource_not_found, fake_skill, 'SkillRule'
+    s.check_resource_not_found(fake_skill, 'SkillRule')
 
 
 def test_post_errors():
     url = confd.queues.skillrules.post
-    for check in error_checks(url):
-        yield check
+    error_checks(url)
 
 
 @fixtures.skill_rule()
 def test_put_errors(skill):
     url = confd.queues.skillrules(skill['id']).put
-    for check in error_checks(url):
-        yield check
+    error_checks(url)
 
 
 def error_checks(url):
-    yield s.check_bogus_field_returns_error, url, 'name', True
-    yield s.check_bogus_field_returns_error, url, 'name', None
-    yield s.check_bogus_field_returns_error, url, 'name', 1234
-    yield s.check_bogus_field_returns_error, url, 'name', s.random_string(65)
-    yield s.check_bogus_field_returns_error, url, 'name', []
-    yield s.check_bogus_field_returns_error, url, 'name', {}
-    yield s.check_bogus_field_returns_error, url, 'rules', True
-    yield s.check_bogus_field_returns_error, url, 'rules', 1234
-    yield s.check_bogus_field_returns_error, url, 'rules', {}
-    yield s.check_bogus_field_returns_error, url, 'rules', 'string'
-    yield s.check_bogus_field_returns_error, url, 'rules', ['string']
-    yield s.check_bogus_field_returns_error, url, 'rules', [{}]
+    s.check_bogus_field_returns_error(url, 'name', True)
+    s.check_bogus_field_returns_error(url, 'name', None)
+    s.check_bogus_field_returns_error(url, 'name', 1234)
+    s.check_bogus_field_returns_error(url, 'name', s.random_string(65))
+    s.check_bogus_field_returns_error(url, 'name', [])
+    s.check_bogus_field_returns_error(url, 'name', {})
+    s.check_bogus_field_returns_error(url, 'rules', True)
+    s.check_bogus_field_returns_error(url, 'rules', 1234)
+    s.check_bogus_field_returns_error(url, 'rules', {})
+    s.check_bogus_field_returns_error(url, 'rules', 'string')
+    s.check_bogus_field_returns_error(url, 'rules', ['string'])
+    s.check_bogus_field_returns_error(url, 'rules', [{}])
 
     regex = r'rules.*definition'
-    yield s.check_bogus_field_returns_error_matching_regex, url, 'rules', [
-        {'definition': True}
-    ], regex
-    yield s.check_bogus_field_returns_error_matching_regex, url, 'rules', [
-        {'definition': 1234}
-    ], regex
-    yield s.check_bogus_field_returns_error_matching_regex, url, 'rules', [
-        {'definition': []}
-    ], regex
-    yield s.check_bogus_field_returns_error_matching_regex, url, 'rules', [
-        {'definition': {}}
-    ], regex
+    s.check_bogus_field_returns_error_matching_regex(
+        url, 'rules', [{'definition': True}], regex
+    )
+    s.check_bogus_field_returns_error_matching_regex(
+        url, 'rules', [{'definition': 1234}], regex
+    )
+    s.check_bogus_field_returns_error_matching_regex(
+        url, 'rules', [{'definition': []}], regex
+    )
+    s.check_bogus_field_returns_error_matching_regex(
+        url, 'rules', [{'definition': {}}], regex
+    )
 
 
 @fixtures.skill_rule(name='search')
@@ -78,7 +76,7 @@ def test_search(skill, hidden):
     searches = {'name': 'search'}
 
     for field, term in searches.items():
-        yield check_search, url, skill, hidden, field, term
+        check_search(url, skill, hidden, field, term)
 
 
 def check_search(url, skill, hidden, field, term):
@@ -125,9 +123,9 @@ def test_list_multi_tenant(main, sub):
 @fixtures.skill_rule(name='sort2')
 def test_sort_offset_limit(skill1, skill2):
     url = confd.queues.skillrules.get
-    yield s.check_sorting, url, skill1, skill2, 'name', 'sort'
-    yield s.check_offset, url, skill1, skill2, 'name', 'sort'
-    yield s.check_limit, url, skill1, skill2, 'name', 'sort'
+    s.check_sorting(url, skill1, skill2, 'name', 'sort')
+    s.check_offset(url, skill1, skill2, 'name', 'sort')
+    s.check_limit(url, skill1, skill2, 'name', 'sort')
 
 
 @fixtures.skill_rule()
@@ -240,6 +238,6 @@ def test_bus_events(skill_rule):
     body = {'name': 'SkillRule'}
     headers = {'tenant_uuid': skill_rule['tenant_uuid']}
 
-    yield s.check_event, 'skill_rule_created', headers, confd.queues.skillrules.post, body
-    yield s.check_event, 'skill_rule_edited', headers, url.put
-    yield s.check_event, 'skill_rule_deleted', headers, url.delete
+    s.check_event('skill_rule_created', headers, confd.queues.skillrules.post, body)
+    s.check_event('skill_rule_edited', headers, url.put)
+    s.check_event('skill_rule_deleted', headers, url.delete)

--- a/integration_tests/suite/base/test_skills.py
+++ b/integration_tests/suite/base/test_skills.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import (
@@ -21,46 +21,43 @@ from ..helpers.config import MAIN_TENANT, SUB_TENANT
 
 def test_get_errors():
     fake_skill = confd.agents.skills(999999).get
-    yield s.check_resource_not_found, fake_skill, 'Skill'
+    s.check_resource_not_found(fake_skill, 'Skill')
 
 
 def test_delete_errors():
     fake_skill = confd.agents.skills(999999).delete
-    yield s.check_resource_not_found, fake_skill, 'Skill'
+    s.check_resource_not_found(fake_skill, 'Skill')
 
 
 def test_post_errors():
     url = confd.agents.skills.post
-    for check in error_checks(url):
-        yield check
+    error_checks(url)
 
 
 @fixtures.skill()
 def test_put_errors(skill):
     url = confd.agents.skills(skill['id']).put
-    for check in error_checks(url):
-        yield check
+    error_checks(url)
 
 
 def error_checks(url):
-    yield s.check_bogus_field_returns_error, url, 'name', True
-    yield s.check_bogus_field_returns_error, url, 'name', 1234
-    yield s.check_bogus_field_returns_error, url, 'name', 'invalid regex'
-    yield s.check_bogus_field_returns_error, url, 'name', s.random_string(65)
-    yield s.check_bogus_field_returns_error, url, 'name', []
-    yield s.check_bogus_field_returns_error, url, 'name', {}
-    yield s.check_bogus_field_returns_error, url, 'description', True
-    yield s.check_bogus_field_returns_error, url, 'description', 1234
-    yield s.check_bogus_field_returns_error, url, 'description', []
-    yield s.check_bogus_field_returns_error, url, 'description', {}
+    s.check_bogus_field_returns_error(url, 'name', True)
+    s.check_bogus_field_returns_error(url, 'name', 1234)
+    s.check_bogus_field_returns_error(url, 'name', 'invalid regex')
+    s.check_bogus_field_returns_error(url, 'name', s.random_string(65))
+    s.check_bogus_field_returns_error(url, 'name', [])
+    s.check_bogus_field_returns_error(url, 'name', {})
+    s.check_bogus_field_returns_error(url, 'description', True)
+    s.check_bogus_field_returns_error(url, 'description', 1234)
+    s.check_bogus_field_returns_error(url, 'description', [])
+    s.check_bogus_field_returns_error(url, 'description', {})
 
-    for check in unique_error_checks(url):
-        yield check
+    unique_error_checks(url)
 
 
 @fixtures.skill(name='unique')
 def unique_error_checks(url, skill):
-    yield s.check_bogus_field_returns_error, url, 'name', skill['name']
+    s.check_bogus_field_returns_error(url, 'name', skill['name'])
 
 
 @fixtures.skill(name='search', description='search')
@@ -70,7 +67,7 @@ def test_search(skill, hidden):
     searches = {'name': 'search', 'description': 'search'}
 
     for field, term in searches.items():
-        yield check_search, url, skill, hidden, field, term
+        check_search(url, skill, hidden, field, term)
 
 
 def check_search(url, skill, hidden, field, term):
@@ -115,9 +112,9 @@ def test_list_multi_tenant(main, sub):
 @fixtures.skill(name='sort2')
 def test_sort_offset_limit(skill1, skill2):
     url = confd.agents.skills.get
-    yield s.check_sorting, url, skill1, skill2, 'name', 'sort'
-    yield s.check_offset, url, skill1, skill2, 'name', 'sort'
-    yield s.check_limit, url, skill1, skill2, 'name', 'sort'
+    s.check_sorting(url, skill1, skill2, 'name', 'sort')
+    s.check_offset(url, skill1, skill2, 'name', 'sort')
+    s.check_limit(url, skill1, skill2, 'name', 'sort')
 
 
 @fixtures.skill()
@@ -229,6 +226,6 @@ def test_bus_events(skill):
     body = {'name': 'Skill'}
     headers = {'tenant_uuid': skill['tenant_uuid']}
 
-    yield s.check_event, 'skill_created', headers, confd.agents.skills.post, body
-    yield s.check_event, 'skill_edited', headers, url.put
-    yield s.check_event, 'skill_deleted', headers, url.delete
+    s.check_event('skill_created', headers, confd.agents.skills.post, body)
+    s.check_event('skill_edited', headers, url.put)
+    s.check_event('skill_deleted', headers, url.delete)

--- a/integration_tests/suite/base/test_sounds.py
+++ b/integration_tests/suite/base/test_sounds.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 
@@ -31,7 +31,7 @@ def setup_module():
 
 def test_get_errors():
     fake_sound = confd.sounds('invalid').get
-    yield s.check_resource_not_found, fake_sound, 'Sound'
+    s.check_resource_not_found(fake_sound, 'Sound')
 
     for invalid_name in ['.foo', 'foo/bar', '../bar']:
         response = confd.sounds(invalid_name).get()
@@ -40,16 +40,14 @@ def test_get_errors():
 
 def test_delete_errors():
     fake_sound = confd.sounds('invalid').delete
-    yield s.check_resource_not_found, fake_sound, 'Sound'
+    s.check_resource_not_found(fake_sound, 'Sound')
 
 
 def test_post_errors():
     url = confd.sounds.post
-    for check in error_checks(url):
-        yield check
+    error_checks(url)
 
-    for check in unique_error_checks(url):
-        yield check
+    unique_error_checks(url)
 
 
 @fixtures.sound(wazo_tenant=MAIN_TENANT)
@@ -58,25 +56,24 @@ def test_search_errors(sound):
         confd.sounds.get,
     ]
     for url in searchable_endpoints:
-        for check in s.search_error_checks(url):
-            yield check
+        s.search_error_checks(url)
 
 
 def error_checks(url):
-    yield s.check_bogus_field_returns_error, url, 'name', True
-    yield s.check_bogus_field_returns_error, url, 'name', 1234
-    yield s.check_bogus_field_returns_error, url, 'name', s.random_string(150)
-    yield s.check_bogus_field_returns_error, url, 'name', '.foo'
-    yield s.check_bogus_field_returns_error, url, 'name', 'foo\nbar'
-    yield s.check_bogus_field_returns_error, url, 'name', []
-    yield s.check_bogus_field_returns_error, url, 'name', {}
+    s.check_bogus_field_returns_error(url, 'name', True)
+    s.check_bogus_field_returns_error(url, 'name', 1234)
+    s.check_bogus_field_returns_error(url, 'name', s.random_string(150))
+    s.check_bogus_field_returns_error(url, 'name', '.foo')
+    s.check_bogus_field_returns_error(url, 'name', 'foo\nbar')
+    s.check_bogus_field_returns_error(url, 'name', [])
+    s.check_bogus_field_returns_error(url, 'name', {})
 
-    yield s.check_bogus_field_returns_error, url, 'name', 'system'
+    s.check_bogus_field_returns_error(url, 'name', 'system')
 
 
 @fixtures.sound(name='unique')
 def unique_error_checks(url, sound):
-    yield s.check_bogus_field_returns_error, url, 'name', sound['name']
+    s.check_bogus_field_returns_error(url, 'name', sound['name'])
 
 
 @fixtures.sound(wazo_tenant=MAIN_TENANT)
@@ -160,7 +157,7 @@ def test_get_with_files(sound):
 @fixtures.sound(name='test_category_1')
 @fixtures.sound(name='test_category_2')
 def test_search_sound(sound1, sound2):
-    yield s.check_sorting, confd.sounds.get, sound1, sound2, 'name', 'test_category', 'name'
+    s.check_sorting(confd.sounds.get, sound1, sound2, 'name', 'test_category', 'name')
 
 
 @fixtures.sound(wazo_tenant=MAIN_TENANT, name='test_category_1')
@@ -190,14 +187,14 @@ def test_search_sound_multi_tenant(sound1, sound2):
 @fixtures.sound(name='test_offset_2')
 def test_search_sound_offset(sound1, sound2):
     url = confd.sounds.get
-    yield s.check_offset, url, sound1, sound2, 'name', 'test_offset', 'name'
+    s.check_offset(url, sound1, sound2, 'name', 'test_offset', 'name')
 
 
 @fixtures.sound(name='test_limit_1')
 @fixtures.sound(name='test_limit_2')
 def test_search_sound_limit(sound1, sound2):
     url = confd.sounds.get
-    yield s.check_limit, url, sound1, sound2, 'name', 'test_limit', 'name'
+    s.check_limit(url, sound1, sound2, 'name', 'test_limit', 'name')
 
 
 def test_get_system_sound():
@@ -677,7 +674,5 @@ def _new_sound_file_client():
 def test_bus_events():
     headers = {'tenant_uuid': MAIN_TENANT}
 
-    yield s.check_event, 'sound_created', headers, confd.sounds.post, {
-        'name': 'bus_event'
-    }
-    yield s.check_event, 'sound_deleted', headers, confd.sounds('bus_event').delete
+    s.check_event('sound_created', headers, confd.sounds.post, {'name': 'bus_event'})
+    s.check_event('sound_deleted', headers, confd.sounds('bus_event').delete)

--- a/integration_tests/suite/base/test_switchboard_fallback.py
+++ b/integration_tests/suite/base/test_switchboard_fallback.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import assert_that, equal_to, has_entries
@@ -14,32 +14,36 @@ FAKE_UUID = '99999999-9999-9999-9999-999999999999'
 
 def test_get_errors():
     fake_switchboard = confd.switchboards(FAKE_UUID).fallbacks.get
-    yield s.check_resource_not_found, fake_switchboard, 'Switchboard'
+    s.check_resource_not_found(fake_switchboard, 'Switchboard')
 
 
 @fixtures.switchboard()
 @fixtures.user()
 def test_put_errors(switchboard, user):
     fake_switchboard = confd.switchboards(FAKE_UUID).fallbacks.put
-    yield s.check_resource_not_found, fake_switchboard, 'Switchboard'
+    s.check_resource_not_found(fake_switchboard, 'Switchboard')
 
     url = confd.switchboards(switchboard['uuid']).fallbacks.put
-    for check in error_checks(url, user):
-        yield check
+    error_checks(url, user)
 
     url = confd.switchboards(switchboard['uuid']).fallbacks.put
-    for check in error_checks(url, user):
-        yield check
+    error_checks(url, user)
 
 
 def error_checks(url, user):
     for destination in invalid_destinations():
-        yield s.check_bogus_field_returns_error, url, 'noanswer_destination', destination
-    yield s.check_bogus_field_returns_error, url, 'noanswer_destination', {
-        'type': 'user',
-        'user_id': user['id'],
-        'moh_uuid': '00000000-0000-0000-0000-000000000000',
-    }, {}, 'MOH was not found'
+        s.check_bogus_field_returns_error(url, 'noanswer_destination', destination)
+    s.check_bogus_field_returns_error(
+        url,
+        'noanswer_destination',
+        {
+            'type': 'user',
+            'user_id': user['id'],
+            'moh_uuid': '00000000-0000-0000-0000-000000000000',
+        },
+        {},
+        'MOH was not found',
+    )
 
 
 @fixtures.switchboard()
@@ -103,9 +107,7 @@ def test_edit_to_none(switchboard):
 @fixtures.moh()
 def test_valid_destinations(switchboard, *destinations):
     for destination in valid_destinations(*destinations):
-        yield _update_switchboard_fallbacks_with_destination, switchboard[
-            'uuid'
-        ], destination
+        _update_switchboard_fallbacks_with_destination(switchboard['uuid'], destination)
 
 
 def _update_switchboard_fallbacks_with_destination(switchboard_uuid, destination):
@@ -152,9 +154,9 @@ def test_nonexistent_destinations(switchboard, moh):
             destination['type'] == 'application'
             and destination['application'] == 'custom'
         ):
-            yield _update_user_fallbacks_with_nonexistent_destination, switchboard[
-                'uuid'
-            ], destination
+            _update_user_fallbacks_with_nonexistent_destination(
+                switchboard['uuid'], destination
+            )
 
 
 def _update_user_fallbacks_with_nonexistent_destination(switchboard_uuid, destination):
@@ -172,7 +174,7 @@ def test_bus_events(switchboard):
         'switchboard_uuid': switchboard['uuid'],
     }
 
-    yield s.check_event, 'switchboard_fallback_edited', headers, url
+    s.check_event('switchboard_fallback_edited', headers, url)
 
 
 @fixtures.switchboard()

--- a/integration_tests/suite/base/test_switchboard_member_user.py
+++ b/integration_tests/suite/base/test_switchboard_member_user.py
@@ -31,19 +31,19 @@ def test_associate_errors(switchboard, user):
 
     url = confd.switchboards(switchboard['uuid']).members.users.put
 
-    yield s.check_missing_required_field_returns_error, url, 'users'
-    yield s.check_bogus_field_returns_error, url, 'users', 123
-    yield s.check_bogus_field_returns_error, url, 'users', None
-    yield s.check_bogus_field_returns_error, url, 'users', True
-    yield s.check_bogus_field_returns_error, url, 'users', 'string'
-    yield s.check_bogus_field_returns_error, url, 'users', [123]
-    yield s.check_bogus_field_returns_error, url, 'users', [None]
-    yield s.check_bogus_field_returns_error, url, 'users', ['string']
-    yield s.check_bogus_field_returns_error, url, 'users', [{}]
-    yield s.check_bogus_field_returns_error, url, 'users', [{'uuid': None}]
-    yield s.check_bogus_field_returns_error, url, 'users', [{'uuid': 1}, {'uuid': None}]
-    yield s.check_bogus_field_returns_error, url, 'users', [{'not_uuid': 123}]
-    yield s.check_bogus_field_returns_error, url, 'users', [{'uuid': FAKE_UUID}]
+    s.check_missing_required_field_returns_error(url, 'users')
+    s.check_bogus_field_returns_error(url, 'users', 123)
+    s.check_bogus_field_returns_error(url, 'users', None)
+    s.check_bogus_field_returns_error(url, 'users', True)
+    s.check_bogus_field_returns_error(url, 'users', 'string')
+    s.check_bogus_field_returns_error(url, 'users', [123])
+    s.check_bogus_field_returns_error(url, 'users', [None])
+    s.check_bogus_field_returns_error(url, 'users', ['string'])
+    s.check_bogus_field_returns_error(url, 'users', [{}])
+    s.check_bogus_field_returns_error(url, 'users', [{'uuid': None}])
+    s.check_bogus_field_returns_error(url, 'users', [{'uuid': 1}, {'uuid': None}])
+    s.check_bogus_field_returns_error(url, 'users', [{'not_uuid': 123}])
+    s.check_bogus_field_returns_error(url, 'users', [{'uuid': FAKE_UUID}])
 
 
 @fixtures.switchboard()
@@ -174,10 +174,10 @@ def test_delete_user_when_switchboard_and_user_associated(
         confd.users(user['uuid']).delete().assert_deleted()
 
         response = confd.switchboards(switchboard1['uuid']).get()
-        yield assert_that, response.item['members']['users'], empty()
+        assert_that(response.item['members']['users'], empty())
 
         response = confd.switchboards(switchboard2['uuid']).get()
-        yield assert_that, response.item['members']['users'], empty()
+        assert_that(response.item['members']['users'], empty())
 
 
 @fixtures.switchboard()
@@ -191,4 +191,4 @@ def test_bus_events(switchboard, user):
         f'user_uuid:{user["uuid"]}': True,
     }
 
-    yield s.check_event, 'switchboard_member_user_associated', headers, url, body
+    s.check_event('switchboard_member_user_associated', headers, url, body)

--- a/integration_tests/suite/base/test_switchboards.py
+++ b/integration_tests/suite/base/test_switchboards.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import (
@@ -23,68 +23,68 @@ NOT_FOUND_SWITCHBOARD_UUID = 'uuid-not-found'
 
 def test_get_errors():
     fake_switchboard = confd.switchboards(NOT_FOUND_SWITCHBOARD_UUID).get
-    yield s.check_resource_not_found, fake_switchboard, 'Switchboard'
+    s.check_resource_not_found(fake_switchboard, 'Switchboard')
 
 
 def test_delete_errors():
     fake_switchboard = confd.switchboards(NOT_FOUND_SWITCHBOARD_UUID).delete
-    yield s.check_resource_not_found, fake_switchboard, 'Switchboard'
+    s.check_resource_not_found(fake_switchboard, 'Switchboard')
 
 
 @fixtures.moh(label='othertenant', wazo_tenant=SUB_TENANT)
 def test_post_errors(_):
     switchboard_post = confd.switchboards(name='TheSwitchboard').post
-    for check in error_checks(switchboard_post):
-        yield check
+    error_checks(switchboard_post)
 
-    yield s.check_bogus_field_returns_error, switchboard_post, 'queue_music_on_hold', 'othertenant'
-    yield s.check_bogus_field_returns_error, switchboard_post, 'waiting_room_music_on_hold', 'othertenant'
+    s.check_bogus_field_returns_error(
+        switchboard_post, 'queue_music_on_hold', 'othertenant'
+    )
+    s.check_bogus_field_returns_error(
+        switchboard_post, 'waiting_room_music_on_hold', 'othertenant'
+    )
 
 
 @fixtures.switchboard()
 @fixtures.moh(label='othertenant', wazo_tenant=SUB_TENANT)
 def test_put_errors(switchboard, _):
     fake_switchboard = confd.switchboards(NOT_FOUND_SWITCHBOARD_UUID).put
-    yield s.check_resource_not_found, fake_switchboard, 'Switchboard'
+    s.check_resource_not_found(fake_switchboard, 'Switchboard')
 
     url = confd.switchboards(switchboard['uuid']).put
-    for check in error_checks(url):
-        yield check
+    error_checks(url)
 
-    yield s.check_bogus_field_returns_error, url, 'queue_music_on_hold', 'othertenant'
-    yield s.check_bogus_field_returns_error, url, 'waiting_room_music_on_hold', 'othertenant'
+    s.check_bogus_field_returns_error(url, 'queue_music_on_hold', 'othertenant')
+    s.check_bogus_field_returns_error(url, 'waiting_room_music_on_hold', 'othertenant')
 
 
 def error_checks(url):
-    yield s.check_bogus_field_returns_error, url, 'name', 123
-    yield s.check_bogus_field_returns_error, url, 'name', True
-    yield s.check_bogus_field_returns_error, url, 'name', None
-    yield s.check_bogus_field_returns_error, url, 'name', s.random_string(129)
-    yield s.check_bogus_field_returns_error, url, 'name', []
-    yield s.check_bogus_field_returns_error, url, 'name', {}
-    yield s.check_bogus_field_returns_error, url, 'queue_music_on_hold', 'unknown'
-    yield s.check_bogus_field_returns_error, url, 'queue_music_on_hold', 123
-    yield s.check_bogus_field_returns_error, url, 'queue_music_on_hold', True
-    yield s.check_bogus_field_returns_error, url, 'queue_music_on_hold', False
-    yield s.check_bogus_field_returns_error, url, 'queue_music_on_hold', s.random_string(
-        129
+    s.check_bogus_field_returns_error(url, 'name', 123)
+    s.check_bogus_field_returns_error(url, 'name', True)
+    s.check_bogus_field_returns_error(url, 'name', None)
+    s.check_bogus_field_returns_error(url, 'name', s.random_string(129))
+    s.check_bogus_field_returns_error(url, 'name', [])
+    s.check_bogus_field_returns_error(url, 'name', {})
+    s.check_bogus_field_returns_error(url, 'queue_music_on_hold', 'unknown')
+    s.check_bogus_field_returns_error(url, 'queue_music_on_hold', 123)
+    s.check_bogus_field_returns_error(url, 'queue_music_on_hold', True)
+    s.check_bogus_field_returns_error(url, 'queue_music_on_hold', False)
+    s.check_bogus_field_returns_error(url, 'queue_music_on_hold', s.random_string(129))
+    s.check_bogus_field_returns_error(url, 'queue_music_on_hold', [])
+    s.check_bogus_field_returns_error(url, 'queue_music_on_hold', {})
+    s.check_bogus_field_returns_error(url, 'waiting_room_music_on_hold', 'unknown')
+    s.check_bogus_field_returns_error(url, 'waiting_room_music_on_hold', 123)
+    s.check_bogus_field_returns_error(url, 'waiting_room_music_on_hold', True)
+    s.check_bogus_field_returns_error(url, 'waiting_room_music_on_hold', False)
+    s.check_bogus_field_returns_error(
+        url, 'waiting_room_music_on_hold', s.random_string(129)
     )
-    yield s.check_bogus_field_returns_error, url, 'queue_music_on_hold', []
-    yield s.check_bogus_field_returns_error, url, 'queue_music_on_hold', {}
-    yield s.check_bogus_field_returns_error, url, 'waiting_room_music_on_hold', 'unknown'
-    yield s.check_bogus_field_returns_error, url, 'waiting_room_music_on_hold', 123
-    yield s.check_bogus_field_returns_error, url, 'waiting_room_music_on_hold', True
-    yield s.check_bogus_field_returns_error, url, 'waiting_room_music_on_hold', False
-    yield s.check_bogus_field_returns_error, url, 'waiting_room_music_on_hold', s.random_string(
-        129
-    )
-    yield s.check_bogus_field_returns_error, url, 'waiting_room_music_on_hold', []
-    yield s.check_bogus_field_returns_error, url, 'waiting_room_music_on_hold', {}
-    yield s.check_bogus_field_returns_error, url, 'timeout', 'unknown'
-    yield s.check_bogus_field_returns_error, url, 'timeout', True
-    yield s.check_bogus_field_returns_error, url, 'timeout', False
-    yield s.check_bogus_field_returns_error, url, 'timeout', -1
-    yield s.check_bogus_field_returns_error, url, 'timeout', 0
+    s.check_bogus_field_returns_error(url, 'waiting_room_music_on_hold', [])
+    s.check_bogus_field_returns_error(url, 'waiting_room_music_on_hold', {})
+    s.check_bogus_field_returns_error(url, 'timeout', 'unknown')
+    s.check_bogus_field_returns_error(url, 'timeout', True)
+    s.check_bogus_field_returns_error(url, 'timeout', False)
+    s.check_bogus_field_returns_error(url, 'timeout', -1)
+    s.check_bogus_field_returns_error(url, 'timeout', 0)
 
 
 @fixtures.switchboard(wazo_tenant=MAIN_TENANT)
@@ -107,7 +107,7 @@ def test_search(hidden, switchboard):
     searches = {'name': 'search'}
 
     for field, term in searches.items():
-        yield check_search, url, switchboard, hidden, field, term
+        check_search(url, switchboard, hidden, field, term)
 
 
 def check_search(url, switchboard, hidden, field, term):
@@ -123,7 +123,7 @@ def check_search(url, switchboard, hidden, field, term):
 @fixtures.switchboard(name='sort1')
 @fixtures.switchboard(name='sort2')
 def test_sorting(switchboard1, switchboard2):
-    yield check_sorting, switchboard1, switchboard2, 'name', 'sort'
+    check_sorting(switchboard1, switchboard2, 'name', 'sort')
 
 
 def check_sorting(switchboard1, switchboard2, field, search):
@@ -322,9 +322,9 @@ def test_bus_events(switchboard):
         'tenant_uuid': switchboard['tenant_uuid'],
     }
 
-    yield s.check_event, 'switchboard_created', headers, confd.switchboards.post, {
-        'name': 'bus_event'
-    }
+    s.check_event(
+        'switchboard_created', headers, confd.switchboards.post, {'name': 'bus_event'}
+    )
     headers['switchboard_uuid'] = switchboard['uuid']
-    yield s.check_event, 'switchboard_edited', headers, url.put
-    yield s.check_event, 'switchboard_deleted', headers, url.delete
+    s.check_event('switchboard_edited', headers, url.put)
+    s.check_event('switchboard_deleted', headers, url.delete)

--- a/integration_tests/suite/base/test_tenants.py
+++ b/integration_tests/suite/base/test_tenants.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2020-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import (
@@ -115,7 +115,21 @@ class BaseTestDeleteByEvent(BaseTestTenants):
             'func_key',
             'func_key_dest_custom',
         ]
+        BaseIntegrationTest.mock_auth.set_tenants(*DEFAULT_TENANTS)
+
+        for t in DEFAULT_TENANTS:
+            BusClient.send_tenant_created(t['uuid'], t['slug'])
+
+        # xivo-manage-db creates a tenant (with a random uuid)
+        # sync_db is called now to remove this tenant
+        BaseIntegrationTest.sync_db()
+
+        # count before the creation of the DELETED_TENANT
         self.before_tables_rows_counts = self.count_tables_rows()
+
+        # add the tenant DELETED_TENANT in wazo-auth for the authorization,
+        # to be able to create the tenant in wazo-confd
+        BaseIntegrationTest.mock_auth.set_tenants(*ALL_TENANTS)
 
     @fixtures.user(wazo_tenant=DELETED_TENANT)
     @fixtures.group(wazo_tenant=DELETED_TENANT)

--- a/integration_tests/suite/base/test_tenants.py
+++ b/integration_tests/suite/base/test_tenants.py
@@ -1,6 +1,7 @@
 # Copyright 2020-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+from contextlib import contextmanager, ExitStack
 from hamcrest import (
     all_of,
     assert_that,
@@ -9,9 +10,10 @@ from hamcrest import (
     has_key,
     not_,
 )
-from unittest import TestCase
 from sqlalchemy.sql import text
 from wazo_test_helpers import until
+
+from typing import Dict
 
 from . import confd, db, BaseIntegrationTest
 from ..helpers import errors as e, fixtures, associations as a
@@ -25,6 +27,7 @@ from ..helpers.config import (
     ALL_TENANTS,
     DEFAULT_TENANTS,
 )
+from ..helpers.database import DatabaseQueries
 
 
 def test_get():
@@ -77,126 +80,164 @@ def test_list_multi_tenant(_):
     )
 
 
-class BaseTestTenants(TestCase):
-    def count_tables_rows(self):
-        tables_counts = {}
-        with self.db.queries() as queries:
-            query = text(
-                "SELECT * FROM pg_catalog.pg_tables WHERE schemaname != 'pg_catalog' AND schemaname != 'information_schema';"
-            )
-            result = queries.connection.execute(query)
-            for row in result:
-                if row.tablename not in self.excluded_tables:
-                    query = text(f"SELECT COUNT(*) FROM {row.tablename};")
-                    count = queries.connection.execute(query).scalar()
-                    tables_counts[row.tablename] = count
-        return tables_counts
+def test_tenant_deletion_with_event():
+    _reset_tenants()
+    tables_rows_count_before_deletion = _count_tables_rows()
+    with _create_tenant_ready_for_deletion() as tenant_uuid:
+        with BaseIntegrationTest.delete_auth_tenant(tenant_uuid):
+            BusClient.send_tenant_deleted(DELETED_TENANT, 'slug2')
 
-    def diff(self, after_tables_rows_counts):
-        diff = {
-            k: {
-                'before': self.before_tables_rows_counts[k],
-                'after': after_tables_rows_counts[k],
-            }
-            for k in self.before_tables_rows_counts
-            if k in after_tables_rows_counts
-            and self.before_tables_rows_counts[k] != after_tables_rows_counts[k]
+            def resources_deleted():
+                tables_rows_count_after_deletion = _count_tables_rows()
+                diff = _diff_tables_rows(
+                    tables_rows_count_before_deletion, tables_rows_count_after_deletion
+                )
+                assert (
+                    len(diff) == 0
+                ), f'Some tables are not properly cleaned after tenant deletion: {diff}'
+
+            until.assert_(resources_deleted, tries=5, interval=5)
+
+
+def test_tenant_deletion_with_sync_db():
+    _reset_tenants()
+    tables_rows_count_before_deletion = _count_tables_rows()
+    with _create_tenant_ready_for_deletion() as tenant_uuid:
+        with BaseIntegrationTest.delete_auth_tenant(tenant_uuid):
+            BaseIntegrationTest.sync_db()
+
+            def resources_deleted():
+                tables_rows_count_after_deletion = _count_tables_rows()
+                diff = _diff_tables_rows(
+                    tables_rows_count_before_deletion, tables_rows_count_after_deletion
+                )
+                assert (
+                    len(diff) == 0
+                ), f'Some tables are not properly cleaned after tenant deletion: {diff}'
+
+            until.assert_(resources_deleted, tries=5, interval=5)
+
+
+def _reset_tenants():
+    BaseIntegrationTest.mock_auth.set_tenants(*DEFAULT_TENANTS)
+
+    for t in DEFAULT_TENANTS:
+        BusClient.send_tenant_created(t['uuid'], t['slug'])
+
+    # xivo-manage-db creates a tenant (with a random uuid)
+    # sync_db is called now to remove this tenant
+    BaseIntegrationTest.sync_db()
+
+
+def _count_table_rows(queries: DatabaseQueries, table_name: str) -> int:
+    query = text(f"SELECT COUNT(*) FROM {table_name};")
+    count = queries.connection.execute(query).scalar()
+    return count
+
+
+def _count_tables_rows() -> Dict[str, int]:
+    excluded_tables = [
+        'agentqueueskill',
+        'dialaction',
+        'pickupmember',
+        'func_key',
+        'func_key_dest_custom',
+    ]
+    with db.queries() as queries:
+        query = text(
+            "SELECT tablename FROM pg_catalog.pg_tables WHERE schemaname != 'pg_catalog' AND schemaname != 'information_schema';"
+        )
+        result = queries.connection.execute(query)
+        table_names = set(row.tablename for row in result)
+        tables_counts = {
+            table_name: _count_table_rows(queries, table_name)
+            for table_name in table_names
+            if table_name not in excluded_tables
         }
-        return diff
+    return tables_counts
 
 
-class BaseTestDeleteByEvent(BaseTestTenants):
-    def setUp(self):
-        self.db = db
-        self.excluded_tables = [
-            'agentqueueskill',
-            'dialaction',
-            'pickupmember',
-            'func_key',
-            'func_key_dest_custom',
-        ]
-        BaseIntegrationTest.mock_auth.set_tenants(*DEFAULT_TENANTS)
+def _diff_tables_rows(before: Dict[str, int], after: Dict[str, int]):
+    diff = {
+        table_name: {
+            'before': before[table_name],
+            'after': after[table_name],
+        }
+        for table_name in set(before) | set(after)
+        if before.get(table_name) != after.get(table_name)
+    }
+    return diff
 
-        for t in DEFAULT_TENANTS:
-            BusClient.send_tenant_created(t['uuid'], t['slug'])
 
-        # xivo-manage-db creates a tenant (with a random uuid)
-        # sync_db is called now to remove this tenant
-        BaseIntegrationTest.sync_db()
+@contextmanager
+def _create_tenant_ready_for_deletion():
+    # add the tenant DELETED_TENANT in wazo-auth for the authorization,
+    # to be able to create the tenant in wazo-confd
+    BaseIntegrationTest.mock_auth.set_tenants(*ALL_TENANTS)
 
-        # count before the creation of the DELETED_TENANT
-        self.before_tables_rows_counts = self.count_tables_rows()
+    with ExitStack() as stack:
+        user = stack.enter_context(fixtures.user(wazo_tenant=DELETED_TENANT))
+        group = stack.enter_context(fixtures.group(wazo_tenant=DELETED_TENANT))
+        incall = stack.enter_context(fixtures.incall(wazo_tenant=DELETED_TENANT))
+        outcall = stack.enter_context(fixtures.outcall(wazo_tenant=DELETED_TENANT))
+        conference = stack.enter_context(
+            fixtures.conference(wazo_tenant=DELETED_TENANT)
+        )
+        context = stack.enter_context(
+            fixtures.context(label='mycontext', wazo_tenant=DELETED_TENANT)
+        )
+        stack.enter_context(
+            fixtures.funckey_template(
+                keys={'1': {'destination': {'type': 'custom', 'exten': '123'}}},
+                wazo_tenant=DELETED_TENANT,
+            )
+        )
+        switchboard = stack.enter_context(
+            fixtures.switchboard(wazo_tenant=DELETED_TENANT)
+        )
+        stack.enter_context(fixtures.device(wazo_tenant=DELETED_TENANT))
+        queue = stack.enter_context(fixtures.queue(wazo_tenant=DELETED_TENANT))
+        trunk_sip = stack.enter_context(fixtures.trunk(wazo_tenant=DELETED_TENANT))
+        trunk_iax = stack.enter_context(fixtures.trunk(wazo_tenant=DELETED_TENANT))
+        trunk_custom = stack.enter_context(fixtures.trunk(wazo_tenant=DELETED_TENANT))
+        user_sip = stack.enter_context(
+            fixtures.sip(name='endpoint_sip', wazo_tenant=DELETED_TENANT)
+        )
+        sip = stack.enter_context(
+            fixtures.sip(name='endpoint_sip2', wazo_tenant=DELETED_TENANT)
+        )
+        iax = stack.enter_context(
+            fixtures.iax(name='endpoint_iax', wazo_tenant=DELETED_TENANT)
+        )
+        custom = stack.enter_context(
+            fixtures.custom(interface='endpoint_custom', wazo_tenant=DELETED_TENANT)
+        )
+        agent = stack.enter_context(
+            fixtures.agent(number='5678', wazo_tenant=DELETED_TENANT)
+        )
+        skill = stack.enter_context(fixtures.skill(wazo_tenant=DELETED_TENANT))
+        call_pickup = stack.enter_context(
+            fixtures.call_pickup(wazo_tenant=DELETED_TENANT)
+        )
+        user2 = stack.enter_context(fixtures.user(wazo_tenant=DELETED_TENANT))
+        stack.enter_context(
+            fixtures.call_permission(
+                mode='allow',
+                enabled=True,
+                extensions=[gen_group_exten()],
+                wazo_tenant=DELETED_TENANT,
+            )
+        )
+        stack.enter_context(fixtures.call_filter(wazo_tenant=DELETED_TENANT))
+        schedule = stack.enter_context(fixtures.schedule(wazo_tenant=DELETED_TENANT))
+        trunk = stack.enter_context(fixtures.trunk(wazo_tenant=DELETED_TENANT))
+        stack.enter_context(
+            fixtures.ivr(
+                choices=[{'exten': gen_group_exten(), 'destination': {'type': 'none'}}],
+                wazo_tenant=DELETED_TENANT,
+            )
+        )
 
-        # add the tenant DELETED_TENANT in wazo-auth for the authorization,
-        # to be able to create the tenant in wazo-confd
-        BaseIntegrationTest.mock_auth.set_tenants(*ALL_TENANTS)
-
-    @fixtures.user(wazo_tenant=DELETED_TENANT)
-    @fixtures.group(wazo_tenant=DELETED_TENANT)
-    @fixtures.incall(wazo_tenant=DELETED_TENANT)
-    @fixtures.outcall(wazo_tenant=DELETED_TENANT)
-    @fixtures.conference(wazo_tenant=DELETED_TENANT)
-    @fixtures.context(label='mycontext', wazo_tenant=DELETED_TENANT)
-    @fixtures.funckey_template(
-        keys={'1': {'destination': {'type': 'custom', 'exten': '123'}}},
-        wazo_tenant=DELETED_TENANT,
-    )
-    @fixtures.switchboard(wazo_tenant=DELETED_TENANT)
-    @fixtures.device(wazo_tenant=DELETED_TENANT)
-    @fixtures.queue(wazo_tenant=DELETED_TENANT)
-    @fixtures.trunk(wazo_tenant=DELETED_TENANT)
-    @fixtures.trunk(wazo_tenant=DELETED_TENANT)
-    @fixtures.trunk(wazo_tenant=DELETED_TENANT)
-    @fixtures.sip(name='endpoint_sip', wazo_tenant=DELETED_TENANT)
-    @fixtures.sip(name='endpoint_sip2', wazo_tenant=DELETED_TENANT)
-    @fixtures.iax(name='endpoint_iax', wazo_tenant=DELETED_TENANT)
-    @fixtures.custom(interface='endpoint_custom', wazo_tenant=DELETED_TENANT)
-    @fixtures.agent(number='1234', wazo_tenant=DELETED_TENANT)
-    @fixtures.skill(wazo_tenant=DELETED_TENANT)
-    @fixtures.call_pickup(wazo_tenant=DELETED_TENANT)
-    @fixtures.user(wazo_tenant=DELETED_TENANT)
-    @fixtures.call_permission(
-        mode='allow',
-        enabled=True,
-        extensions=[gen_group_exten()],
-        wazo_tenant=DELETED_TENANT,
-    )
-    @fixtures.call_filter(wazo_tenant=DELETED_TENANT)
-    @fixtures.schedule(wazo_tenant=DELETED_TENANT)
-    @fixtures.trunk(wazo_tenant=DELETED_TENANT)
-    @fixtures.ivr(
-        choices=[{'exten': gen_group_exten(), 'destination': {'type': 'none'}}],
-        wazo_tenant=DELETED_TENANT,
-    )
-    def test_delete_tenant_with_many_resources_by_event(
-        self,
-        user,
-        group,
-        incall,
-        outcall,
-        conference,
-        context,
-        funckey_template,
-        switchboard,
-        device,
-        queue,
-        trunk_sip,
-        trunk_iax,
-        trunk_custom,
-        user_sip,
-        sip,
-        iax,
-        custom,
-        agent,
-        skill,
-        call_pickup,
-        user2,
-        call_permission,
-        call_filter,
-        schedule,
-        trunk,
-        ivr,
-    ):
         confd.users(user['uuid']).funckeys('1').put(
             {
                 'destination': {
@@ -206,224 +247,57 @@ class BaseTestDeleteByEvent(BaseTestTenants):
             }
         )
 
-        @fixtures.voicemail(context=context['name'], wazo_tenant=DELETED_TENANT)
-        @fixtures.line_sip(
-            context={'name': context['name']}, wazo_tenant=DELETED_TENANT
+        voicemail = stack.enter_context(
+            fixtures.voicemail(context=context['name'], wazo_tenant=DELETED_TENANT)
         )
-        @fixtures.extension(exten=gen_group_exten(), context=context['name'])
-        @fixtures.extension(exten=gen_line_exten(), context=context['name'])
-        @fixtures.extension(exten=gen_line_exten(), context=context['name'])
-        @fixtures.funckey_template(
-            keys={
-                '1': {
-                    'destination': {
-                        'type': 'conference',
-                        'conference_id': conference['id'],
+        line = stack.enter_context(
+            fixtures.line_sip(
+                context={'name': context['name']}, wazo_tenant=DELETED_TENANT
+            )
+        )
+        group_extension = stack.enter_context(
+            fixtures.extension(exten=gen_group_exten(), context=context['name'])
+        )
+        incall_extension = stack.enter_context(
+            fixtures.extension(exten=gen_line_exten(), context=context['name'])
+        )
+        outcall_extension = stack.enter_context(
+            fixtures.extension(exten=gen_line_exten(), context=context['name'])
+        )
+        stack.enter_context(
+            fixtures.funckey_template(
+                keys={
+                    '1': {
+                        'destination': {
+                            'type': 'conference',
+                            'conference_id': conference['id'],
+                        }
                     }
-                }
-            },
-            wazo_tenant=DELETED_TENANT,
+                },
+                wazo_tenant=DELETED_TENANT,
+            )
         )
-        def aux(
-            voicemail,
-            line,
-            group_extension,
-            incall_extension,
-            outcall_extension,
-            funckey_template_conference,
-        ):
-            with (
-                a.user_line(user, line, check=False),
-                a.line_endpoint_sip(line, user_sip, check=False),
-                a.user_voicemail(user, voicemail, check=False),
-                a.switchboard_member_user(switchboard, [user], check=False),
-                a.group_extension(group, group_extension, check=False),
-                a.user_agent(user, agent, check=False),
-                a.queue_member_agent(queue, agent, check=False),
-                a.agent_skill(agent, skill, check=False),
-                a.incall_extension(incall, incall_extension, check=False),
-                a.outcall_extension(outcall, outcall_extension, check=False),
-                a.group_member_user(group, user, check=False),
-                a.trunk_endpoint_sip(trunk_sip, sip, check=False),
-                a.trunk_endpoint_iax(trunk_iax, iax, check=False),
-                a.trunk_endpoint_custom(trunk_custom, custom, check=False),
-                a.call_pickup_interceptor_user(call_pickup, user, check=False),
-                a.call_pickup_target_user(call_pickup, user2, check=False),
-                a.incall_schedule(incall, schedule, check=False),
-                a.outcall_trunk(outcall, trunk, check=False),
-            ):
-                BusClient.send_tenant_deleted(DELETED_TENANT, 'slug2')
-
-                def resources_deleted():
-                    after_deletion_tables_rows_counts = self.count_tables_rows()
-                    diff = self.diff(after_deletion_tables_rows_counts)
-                    assert (
-                        len(diff) == 0
-                    ), f'Some tables are not properly cleaned after tenant deletion: {diff}'
-
-                until.assert_(resources_deleted, tries=5, interval=5)
-
-        aux()
-
-
-class BaseTestDeleteBySyncDb(BaseTestTenants):
-    def setUp(self):
-        self.db = db
-        self.excluded_tables = [
-            'agentqueueskill',
-            'dialaction',
-            'pickupmember',
-            'func_key',
-            'func_key_dest_custom',
-        ]
-
-        BaseIntegrationTest.mock_auth.set_tenants(*DEFAULT_TENANTS)
-
-        for t in DEFAULT_TENANTS:
-            BusClient.send_tenant_created(t['uuid'], t['slug'])
-
-        # xivo-manage-db creates a tenant (with a random uuid)
-        # sync_db is called now to remove this tenant
-        BaseIntegrationTest.sync_db()
-
-        # count before the creation of the DELETED_TENANT
-        self.before_tables_rows_counts = self.count_tables_rows()
-
-        # add the tenant DELETED_TENANT in wazo-auth for the authorization,
-        # to be able to create the tenant in wazo-confd
-        BaseIntegrationTest.mock_auth.set_tenants(*ALL_TENANTS)
-
-    @fixtures.user(wazo_tenant=DELETED_TENANT)
-    @fixtures.group(wazo_tenant=DELETED_TENANT)
-    @fixtures.incall(wazo_tenant=DELETED_TENANT)
-    @fixtures.outcall(wazo_tenant=DELETED_TENANT)
-    @fixtures.conference(wazo_tenant=DELETED_TENANT)
-    @fixtures.context(label='mycontext', wazo_tenant=DELETED_TENANT)
-    @fixtures.funckey_template(
-        keys={'1': {'destination': {'type': 'custom', 'exten': '123'}}},
-        wazo_tenant=DELETED_TENANT,
-    )
-    @fixtures.switchboard(wazo_tenant=DELETED_TENANT)
-    @fixtures.device(wazo_tenant=DELETED_TENANT)
-    @fixtures.queue(wazo_tenant=DELETED_TENANT)
-    @fixtures.trunk(wazo_tenant=DELETED_TENANT)
-    @fixtures.trunk(wazo_tenant=DELETED_TENANT)
-    @fixtures.trunk(wazo_tenant=DELETED_TENANT)
-    @fixtures.sip(name='endpoint_sip', wazo_tenant=DELETED_TENANT)
-    @fixtures.sip(name='endpoint_sip2', wazo_tenant=DELETED_TENANT)
-    @fixtures.iax(name='endpoint_iax', wazo_tenant=DELETED_TENANT)
-    @fixtures.custom(interface='endpoint_custom', wazo_tenant=DELETED_TENANT)
-    @fixtures.agent(number='5678', wazo_tenant=DELETED_TENANT)
-    @fixtures.skill(wazo_tenant=DELETED_TENANT)
-    @fixtures.call_pickup(wazo_tenant=DELETED_TENANT)
-    @fixtures.user(wazo_tenant=DELETED_TENANT)
-    @fixtures.call_permission(
-        mode='allow',
-        enabled=True,
-        extensions=[gen_group_exten()],
-        wazo_tenant=DELETED_TENANT,
-    )
-    @fixtures.call_filter(wazo_tenant=DELETED_TENANT)
-    @fixtures.schedule(wazo_tenant=DELETED_TENANT)
-    @fixtures.trunk(wazo_tenant=DELETED_TENANT)
-    @fixtures.ivr(
-        choices=[{'exten': gen_group_exten(), 'destination': {'type': 'none'}}],
-        wazo_tenant=DELETED_TENANT,
-    )
-    def test_delete_tenant_with_many_resources_by_syncdb(
-        self,
-        user,
-        group,
-        incall,
-        outcall,
-        conference,
-        context,
-        funckey_template,
-        switchboard,
-        device,
-        queue,
-        trunk_sip,
-        trunk_iax,
-        trunk_custom,
-        user_sip,
-        sip,
-        iax,
-        custom,
-        agent,
-        skill,
-        call_pickup,
-        user2,
-        call_permission,
-        call_filter,
-        schedule,
-        trunk,
-        ivr,
-    ):
-        confd.users(user['uuid']).funckeys('1').put(
-            {
-                'destination': {
-                    'type': 'conference',
-                    'conference_id': conference['id'],
-                }
-            }
+        stack.enter_context(a.user_line(user, line, check=False))
+        stack.enter_context(a.line_endpoint_sip(line, user_sip, check=False))
+        stack.enter_context(a.user_voicemail(user, voicemail, check=False))
+        stack.enter_context(a.switchboard_member_user(switchboard, [user], check=False))
+        stack.enter_context(a.group_extension(group, group_extension, check=False))
+        stack.enter_context(a.user_agent(user, agent, check=False))
+        stack.enter_context(a.queue_member_agent(queue, agent, check=False))
+        stack.enter_context(a.agent_skill(agent, skill, check=False))
+        stack.enter_context(a.incall_extension(incall, incall_extension, check=False))
+        stack.enter_context(
+            a.outcall_extension(outcall, outcall_extension, check=False)
         )
-
-        @fixtures.voicemail(context=context['name'], wazo_tenant=DELETED_TENANT)
-        @fixtures.line_sip(
-            context={'name': context['name']}, wazo_tenant=DELETED_TENANT
+        stack.enter_context(a.group_member_user(group, user, check=False))
+        stack.enter_context(a.trunk_endpoint_sip(trunk_sip, sip, check=False))
+        stack.enter_context(a.trunk_endpoint_iax(trunk_iax, iax, check=False))
+        stack.enter_context(a.trunk_endpoint_custom(trunk_custom, custom, check=False))
+        stack.enter_context(
+            a.call_pickup_interceptor_user(call_pickup, user, check=False)
         )
-        @fixtures.extension(exten=gen_group_exten(), context=context['name'])
-        @fixtures.extension(exten=gen_line_exten(), context=context['name'])
-        @fixtures.extension(exten=gen_line_exten(), context=context['name'])
-        @fixtures.funckey_template(
-            keys={
-                '1': {
-                    'destination': {
-                        'type': 'conference',
-                        'conference_id': conference['id'],
-                    }
-                }
-            },
-            wazo_tenant=DELETED_TENANT,
-        )
-        def aux(
-            voicemail,
-            line,
-            group_extension,
-            incall_extension,
-            outcall_extension,
-            funckey_template_conference,
-        ):
-            with (
-                a.user_line(user, line, check=False),
-                a.line_endpoint_sip(line, user_sip, check=False),
-                a.user_voicemail(user, voicemail, check=False),
-                a.switchboard_member_user(switchboard, [user], check=False),
-                a.group_extension(group, group_extension, check=False),
-                a.user_agent(user, agent, check=False),
-                a.queue_member_agent(queue, agent, check=False),
-                a.agent_skill(agent, skill, check=False),
-                a.incall_extension(incall, incall_extension, check=False),
-                a.outcall_extension(outcall, outcall_extension, check=False),
-                a.group_member_user(group, user, check=False),
-                a.trunk_endpoint_sip(trunk_sip, sip, check=False),
-                a.trunk_endpoint_iax(trunk_iax, iax, check=False),
-                a.trunk_endpoint_custom(trunk_custom, custom, check=False),
-                a.call_pickup_interceptor_user(call_pickup, user, check=False),
-                a.call_pickup_target_user(call_pickup, user2, check=False),
-                a.incall_schedule(incall, schedule, check=False),
-                a.outcall_trunk(outcall, trunk, check=False),
-            ):
-                with BaseIntegrationTest.delete_auth_tenant(DELETED_TENANT):
-                    BaseIntegrationTest.sync_db()
+        stack.enter_context(a.call_pickup_target_user(call_pickup, user2, check=False))
+        stack.enter_context(a.incall_schedule(incall, schedule, check=False))
+        stack.enter_context(a.outcall_trunk(outcall, trunk, check=False))
 
-                    def resources_deleted():
-                        after_deletion_tables_rows_counts = self.count_tables_rows()
-                        diff = self.diff(after_deletion_tables_rows_counts)
-                        assert (
-                            len(diff) == 0
-                        ), f'Some tables are not properly cleaned after tenant deletion: {diff}'
-
-                    until.assert_(resources_deleted, tries=5, interval=5)
-
-        aux()
+        yield DELETED_TENANT

--- a/integration_tests/suite/base/test_trunk_endpoint_custom.py
+++ b/integration_tests/suite/base/test_trunk_endpoint_custom.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import assert_that, has_entries
@@ -16,8 +16,8 @@ def test_associate_errors(trunk, custom):
     fake_trunk = confd.trunks(FAKE_ID).endpoints.custom(custom['id']).put
     fake_custom = confd.trunks(trunk['id']).endpoints.custom(FAKE_ID).put
 
-    yield s.check_resource_not_found, fake_trunk, 'Trunk'
-    yield s.check_resource_not_found, fake_custom, 'CustomEndpoint'
+    s.check_resource_not_found(fake_trunk, 'Trunk')
+    s.check_resource_not_found(fake_custom, 'CustomEndpoint')
 
 
 @fixtures.trunk()
@@ -26,8 +26,8 @@ def test_dissociate_errors(trunk, custom):
     fake_trunk = confd.trunks(FAKE_ID).endpoints.custom(custom['id']).delete
     fake_custom = confd.trunks(trunk['id']).endpoints.custom(FAKE_ID).delete
 
-    yield s.check_resource_not_found, fake_trunk, 'Trunk'
-    yield s.check_resource_not_found, fake_custom, 'CustomEndpoint'
+    s.check_resource_not_found(fake_trunk, 'Trunk')
+    s.check_resource_not_found(fake_custom, 'CustomEndpoint')
 
 
 @fixtures.trunk()
@@ -174,8 +174,8 @@ def test_delete_trunk_when_trunk_and_endpoint_associated(trunk, custom):
 
         deleted_trunk = confd.trunks(trunk['id']).get
         deleted_custom = confd.endpoints.custom(custom['id']).get
-        yield s.check_resource_not_found, deleted_trunk, 'Trunk'
-        yield s.check_resource_not_found, deleted_custom, 'CustomEndpoint'
+        s.check_resource_not_found(deleted_trunk, 'Trunk')
+        s.check_resource_not_found(deleted_custom, 'CustomEndpoint')
 
 
 @fixtures.trunk()
@@ -194,5 +194,5 @@ def test_bus_events(trunk, custom):
     url = confd.trunks(trunk['id']).endpoints.custom(custom['id'])
     headers = {'tenant_uuid': trunk['tenant_uuid']}
 
-    yield s.check_event, 'trunk_endpoint_custom_associated', headers, url.put
-    yield s.check_event, 'trunk_endpoint_custom_dissociated', headers, url.delete
+    s.check_event('trunk_endpoint_custom_associated', headers, url.put)
+    s.check_event('trunk_endpoint_custom_dissociated', headers, url.delete)

--- a/integration_tests/suite/base/test_trunk_endpoint_iax.py
+++ b/integration_tests/suite/base/test_trunk_endpoint_iax.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import assert_that, has_entries, none
@@ -17,8 +17,8 @@ def test_associate_errors(trunk, iax):
     fake_trunk = confd.trunks(FAKE_ID).endpoints.iax(iax['id']).put
     fake_iax = confd.trunks(trunk['id']).endpoints.iax(FAKE_ID).put
 
-    yield s.check_resource_not_found, fake_trunk, 'Trunk'
-    yield s.check_resource_not_found, fake_iax, 'IAXEndpoint'
+    s.check_resource_not_found(fake_trunk, 'Trunk')
+    s.check_resource_not_found(fake_iax, 'IAXEndpoint')
 
 
 @fixtures.trunk()
@@ -27,8 +27,8 @@ def test_dissociate_errors(trunk, iax):
     fake_trunk = confd.trunks(FAKE_ID).endpoints.iax(iax['id']).delete
     fake_iax = confd.trunks(trunk['id']).endpoints.iax(FAKE_ID).delete
 
-    yield s.check_resource_not_found, fake_trunk, 'Trunk'
-    yield s.check_resource_not_found, fake_iax, 'IAXEndpoint'
+    s.check_resource_not_found(fake_trunk, 'Trunk')
+    s.check_resource_not_found(fake_iax, 'IAXEndpoint')
 
 
 @fixtures.trunk()
@@ -153,8 +153,8 @@ def test_delete_trunk_when_trunk_and_endpoint_associated(trunk, iax):
 
         deleted_trunk = confd.trunks(trunk['id']).get
         deleted_iax = confd.endpoints.iax(iax['id']).get
-        yield s.check_resource_not_found, deleted_trunk, 'Trunk'
-        yield s.check_resource_not_found, deleted_iax, 'IAXEndpoint'
+        s.check_resource_not_found(deleted_trunk, 'Trunk')
+        s.check_resource_not_found(deleted_iax, 'IAXEndpoint')
 
 
 @fixtures.trunk()
@@ -173,5 +173,5 @@ def test_bus_events(trunk, iax):
     url = confd.trunks(trunk['id']).endpoints.iax(iax['id'])
     headers = {'tenant_uuid': trunk['tenant_uuid']}
 
-    yield s.check_event, 'trunk_endpoint_iax_associated', headers, url.put
-    yield s.check_event, 'trunk_endpoint_iax_dissociated', headers, url.delete
+    s.check_event('trunk_endpoint_iax_associated', headers, url.put)
+    s.check_event('trunk_endpoint_iax_dissociated', headers, url.delete)

--- a/integration_tests/suite/base/test_trunk_endpoint_sip.py
+++ b/integration_tests/suite/base/test_trunk_endpoint_sip.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import assert_that, has_entries, contains
@@ -17,8 +17,8 @@ def test_associate_errors(trunk, sip):
     fake_trunk = confd.trunks(FAKE_ID).endpoints.sip(sip['uuid']).put
     fake_sip = confd.trunks(trunk['id']).endpoints.sip(FAKE_UUID).put
 
-    yield s.check_resource_not_found, fake_trunk, 'Trunk'
-    yield s.check_resource_not_found, fake_sip, 'SIPEndpoint'
+    s.check_resource_not_found(fake_trunk, 'Trunk')
+    s.check_resource_not_found(fake_sip, 'SIPEndpoint')
 
 
 @fixtures.trunk()
@@ -27,8 +27,8 @@ def test_dissociate_errors(trunk, sip):
     fake_trunk = confd.trunks(FAKE_ID).endpoints.sip(sip['uuid']).delete
     fake_sip = confd.trunks(trunk['id']).endpoints.sip(FAKE_UUID).delete
 
-    yield s.check_resource_not_found, fake_trunk, 'Trunk'
-    yield s.check_resource_not_found, fake_sip, 'SIPEndpoint'
+    s.check_resource_not_found(fake_trunk, 'Trunk')
+    s.check_resource_not_found(fake_sip, 'SIPEndpoint')
 
 
 @fixtures.trunk()
@@ -188,8 +188,8 @@ def test_delete_trunk_when_trunk_and_endpoint_associated(trunk, sip):
 
         deleted_trunk = confd.trunks(trunk['id']).get
         deleted_sip = confd.endpoints.sip(sip['uuid']).get
-        yield s.check_resource_not_found, deleted_trunk, 'Trunk'
-        yield s.check_resource_not_found, deleted_sip, 'SIPEndpoint'
+        s.check_resource_not_found(deleted_trunk, 'Trunk')
+        s.check_resource_not_found(deleted_sip, 'SIPEndpoint')
 
 
 @fixtures.trunk()
@@ -208,5 +208,5 @@ def test_bus_events(trunk, sip):
     url = confd.trunks(trunk['id']).endpoints.sip(sip['uuid'])
     headers = {'tenant_uuid': trunk['tenant_uuid']}
 
-    yield s.check_event, 'trunk_endpoint_sip_associated', headers, url.put
-    yield s.check_event, 'trunk_endpoint_sip_dissociated', headers, url.delete
+    s.check_event('trunk_endpoint_sip_associated', headers, url.put)
+    s.check_event('trunk_endpoint_sip_dissociated', headers, url.delete)

--- a/integration_tests/suite/base/test_trunk_register_iax.py
+++ b/integration_tests/suite/base/test_trunk_register_iax.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import assert_that, has_entries, none
@@ -15,8 +15,8 @@ def test_associate_errors(trunk, register):
     fake_trunk = confd.trunks(FAKE_ID).registers.iax(register['id']).put
     fake_register = confd.trunks(trunk['id']).registers.iax(FAKE_ID).put
 
-    yield s.check_resource_not_found, fake_trunk, 'Trunk'
-    yield s.check_resource_not_found, fake_register, 'IAXRegister'
+    s.check_resource_not_found(fake_trunk, 'Trunk')
+    s.check_resource_not_found(fake_register, 'IAXRegister')
 
 
 @fixtures.trunk()
@@ -25,8 +25,8 @@ def test_dissociate_errors(trunk, register):
     fake_trunk = confd.trunks(FAKE_ID).registers.iax(register['id']).delete
     fake_register = confd.trunks(trunk['id']).registers.iax(FAKE_ID).delete
 
-    yield s.check_resource_not_found, fake_trunk, 'Trunk'
-    yield s.check_resource_not_found, fake_register, 'IAXRegister'
+    s.check_resource_not_found(fake_trunk, 'Trunk')
+    s.check_resource_not_found(fake_register, 'IAXRegister')
 
 
 @fixtures.trunk()
@@ -121,8 +121,8 @@ def test_delete_trunk_when_trunk_and_register_associated(trunk, register):
 
         deleted_trunk = confd.trunks(trunk['id']).get
         deleted_register = confd.registers.iax(register['id']).get
-        yield s.check_resource_not_found, deleted_trunk, 'Trunk'
-        yield s.check_resource_not_found, deleted_register, 'IAXRegister'
+        s.check_resource_not_found(deleted_trunk, 'Trunk')
+        s.check_resource_not_found(deleted_register, 'IAXRegister')
 
 
 @fixtures.trunk()
@@ -141,5 +141,5 @@ def test_bus_events(trunk, register):
     url = confd.trunks(trunk['id']).registers.iax(register['id'])
     headers = {'tenant_uuid': trunk['tenant_uuid']}
 
-    yield s.check_event, 'trunk_register_iax_associated', headers, url.put
-    yield s.check_event, 'trunk_register_iax_dissociated', headers, url.delete
+    s.check_event('trunk_register_iax_associated', headers, url.put)
+    s.check_event('trunk_register_iax_dissociated', headers, url.delete)

--- a/integration_tests/suite/base/test_trunks.py
+++ b/integration_tests/suite/base/test_trunks.py
@@ -26,35 +26,33 @@ from ..helpers.config import MAIN_TENANT, SUB_TENANT
 
 def test_get_errors():
     fake_trunk = confd.trunks(999999).get
-    yield s.check_resource_not_found, fake_trunk, 'Trunk'
+    s.check_resource_not_found(fake_trunk, 'Trunk')
 
 
 def test_delete_errors():
     fake_trunk = confd.trunks(999999).delete
-    yield s.check_resource_not_found, fake_trunk, 'Trunk'
+    s.check_resource_not_found(fake_trunk, 'Trunk')
 
 
 def test_post_errors():
     url = confd.trunks.post
-    for check in error_checks(url):
-        yield check
+    error_checks(url)
 
 
 @fixtures.trunk()
 def test_put_errors(trunk):
     url = confd.trunks(trunk['id']).put
-    for check in error_checks(url):
-        yield check
+    error_checks(url)
 
 
 def error_checks(url):
-    yield s.check_bogus_field_returns_error, url, 'context', 123
-    yield s.check_bogus_field_returns_error, url, 'context', []
-    yield s.check_bogus_field_returns_error, url, 'context', {}
-    yield s.check_bogus_field_returns_error, url, 'context', 'invalid'
-    yield s.check_bogus_field_returns_error, url, 'twilio_incoming', 123
-    yield s.check_bogus_field_returns_error, url, 'twilio_incoming', []
-    yield s.check_bogus_field_returns_error, url, 'twilio_incoming', {}
+    s.check_bogus_field_returns_error(url, 'context', 123)
+    s.check_bogus_field_returns_error(url, 'context', [])
+    s.check_bogus_field_returns_error(url, 'context', {})
+    s.check_bogus_field_returns_error(url, 'context', 'invalid')
+    s.check_bogus_field_returns_error(url, 'twilio_incoming', 123)
+    s.check_bogus_field_returns_error(url, 'twilio_incoming', [])
+    s.check_bogus_field_returns_error(url, 'twilio_incoming', {})
 
 
 @fixtures.context(label='search')
@@ -71,22 +69,22 @@ def test_search(search_ctx, hidden_ctx, sip, iax, custom):
         searches = {'context': search_ctx['name']}
 
         for field, term in searches.items():
-            yield check_search, url, trunk, hidden, field, term
+            check_search(url, trunk, hidden, field, term)
 
         searches = {'name': 'name_search', 'label': 'label_search'}
         with a.trunk_endpoint_sip(trunk, sip):
             for field, term in searches.items():
-                yield check_relation_search, url, trunk, hidden, field, term
+                check_relation_search(url, trunk, hidden, field, term)
 
         searches = {'name': 'name_search'}
         with a.trunk_endpoint_iax(trunk, iax):
             for field, term in searches.items():
-                yield check_relation_search, url, trunk, hidden, field, term
+                check_relation_search(url, trunk, hidden, field, term)
 
         searches = {'name': 'name_search'}
         with a.trunk_endpoint_custom(trunk, custom):
             for field, term in searches.items():
-                yield check_relation_search, url, trunk, hidden, field, term
+                check_relation_search(url, trunk, hidden, field, term)
 
 
 def check_search(url, trunk, hidden, field, term):

--- a/integration_tests/suite/base/test_user_agent.py
+++ b/integration_tests/suite/base/test_user_agent.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import assert_that, contains_inanyorder, empty, has_entries, not_
@@ -16,15 +16,15 @@ def test_associate_errors(agent, user):
     fake_user = confd.users(FAKE_ID).agents(agent['id']).put
     fake_agent = confd.users(user['id']).agents(FAKE_ID).put
 
-    yield s.check_resource_not_found, fake_user, 'User'
-    yield s.check_resource_not_found, fake_agent, 'Agent'
+    s.check_resource_not_found(fake_user, 'User')
+    s.check_resource_not_found(fake_agent, 'Agent')
 
 
 @fixtures.user()
 def test_dissociate_errors(user):
     fake_user = confd.users(FAKE_ID).agents().delete
 
-    yield s.check_resource_not_found, fake_user, 'User'
+    s.check_resource_not_found(fake_user, 'User')
 
 
 @fixtures.agent()
@@ -168,7 +168,7 @@ def test_bus_events(agent, user):
     }
 
     url = confd.users(user['id']).agents(agent['id']).put
-    yield s.check_event, 'user_agent_associated', headers, url
+    s.check_event('user_agent_associated', headers, url)
 
     url = confd.users(user['id']).agents.delete
-    yield s.check_event, 'user_agent_dissociated', headers, url
+    s.check_event('user_agent_dissociated', headers, url)

--- a/integration_tests/suite/base/test_user_call_permission.py
+++ b/integration_tests/suite/base/test_user_call_permission.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2020 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import assert_that, contains, empty, has_entries, not_
@@ -21,8 +21,8 @@ def test_associate_errors(user, call_permission):
     fake_user = confd.users(FAKE_ID).callpermissions(call_permission['id']).put
     fake_call_permission = confd.users(user['id']).callpermissions(FAKE_ID).put
 
-    yield s.check_resource_not_found, fake_user, 'User'
-    yield s.check_resource_not_found, fake_call_permission, 'CallPermission'
+    s.check_resource_not_found(fake_user, 'User')
+    s.check_resource_not_found(fake_call_permission, 'CallPermission')
 
 
 @fixtures.user()
@@ -31,8 +31,8 @@ def test_dissociate_errors(user, call_permission):
     fake_user = confd.users(FAKE_ID).callpermissions(call_permission['id']).delete
     fake_call_permission = confd.users(user['id']).callpermissions(FAKE_ID).delete
 
-    yield s.check_resource_not_found, fake_user, 'User'
-    yield s.check_resource_not_found, fake_call_permission, 'CallPermission'
+    s.check_resource_not_found(fake_user, 'User')
+    s.check_resource_not_found(fake_call_permission, 'CallPermission')
 
 
 @fixtures.user()

--- a/integration_tests/suite/base/test_user_external_apps.py
+++ b/integration_tests/suite/base/test_user_external_apps.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2020-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import json
@@ -22,45 +22,43 @@ from ..helpers.config import MAIN_TENANT, SUB_TENANT
 @fixtures.user()
 def test_get_errors(user):
     fake_app = confd.users(user['uuid']).external.apps('invalid').get
-    yield s.check_resource_not_found, fake_app, 'UserExternalApp'
+    s.check_resource_not_found(fake_app, 'UserExternalApp')
 
 
 @fixtures.user()
 def test_delete_errors(user):
     fake_app = confd.users(user['uuid']).external.apps('invalid').delete
-    yield s.check_resource_not_found, fake_app, 'UserExternalApp'
+    s.check_resource_not_found(fake_app, 'UserExternalApp')
 
 
 @fixtures.user_external_app(name='unique')
 def test_post_errors(app):
     url = confd.users(app['user_uuid']).external.apps('myapp').post
-    for check in error_checks(url):
-        yield check
+    error_checks(url)
 
     url = confd.users(app['user_uuid']).external.apps(s.random_string(129)).post
-    yield s.check_bogus_field_returns_error, url, 'name', s.random_string(129)
+    s.check_bogus_field_returns_error(url, 'name', s.random_string(129))
 
     url = confd.users(app['user_uuid']).external.apps(app['name']).post
-    yield s.check_bogus_field_returns_error, url, 'name', app['name']
+    s.check_bogus_field_returns_error(url, 'name', app['name'])
 
 
 @fixtures.user_external_app()
 def test_put_errors(app):
     url = confd.users(app['user_uuid']).external.apps(app['name']).put
-    for check in error_checks(url):
-        yield check
+    error_checks(url)
 
 
 def error_checks(url):
-    yield s.check_bogus_field_returns_error, url, 'label', True
-    yield s.check_bogus_field_returns_error, url, 'label', 1234
-    yield s.check_bogus_field_returns_error, url, 'label', s.random_string(257)
-    yield s.check_bogus_field_returns_error, url, 'label', []
-    yield s.check_bogus_field_returns_error, url, 'label', {}
-    yield s.check_bogus_field_returns_error, url, 'configuration', True
-    yield s.check_bogus_field_returns_error, url, 'configuration', json.dumps('invalid')
-    yield s.check_bogus_field_returns_error, url, 'configuration', json.dumps(1234)
-    yield s.check_bogus_field_returns_error, url, 'configuration', []
+    s.check_bogus_field_returns_error(url, 'label', True)
+    s.check_bogus_field_returns_error(url, 'label', 1234)
+    s.check_bogus_field_returns_error(url, 'label', s.random_string(257))
+    s.check_bogus_field_returns_error(url, 'label', [])
+    s.check_bogus_field_returns_error(url, 'label', {})
+    s.check_bogus_field_returns_error(url, 'configuration', True)
+    s.check_bogus_field_returns_error(url, 'configuration', json.dumps('invalid'))
+    s.check_bogus_field_returns_error(url, 'configuration', json.dumps(1234))
+    s.check_bogus_field_returns_error(url, 'configuration', [])
 
 
 @fixtures.user_external_app(wazo_tenant=MAIN_TENANT)
@@ -87,7 +85,7 @@ def test_search(user):
         searches = {'name': 'search'}
 
         for field, term in searches.items():
-            yield check_search, url, external_app, hidden, field, term
+            check_search(url, external_app, hidden, field, term)
 
 
 def check_search(url, external_app, hidden, field, term):
@@ -111,9 +109,9 @@ def test_sort_offset_limit(user):
         )
 
         url = confd.users(user['uuid']).external.apps.get
-        yield s.check_sorting, url, external_app1, external_app2, 'name', 'sort', 'name'
-        yield s.check_offset, url, external_app1, external_app2, 'name', 'sort', 'name'
-        yield s.check_limit, url, external_app1, external_app2, 'name', 'sort', 'name'
+        s.check_sorting(url, external_app1, external_app2, 'name', 'sort', 'name')
+        s.check_offset(url, external_app1, external_app2, 'name', 'sort', 'name')
+        s.check_limit(url, external_app1, external_app2, 'name', 'sort', 'name')
 
 
 @fixtures.user()
@@ -310,6 +308,6 @@ def test_bus_events(user):
     url = confd.users(user['uuid']).external.apps('myapp')
     headers = {'tenant_uuid': user['tenant_uuid']}
 
-    yield s.check_event, 'user_external_app_created', headers, url.post
-    yield s.check_event, 'user_external_app_edited', headers, url.put
-    yield s.check_event, 'user_external_app_deleted', headers, url.delete
+    s.check_event('user_external_app_created', headers, url.post)
+    s.check_event('user_external_app_edited', headers, url.put)
+    s.check_event('user_external_app_deleted', headers, url.delete)

--- a/integration_tests/suite/base/test_user_fallback.py
+++ b/integration_tests/suite/base/test_user_fallback.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import assert_that, has_entries
@@ -13,17 +13,16 @@ FAKE_ID = 999999999
 
 def test_get_errors():
     fake_user = confd.users(FAKE_ID).fallbacks.get
-    yield s.check_resource_not_found, fake_user, 'User'
+    s.check_resource_not_found(fake_user, 'User')
 
 
 @fixtures.user()
 def test_put_errors(user):
     fake_user = confd.users(FAKE_ID).fallbacks.put
-    yield s.check_resource_not_found, fake_user, 'User'
+    s.check_resource_not_found(fake_user, 'User')
 
     url = confd.users(user['uuid']).fallbacks.put
-    for check in error_checks(url, user):
-        yield check
+    error_checks(url, user)
 
 
 def error_checks(url, user):
@@ -36,13 +35,19 @@ def error_checks(url, user):
 
     for destination_type in destination_types:
         for destination in invalid_destinations():
-            yield s.check_bogus_field_returns_error, url, destination_type, destination
+            s.check_bogus_field_returns_error(url, destination_type, destination)
 
-        yield s.check_bogus_field_returns_error, url, destination_type, {
-            'type': 'user',
-            'user_id': user['id'],
-            'moh_uuid': '00000000-0000-0000-0000-000000000000',
-        }, {}, 'MOH was not found'
+        s.check_bogus_field_returns_error(
+            url,
+            destination_type,
+            {
+                'type': 'user',
+                'user_id': user['id'],
+                'moh_uuid': '00000000-0000-0000-0000-000000000000',
+            },
+            {},
+            'MOH was not found',
+        )
 
 
 @fixtures.user()
@@ -141,7 +146,7 @@ def test_edit_to_none(user):
 @fixtures.moh()
 def test_valid_destinations(user, *destinations):
     for destination in valid_destinations(*destinations):
-        yield _update_user_fallbacks_with_destination, user['uuid'], destination
+        _update_user_fallbacks_with_destination(user['uuid'], destination)
 
 
 def _update_user_fallbacks_with_destination(user_id, destination):
@@ -193,17 +198,17 @@ def test_nonexistent_destinations(user):
             'voicemail',
             'conference',
         ):
-            yield _update_user_fallbacks_with_nonexistent_destination, user[
-                'uuid'
-            ], destination
+            _update_user_fallbacks_with_nonexistent_destination(
+                user['uuid'], destination
+            )
 
         if (
             destination['type'] == 'application'
             and destination['application'] == 'custom'
         ):
-            yield _update_user_fallbacks_with_nonexistent_destination, user[
-                'uuid'
-            ], destination
+            _update_user_fallbacks_with_nonexistent_destination(
+                user['uuid'], destination
+            )
 
 
 def _update_user_fallbacks_with_nonexistent_destination(user_id, destination):
@@ -221,7 +226,7 @@ def test_bus_events(user):
     url = confd.users(user['uuid']).fallbacks.put
     headers = {'tenant_uuid': user['tenant_uuid']}
 
-    yield s.check_event, 'user_fallback_edited', headers, url
+    s.check_event('user_fallback_edited', headers, url)
 
 
 @fixtures.user(

--- a/integration_tests/suite/base/test_user_group.py
+++ b/integration_tests/suite/base/test_user_group.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import assert_that, contains_inanyorder, has_entries
@@ -21,23 +21,22 @@ def test_associate_errors(group, user):
     response.assert_status(404)
 
     url = confd.users(user['uuid']).groups.put
-    for check in error_checks(url):
-        yield check
+    error_checks(url)
 
 
 def error_checks(url):
-    yield s.check_bogus_field_returns_error, url, 'groups', 123
-    yield s.check_bogus_field_returns_error, url, 'groups', None
-    yield s.check_bogus_field_returns_error, url, 'groups', True
-    yield s.check_bogus_field_returns_error, url, 'groups', 'string'
-    yield s.check_bogus_field_returns_error, url, 'groups', [123]
-    yield s.check_bogus_field_returns_error, url, 'groups', [None]
-    yield s.check_bogus_field_returns_error, url, 'groups', ['string']
-    yield s.check_bogus_field_returns_error, url, 'groups', [{}]
-    yield s.check_bogus_field_returns_error, url, 'groups', [{'id': None}]
-    yield s.check_bogus_field_returns_error, url, 'groups', [{'id': 1}, {'uuid': None}]
-    yield s.check_bogus_field_returns_error, url, 'groups', [{'not_id': 123}]
-    yield s.check_bogus_field_returns_error, url, 'groups', [{'id': FAKE_UUID}]
+    s.check_bogus_field_returns_error(url, 'groups', 123)
+    s.check_bogus_field_returns_error(url, 'groups', None)
+    s.check_bogus_field_returns_error(url, 'groups', True)
+    s.check_bogus_field_returns_error(url, 'groups', 'string')
+    s.check_bogus_field_returns_error(url, 'groups', [123])
+    s.check_bogus_field_returns_error(url, 'groups', [None])
+    s.check_bogus_field_returns_error(url, 'groups', ['string'])
+    s.check_bogus_field_returns_error(url, 'groups', [{}])
+    s.check_bogus_field_returns_error(url, 'groups', [{'id': None}])
+    s.check_bogus_field_returns_error(url, 'groups', [{'id': 1}, {'uuid': None}])
+    s.check_bogus_field_returns_error(url, 'groups', [{'not_id': 123}])
+    s.check_bogus_field_returns_error(url, 'groups', [{'id': FAKE_UUID}])
 
 
 @fixtures.group()
@@ -136,4 +135,4 @@ def test_bus_events(group, user, line):
             f'user_uuid:{user["uuid"]}': True,
         }
 
-        yield s.check_event, 'user_groups_associated', headers, url, body
+        s.check_event('user_groups_associated', headers, url, body)

--- a/integration_tests/suite/base/test_user_import.py
+++ b/integration_tests/suite/base/test_user_import.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2021 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import unittest
@@ -912,13 +912,13 @@ def test_given_field_group_is_empty_then_resource_is_not_created():
         "voicemail_delete_messages": "",
         "voicemail_ask_password": "",
     }
-    yield import_empty_group, group, 'voicemail_id'
+    import_empty_group(group, 'voicemail_id')
 
     group = {"line_protocol": ""}
-    yield import_empty_group, group, 'line_id'
+    import_empty_group(group, 'line_id')
 
     group = {"line_protocol": "sip", "exten": "", "context": ""}
-    yield import_empty_group, group, 'extension_id'
+    import_empty_group(group, 'extension_id')
 
     exten = h.extension.find_available_exten(config.CONTEXT)
     group = {
@@ -928,10 +928,10 @@ def test_given_field_group_is_empty_then_resource_is_not_created():
         "incall_exten": "",
         "incall_context": "",
     }
-    yield import_empty_group, group, 'incall_extension_id'
+    import_empty_group(group, 'incall_extension_id')
 
     group = {"call_permissions": ""}
-    yield import_empty_group, group, 'call_permission_ids', []
+    import_empty_group(group, 'call_permission_ids', [])
 
 
 def import_empty_group(fields, parameter, expected=None):
@@ -1324,9 +1324,9 @@ def check_error_on_update(entry, fields, error):
 @unittest.skip('PUT has been disabled')
 def test_given_csv_has_errors_then_errors_returned():
     with fixtures.csv_entry(voicemail=True, incall=True, line_protocol="sip") as entry:
-        yield check_error_on_update, entry, {'firstname': ''}, 'firstname'
-        yield check_error_on_update, entry, {'voicemail_number': '^]'}, 'number'
-        yield check_error_on_update, entry, {'sip_username': '^]'}, 'name'
+        check_error_on_update(entry, {'firstname': ''}, 'firstname')
+        check_error_on_update(entry, {'voicemail_number': '^]'}, 'number')
+        check_error_on_update(entry, {'sip_username': '^]'}, 'name')
 
 
 @unittest.skip('PUT has been disabled')
@@ -1556,7 +1556,7 @@ def test_given_each_field_updated_individually_then_entry_updated(
     }
 
     for name, value in fields.items():
-        yield update_csv_field, entry['user_uuid'], name, value
+        update_csv_field(entry['user_uuid'], name, value)
 
 
 def update_csv_field(uuid, field, value):

--- a/integration_tests/suite/base/test_user_line.py
+++ b/integration_tests/suite/base/test_user_line.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import re
@@ -31,8 +31,8 @@ def test_associate_errors(user, line):
     fake_user = confd.users(FAKE_ID).lines(line['id']).put
     fake_line = confd.users(user['id']).lines(FAKE_ID).put
 
-    yield s.check_resource_not_found, fake_user, 'User'
-    yield s.check_resource_not_found, fake_line, 'Line'
+    s.check_resource_not_found(fake_user, 'User')
+    s.check_resource_not_found(fake_line, 'Line')
 
 
 @fixtures.user()
@@ -41,8 +41,8 @@ def test_dissociate_errors(user, line):
     fake_user = confd.users(FAKE_ID).lines(line['id']).delete
     fake_line = confd.users(user['id']).lines(FAKE_ID).delete
 
-    yield s.check_resource_not_found, fake_user, 'User'
-    yield s.check_resource_not_found, fake_line, 'Line'
+    s.check_resource_not_found(fake_user, 'User')
+    s.check_resource_not_found(fake_line, 'Line')
 
 
 @fixtures.user()
@@ -449,5 +449,5 @@ def test_bus_events(user, line):
         f'user_uuid:{user["uuid"]}': True,
     }
 
-    yield (s.check_event, 'user_line_associated', headers, url.put)
-    yield (s.check_event, 'user_line_dissociated', headers, url.delete)
+    (s.check_event('user_line_associated', headers, url.put))
+    (s.check_event('user_line_dissociated', headers, url.delete))

--- a/integration_tests/suite/base/test_user_schedule.py
+++ b/integration_tests/suite/base/test_user_schedule.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import assert_that, contains, has_entries
@@ -16,8 +16,8 @@ def test_associate_errors(user, schedule):
     fake_user = confd.users(FAKE_ID).schedules(schedule['id']).put
     fake_schedule = confd.users(user['uuid']).schedules(FAKE_ID).put
 
-    yield s.check_resource_not_found, fake_user, 'User'
-    yield s.check_resource_not_found, fake_schedule, 'Schedule'
+    s.check_resource_not_found(fake_user, 'User')
+    s.check_resource_not_found(fake_schedule, 'Schedule')
 
 
 @fixtures.user()
@@ -26,8 +26,8 @@ def test_dissociate_errors(user, schedule):
     fake_user = confd.users(FAKE_ID).schedules(schedule['id']).delete
     fake_schedule = confd.users(user['uuid']).schedules(FAKE_ID).delete
 
-    yield s.check_resource_not_found, fake_user, 'User'
-    yield s.check_resource_not_found, fake_schedule, 'Schedule'
+    s.check_resource_not_found(fake_user, 'User')
+    s.check_resource_not_found(fake_schedule, 'Schedule')
 
 
 @fixtures.user()

--- a/integration_tests/suite/base/test_user_voicemail.py
+++ b/integration_tests/suite/base/test_user_voicemail.py
@@ -27,8 +27,8 @@ def test_associate_errors(user, voicemail):
     fake_user = confd.users(FAKE_ID).voicemails(voicemail['id']).put
     fake_voicemail = confd.users(user['id']).voicemails(FAKE_ID).put
 
-    yield s.check_resource_not_found, fake_user, 'User'
-    yield s.check_resource_not_found, fake_voicemail, 'Voicemail'
+    s.check_resource_not_found(fake_user, 'User')
+    s.check_resource_not_found(fake_voicemail, 'Voicemail')
 
 
 @fixtures.user()
@@ -36,7 +36,7 @@ def test_associate_errors(user, voicemail):
 def test_dissociate_errors(user, voicemail):
     fake_user = confd.users(FAKE_ID).voicemails.delete
 
-    yield s.check_resource_not_found, fake_user, 'User'
+    s.check_resource_not_found(fake_user, 'User')
 
 
 @fixtures.user()
@@ -196,10 +196,10 @@ def test_bus_events(user, voicemail):
     }
 
     url = confd.users(user['id']).voicemails(voicemail['id']).put
-    yield s.check_event, 'user_voicemail_associated', headers, url
+    s.check_event('user_voicemail_associated', headers, url)
 
     url = confd.users(user['id']).voicemails.delete
-    yield s.check_event, 'user_voicemail_dissociated', headers, url
+    s.check_event('user_voicemail_dissociated', headers, url)
 
 
 @fixtures.user()

--- a/integration_tests/suite/base/test_users.py
+++ b/integration_tests/suite/base/test_users.py
@@ -106,8 +106,7 @@ AUTH_USER = {
 
 def test_search_errors():
     url = confd.users.get
-    for check in s.search_error_checks(url):
-        yield check
+    s.search_error_checks(url)
 
 
 def test_head_errors():
@@ -117,208 +116,213 @@ def test_head_errors():
 
 def test_get_errors():
     fake_get = confd.users(999999).get
-    yield s.check_resource_not_found, fake_get, 'User'
+    s.check_resource_not_found(fake_get, 'User')
 
 
 def test_post_errors():
     empty_post = confd.users.post
     user_post = confd.users(firstname="Jôhn").post
 
-    yield s.check_missing_required_field_returns_error, empty_post, 'firstname'
-    for check in error_checks(user_post):
-        yield check
+    s.check_missing_required_field_returns_error(empty_post, 'firstname')
+    error_checks(user_post)
 
 
 def error_checks(url):
-    yield s.check_bogus_field_returns_error, url, 'firstname', 123
-    yield s.check_bogus_field_returns_error, url, 'firstname', None
-    yield s.check_bogus_field_returns_error, url, 'firstname', s.random_string(129)
-    yield s.check_bogus_field_returns_error, url, 'firstname', {}
-    yield s.check_bogus_field_returns_error, url, 'firstname', []
-    yield s.check_bogus_field_returns_error, url, 'lastname', 123
-    yield s.check_bogus_field_returns_error, url, 'lastname', s.random_string(129)
-    yield s.check_bogus_field_returns_error, url, 'lastname', {}
-    yield s.check_bogus_field_returns_error, url, 'lastname', []
-    yield s.check_bogus_field_returns_error, url, 'email', s.random_string(255)
-    yield s.check_bogus_field_returns_error, url, 'email', 123
-    yield s.check_bogus_field_returns_error, url, 'email', 'invalid_email'
-    yield s.check_bogus_field_returns_error, url, 'email', {}
-    yield s.check_bogus_field_returns_error, url, 'email', []
-    yield s.check_bogus_field_returns_error, url, 'timezone', 123
-    yield s.check_bogus_field_returns_error, url, 'timezone', s.random_string(129)
-    yield s.check_bogus_field_returns_error, url, 'timezone', {}
-    yield s.check_bogus_field_returns_error, url, 'timezone', []
-    yield s.check_bogus_field_returns_error, url, 'language', 123
-    yield s.check_bogus_field_returns_error, url, 'language', 'klingon'
-    yield s.check_bogus_field_returns_error, url, 'language', {}
-    yield s.check_bogus_field_returns_error, url, 'language', []
-    yield s.check_bogus_field_returns_error, url, 'description', 123
-    yield s.check_bogus_field_returns_error, url, 'description', {}
-    yield s.check_bogus_field_returns_error, url, 'description', []
-    yield s.check_bogus_field_returns_error, url, 'caller_id', 123
-    yield s.check_bogus_field_returns_error, url, 'caller_id', 'invalid_regex'
-    yield s.check_bogus_field_returns_error, url, 'caller_id', s.random_string(161)
-    yield s.check_bogus_field_returns_error, url, 'caller_id', {}
-    yield s.check_bogus_field_returns_error, url, 'caller_id', []
-    yield s.check_bogus_field_returns_error, url, 'outgoing_caller_id', 123
-    yield s.check_bogus_field_returns_error, url, 'outgoing_caller_id', s.random_string(
-        81
+    s.check_bogus_field_returns_error(url, 'firstname', 123)
+    s.check_bogus_field_returns_error(url, 'firstname', None)
+    s.check_bogus_field_returns_error(url, 'firstname', s.random_string(129))
+    s.check_bogus_field_returns_error(url, 'firstname', {})
+    s.check_bogus_field_returns_error(url, 'firstname', [])
+    s.check_bogus_field_returns_error(url, 'lastname', 123)
+    s.check_bogus_field_returns_error(url, 'lastname', s.random_string(129))
+    s.check_bogus_field_returns_error(url, 'lastname', {})
+    s.check_bogus_field_returns_error(url, 'lastname', [])
+    s.check_bogus_field_returns_error(url, 'email', s.random_string(255))
+    s.check_bogus_field_returns_error(url, 'email', 123)
+    s.check_bogus_field_returns_error(url, 'email', 'invalid_email')
+    s.check_bogus_field_returns_error(url, 'email', {})
+    s.check_bogus_field_returns_error(url, 'email', [])
+    s.check_bogus_field_returns_error(url, 'timezone', 123)
+    s.check_bogus_field_returns_error(url, 'timezone', s.random_string(129))
+    s.check_bogus_field_returns_error(url, 'timezone', {})
+    s.check_bogus_field_returns_error(url, 'timezone', [])
+    s.check_bogus_field_returns_error(url, 'language', 123)
+    s.check_bogus_field_returns_error(url, 'language', 'klingon')
+    s.check_bogus_field_returns_error(url, 'language', {})
+    s.check_bogus_field_returns_error(url, 'language', [])
+    s.check_bogus_field_returns_error(url, 'description', 123)
+    s.check_bogus_field_returns_error(url, 'description', {})
+    s.check_bogus_field_returns_error(url, 'description', [])
+    s.check_bogus_field_returns_error(url, 'caller_id', 123)
+    s.check_bogus_field_returns_error(url, 'caller_id', 'invalid_regex')
+    s.check_bogus_field_returns_error(url, 'caller_id', s.random_string(161))
+    s.check_bogus_field_returns_error(url, 'caller_id', {})
+    s.check_bogus_field_returns_error(url, 'caller_id', [])
+    s.check_bogus_field_returns_error(url, 'outgoing_caller_id', 123)
+    s.check_bogus_field_returns_error(url, 'outgoing_caller_id', s.random_string(81))
+    s.check_bogus_field_returns_error(url, 'outgoing_caller_id', {})
+    s.check_bogus_field_returns_error(url, 'outgoing_caller_id', [])
+    s.check_bogus_field_returns_error(url, 'mobile_phone_number', 123)
+    s.check_bogus_field_returns_error(url, 'mobile_phone_number', 'invalid_regex')
+    s.check_bogus_field_returns_error(url, 'mobile_phone_number', '123abcd')
+    s.check_bogus_field_returns_error(url, 'mobile_phone_number', s.random_string(81))
+    s.check_bogus_field_returns_error(url, 'mobile_phone_number', {})
+    s.check_bogus_field_returns_error(url, 'mobile_phone_number', [])
+    s.check_bogus_field_returns_error(url, 'username', 123)
+    s.check_bogus_field_returns_error(url, 'username', 'invalid_régex')
+    s.check_bogus_field_returns_error(url, 'username', s.random_string(1))
+    s.check_bogus_field_returns_error(url, 'username', s.random_string(255))
+    s.check_bogus_field_returns_error(url, 'username', {})
+    s.check_bogus_field_returns_error(url, 'username', [])
+    s.check_bogus_field_returns_error(url, 'password', 123)
+    s.check_bogus_field_returns_error(url, 'password', 'invalid_régex')
+    s.check_bogus_field_returns_error(url, 'password', s.random_string(3))
+    s.check_bogus_field_returns_error(url, 'password', s.random_string(65))
+    s.check_bogus_field_returns_error(url, 'password', {})
+    s.check_bogus_field_returns_error(url, 'password', [])
+    s.check_bogus_field_returns_error(url, 'music_on_hold', 123)
+    s.check_bogus_field_returns_error(url, 'music_on_hold', s.random_string(129))
+    s.check_bogus_field_returns_error(url, 'music_on_hold', {})
+    s.check_bogus_field_returns_error(url, 'music_on_hold', [])
+    s.check_bogus_field_returns_error(url, 'preprocess_subroutine', 123)
+    s.check_bogus_field_returns_error(url, 'preprocess_subroutine', s.random_string(80))
+    s.check_bogus_field_returns_error(url, 'preprocess_subroutine', {})
+    s.check_bogus_field_returns_error(url, 'preprocess_subroutine', [])
+    s.check_bogus_field_returns_error(url, 'userfield', 123)
+    s.check_bogus_field_returns_error(url, 'userfield', s.random_string(129))
+    s.check_bogus_field_returns_error(url, 'userfield', {})
+    s.check_bogus_field_returns_error(url, 'userfield', [])
+    s.check_bogus_field_returns_error(url, 'caller_id', 'invalid')
+    s.check_bogus_field_returns_error(url, 'caller_id', 1234)
+    s.check_bogus_field_returns_error(url, 'caller_id', s.random_string(161))
+    s.check_bogus_field_returns_error(url, 'caller_id', {})
+    s.check_bogus_field_returns_error(url, 'caller_id', [])
+    s.check_bogus_field_returns_error(url, 'call_transfer_enabled', 'yeah')
+    s.check_bogus_field_returns_error(url, 'call_transfer_enabled', 123)
+    s.check_bogus_field_returns_error(url, 'call_transfer_enabled', {})
+    s.check_bogus_field_returns_error(url, 'call_transfer_enabled', [])
+    s.check_bogus_field_returns_error(url, 'dtmf_hangup_enabled', 'yeah')
+    s.check_bogus_field_returns_error(url, 'dtmf_hangup_enabled', 123)
+    s.check_bogus_field_returns_error(url, 'dtmf_hangup_enabled', {})
+    s.check_bogus_field_returns_error(url, 'dtmf_hangup_enabled', [])
+    s.check_bogus_field_returns_error(url, 'call_record_enabled', 'yeah')
+    s.check_bogus_field_returns_error(url, 'call_record_enabled', 123)
+    s.check_bogus_field_returns_error(url, 'call_record_enabled', {})
+    s.check_bogus_field_returns_error(url, 'call_record_enabled', [])
+    s.check_bogus_field_returns_error(
+        url, 'call_record_incoming_external_enabled', 'yeah'
     )
-    yield s.check_bogus_field_returns_error, url, 'outgoing_caller_id', {}
-    yield s.check_bogus_field_returns_error, url, 'outgoing_caller_id', []
-    yield s.check_bogus_field_returns_error, url, 'mobile_phone_number', 123
-    yield s.check_bogus_field_returns_error, url, 'mobile_phone_number', 'invalid_regex'
-    yield s.check_bogus_field_returns_error, url, 'mobile_phone_number', '123abcd'
-    yield s.check_bogus_field_returns_error, url, 'mobile_phone_number', s.random_string(
-        81
+    s.check_bogus_field_returns_error(url, 'call_record_incoming_external_enabled', 123)
+    s.check_bogus_field_returns_error(url, 'call_record_incoming_external_enabled', {})
+    s.check_bogus_field_returns_error(url, 'call_record_incoming_external_enabled', [])
+    s.check_bogus_field_returns_error(
+        url, 'call_record_incoming_internal_enabled', 'yeah'
     )
-    yield s.check_bogus_field_returns_error, url, 'mobile_phone_number', {}
-    yield s.check_bogus_field_returns_error, url, 'mobile_phone_number', []
-    yield s.check_bogus_field_returns_error, url, 'username', 123
-    yield s.check_bogus_field_returns_error, url, 'username', 'invalid_régex'
-    yield s.check_bogus_field_returns_error, url, 'username', s.random_string(1)
-    yield s.check_bogus_field_returns_error, url, 'username', s.random_string(255)
-    yield s.check_bogus_field_returns_error, url, 'username', {}
-    yield s.check_bogus_field_returns_error, url, 'username', []
-    yield s.check_bogus_field_returns_error, url, 'password', 123
-    yield s.check_bogus_field_returns_error, url, 'password', 'invalid_régex'
-    yield s.check_bogus_field_returns_error, url, 'password', s.random_string(3)
-    yield s.check_bogus_field_returns_error, url, 'password', s.random_string(65)
-    yield s.check_bogus_field_returns_error, url, 'password', {}
-    yield s.check_bogus_field_returns_error, url, 'password', []
-    yield s.check_bogus_field_returns_error, url, 'music_on_hold', 123
-    yield s.check_bogus_field_returns_error, url, 'music_on_hold', s.random_string(129)
-    yield s.check_bogus_field_returns_error, url, 'music_on_hold', {}
-    yield s.check_bogus_field_returns_error, url, 'music_on_hold', []
-    yield s.check_bogus_field_returns_error, url, 'preprocess_subroutine', 123
-    yield s.check_bogus_field_returns_error, url, 'preprocess_subroutine', s.random_string(
-        80
+    s.check_bogus_field_returns_error(url, 'call_record_incoming_internal_enabled', 123)
+    s.check_bogus_field_returns_error(url, 'call_record_incoming_internal_enabled', {})
+    s.check_bogus_field_returns_error(url, 'call_record_incoming_internal_enabled', [])
+    s.check_bogus_field_returns_error(
+        url, 'call_record_outgoing_internal_enabled', 'yeah'
     )
-    yield s.check_bogus_field_returns_error, url, 'preprocess_subroutine', {}
-    yield s.check_bogus_field_returns_error, url, 'preprocess_subroutine', []
-    yield s.check_bogus_field_returns_error, url, 'userfield', 123
-    yield s.check_bogus_field_returns_error, url, 'userfield', s.random_string(129)
-    yield s.check_bogus_field_returns_error, url, 'userfield', {}
-    yield s.check_bogus_field_returns_error, url, 'userfield', []
-    yield s.check_bogus_field_returns_error, url, 'caller_id', 'invalid'
-    yield s.check_bogus_field_returns_error, url, 'caller_id', 1234
-    yield s.check_bogus_field_returns_error, url, 'caller_id', s.random_string(161)
-    yield s.check_bogus_field_returns_error, url, 'caller_id', {}
-    yield s.check_bogus_field_returns_error, url, 'caller_id', []
-    yield s.check_bogus_field_returns_error, url, 'call_transfer_enabled', 'yeah'
-    yield s.check_bogus_field_returns_error, url, 'call_transfer_enabled', 123
-    yield s.check_bogus_field_returns_error, url, 'call_transfer_enabled', {}
-    yield s.check_bogus_field_returns_error, url, 'call_transfer_enabled', []
-    yield s.check_bogus_field_returns_error, url, 'dtmf_hangup_enabled', 'yeah'
-    yield s.check_bogus_field_returns_error, url, 'dtmf_hangup_enabled', 123
-    yield s.check_bogus_field_returns_error, url, 'dtmf_hangup_enabled', {}
-    yield s.check_bogus_field_returns_error, url, 'dtmf_hangup_enabled', []
-    yield s.check_bogus_field_returns_error, url, 'call_record_enabled', 'yeah'
-    yield s.check_bogus_field_returns_error, url, 'call_record_enabled', 123
-    yield s.check_bogus_field_returns_error, url, 'call_record_enabled', {}
-    yield s.check_bogus_field_returns_error, url, 'call_record_enabled', []
-    yield s.check_bogus_field_returns_error, url, 'call_record_incoming_external_enabled', 'yeah'
-    yield s.check_bogus_field_returns_error, url, 'call_record_incoming_external_enabled', 123
-    yield s.check_bogus_field_returns_error, url, 'call_record_incoming_external_enabled', {}
-    yield s.check_bogus_field_returns_error, url, 'call_record_incoming_external_enabled', []
-    yield s.check_bogus_field_returns_error, url, 'call_record_incoming_internal_enabled', 'yeah'
-    yield s.check_bogus_field_returns_error, url, 'call_record_incoming_internal_enabled', 123
-    yield s.check_bogus_field_returns_error, url, 'call_record_incoming_internal_enabled', {}
-    yield s.check_bogus_field_returns_error, url, 'call_record_incoming_internal_enabled', []
-    yield s.check_bogus_field_returns_error, url, 'call_record_outgoing_internal_enabled', 'yeah'
-    yield s.check_bogus_field_returns_error, url, 'call_record_outgoing_internal_enabled', 123
-    yield s.check_bogus_field_returns_error, url, 'call_record_outgoing_internal_enabled', {}
-    yield s.check_bogus_field_returns_error, url, 'call_record_outgoing_internal_enabled', []
-    yield s.check_bogus_field_returns_error, url, 'call_record_outgoing_external_enabled', 'yeah'
-    yield s.check_bogus_field_returns_error, url, 'call_record_outgoing_external_enabled', 123
-    yield s.check_bogus_field_returns_error, url, 'call_record_outgoing_external_enabled', {}
-    yield s.check_bogus_field_returns_error, url, 'call_record_outgoing_external_enabled', []
-    yield s.check_bogus_field_returns_error, url, 'online_call_record_enabled', 'yeah'
-    yield s.check_bogus_field_returns_error, url, 'online_call_record_enabled', 123
-    yield s.check_bogus_field_returns_error, url, 'online_call_record_enabled', {}
-    yield s.check_bogus_field_returns_error, url, 'online_call_record_enabled', []
-    yield s.check_bogus_field_returns_error, url, 'supervision_enabled', 'yeah'
-    yield s.check_bogus_field_returns_error, url, 'supervision_enabled', 123
-    yield s.check_bogus_field_returns_error, url, 'supervision_enabled', {}
-    yield s.check_bogus_field_returns_error, url, 'supervision_enabled', []
-    yield s.check_bogus_field_returns_error, url, 'simultaneous_calls', 'sixty'
-    yield s.check_bogus_field_returns_error, url, 'simultaneous_calls', -1
-    yield s.check_bogus_field_returns_error, url, 'simultaneous_calls', 21
-    yield s.check_bogus_field_returns_error, url, 'simultaneous_calls', {}
-    yield s.check_bogus_field_returns_error, url, 'simultaneous_calls', []
-    yield s.check_bogus_field_returns_error, url, 'ring_seconds', 'ten'
-    yield s.check_bogus_field_returns_error, url, 'ring_seconds', -1
-    yield s.check_bogus_field_returns_error, url, 'ring_seconds', 10801
-    yield s.check_bogus_field_returns_error, url, 'ring_seconds', {}
-    yield s.check_bogus_field_returns_error, url, 'ring_seconds', []
-    yield s.check_bogus_field_returns_error, url, 'call_permission_password', 1234
-    yield s.check_bogus_field_returns_error, url, 'call_permission_password', 'invalid_char'
-    yield s.check_bogus_field_returns_error, url, 'call_permission_password', {}
-    yield s.check_bogus_field_returns_error, url, 'call_permission_password', []
-    yield s.check_bogus_field_returns_error, url, 'call_permission_password', s.random_string(
-        17
+    s.check_bogus_field_returns_error(url, 'call_record_outgoing_internal_enabled', 123)
+    s.check_bogus_field_returns_error(url, 'call_record_outgoing_internal_enabled', {})
+    s.check_bogus_field_returns_error(url, 'call_record_outgoing_internal_enabled', [])
+    s.check_bogus_field_returns_error(
+        url, 'call_record_outgoing_external_enabled', 'yeah'
     )
-    yield s.check_bogus_field_returns_error, url, 'subscription_type', 'one'
-    yield s.check_bogus_field_returns_error, url, 'subscription_type', -1
-    yield s.check_bogus_field_returns_error, url, 'subscription_type', 11
-    yield s.check_bogus_field_returns_error, url, 'subscription_type', {}
-    yield s.check_bogus_field_returns_error, url, 'subscription_type', []
-    yield s.check_bogus_field_returns_error, url, 'enabled', 'yeah'
-    yield s.check_bogus_field_returns_error, url, 'enabled', 123
-    yield s.check_bogus_field_returns_error, url, 'enabled', {}
-    yield s.check_bogus_field_returns_error, url, 'enabled', []
+    s.check_bogus_field_returns_error(url, 'call_record_outgoing_external_enabled', 123)
+    s.check_bogus_field_returns_error(url, 'call_record_outgoing_external_enabled', {})
+    s.check_bogus_field_returns_error(url, 'call_record_outgoing_external_enabled', [])
+    s.check_bogus_field_returns_error(url, 'online_call_record_enabled', 'yeah')
+    s.check_bogus_field_returns_error(url, 'online_call_record_enabled', 123)
+    s.check_bogus_field_returns_error(url, 'online_call_record_enabled', {})
+    s.check_bogus_field_returns_error(url, 'online_call_record_enabled', [])
+    s.check_bogus_field_returns_error(url, 'supervision_enabled', 'yeah')
+    s.check_bogus_field_returns_error(url, 'supervision_enabled', 123)
+    s.check_bogus_field_returns_error(url, 'supervision_enabled', {})
+    s.check_bogus_field_returns_error(url, 'supervision_enabled', [])
+    s.check_bogus_field_returns_error(url, 'simultaneous_calls', 'sixty')
+    s.check_bogus_field_returns_error(url, 'simultaneous_calls', -1)
+    s.check_bogus_field_returns_error(url, 'simultaneous_calls', 21)
+    s.check_bogus_field_returns_error(url, 'simultaneous_calls', {})
+    s.check_bogus_field_returns_error(url, 'simultaneous_calls', [])
+    s.check_bogus_field_returns_error(url, 'ring_seconds', 'ten')
+    s.check_bogus_field_returns_error(url, 'ring_seconds', -1)
+    s.check_bogus_field_returns_error(url, 'ring_seconds', 10801)
+    s.check_bogus_field_returns_error(url, 'ring_seconds', {})
+    s.check_bogus_field_returns_error(url, 'ring_seconds', [])
+    s.check_bogus_field_returns_error(url, 'call_permission_password', 1234)
+    s.check_bogus_field_returns_error(url, 'call_permission_password', 'invalid_char')
+    s.check_bogus_field_returns_error(url, 'call_permission_password', {})
+    s.check_bogus_field_returns_error(url, 'call_permission_password', [])
+    s.check_bogus_field_returns_error(
+        url, 'call_permission_password', s.random_string(17)
+    )
+    s.check_bogus_field_returns_error(url, 'subscription_type', 'one')
+    s.check_bogus_field_returns_error(url, 'subscription_type', -1)
+    s.check_bogus_field_returns_error(url, 'subscription_type', 11)
+    s.check_bogus_field_returns_error(url, 'subscription_type', {})
+    s.check_bogus_field_returns_error(url, 'subscription_type', [])
+    s.check_bogus_field_returns_error(url, 'enabled', 'yeah')
+    s.check_bogus_field_returns_error(url, 'enabled', 123)
+    s.check_bogus_field_returns_error(url, 'enabled', {})
+    s.check_bogus_field_returns_error(url, 'enabled', [])
 
     conflict = {'call_record_incoming_external_enabled': True}
-    yield s.check_bogus_field_returns_error, url, 'call_record_enabled', False, conflict
+    s.check_bogus_field_returns_error(url, 'call_record_enabled', False, conflict)
 
 
 def put_error_checks(url):
-    yield s.check_bogus_field_returns_error, url, 'caller_id', None
-    yield s.check_bogus_field_returns_error, url, 'call_transfer_enabled', None
-    yield s.check_bogus_field_returns_error, url, 'dtmf_hangup_enabled', None
-    yield s.check_bogus_field_returns_error, url, 'call_record_enabled', None
-    yield s.check_bogus_field_returns_error, url, 'call_record_incoming_external_enabled', None
-    yield s.check_bogus_field_returns_error, url, 'call_record_incoming_internal_enabled', None
-    yield s.check_bogus_field_returns_error, url, 'call_record_outgoing_internal_enabled', None
-    yield s.check_bogus_field_returns_error, url, 'call_record_outgoing_external_enabled', None
-    yield s.check_bogus_field_returns_error, url, 'online_call_record_enabled', None
-    yield s.check_bogus_field_returns_error, url, 'supervision_enabled', None
-    yield s.check_bogus_field_returns_error, url, 'ring_seconds', None
-    yield s.check_bogus_field_returns_error, url, 'simultaneous_calls', None
-    yield s.check_bogus_field_returns_error, url, 'ring_seconds', None
-    yield s.check_bogus_field_returns_error, url, 'enabled', None
+    s.check_bogus_field_returns_error(url, 'caller_id', None)
+    s.check_bogus_field_returns_error(url, 'call_transfer_enabled', None)
+    s.check_bogus_field_returns_error(url, 'dtmf_hangup_enabled', None)
+    s.check_bogus_field_returns_error(url, 'call_record_enabled', None)
+    s.check_bogus_field_returns_error(
+        url, 'call_record_incoming_external_enabled', None
+    )
+    s.check_bogus_field_returns_error(
+        url, 'call_record_incoming_internal_enabled', None
+    )
+    s.check_bogus_field_returns_error(
+        url, 'call_record_outgoing_internal_enabled', None
+    )
+    s.check_bogus_field_returns_error(
+        url, 'call_record_outgoing_external_enabled', None
+    )
+    s.check_bogus_field_returns_error(url, 'online_call_record_enabled', None)
+    s.check_bogus_field_returns_error(url, 'supervision_enabled', None)
+    s.check_bogus_field_returns_error(url, 'ring_seconds', None)
+    s.check_bogus_field_returns_error(url, 'simultaneous_calls', None)
+    s.check_bogus_field_returns_error(url, 'ring_seconds', None)
+    s.check_bogus_field_returns_error(url, 'enabled', None)
 
 
 @fixtures.user()
 def test_put_errors(user):
     user_put = confd.users(user['id']).put
 
-    for check in error_checks(user_put):
-        yield check
-    for check in put_error_checks(user_put):
-        yield check
+    error_checks(user_put)
+    put_error_checks(user_put)
 
 
 @fixtures.user(firstname='user1', username='unique_username', email='unique@email.com')
 @fixtures.user()
 def test_unique_errors(user1, user2):
     url = confd.users(user2['id']).put
-    for check in unique_error_checks(url, user1):
-        yield check
+    unique_error_checks(url, user1)
 
     required_body = {'firstname': 'user2'}
     url = confd.users.post
-    for check in unique_error_checks(url, user1, required_body):
-        yield check
+    unique_error_checks(url, user1, required_body)
 
 
 def unique_error_checks(url, existing_resource, required_body=None):
-    yield s.check_bogus_field_returns_error, url, 'username', existing_resource[
-        'username'
-    ], required_body
-    yield s.check_bogus_field_returns_error, url, 'email', existing_resource[
-        'email'
-    ], required_body
+    s.check_bogus_field_returns_error(
+        url, 'username', existing_resource['username'], required_body
+    )
+    s.check_bogus_field_returns_error(
+        url, 'email', existing_resource['email'], required_body
+    )
 
 
 def test_deprecated_call_record_enabled():
@@ -374,7 +378,7 @@ def test_deprecated_call_record_enabled():
 def test_delete_errors(user):
     user_url = confd.users(user['id'])
     user_url.delete()
-    yield s.check_resource_not_found, user_url.get, 'User'
+    s.check_resource_not_found(user_url.get, 'User')
 
 
 @fixtures.user(firstname='ÉricDir')
@@ -518,7 +522,7 @@ def test_search_on_user_view(user):
     }
 
     for field, term in searches.items():
-        yield check_search, url, field, term, user[field]
+        check_search(url, field, term, user[field])
 
 
 @fixtures.user(
@@ -542,7 +546,7 @@ def test_search_on_directory_view(user):
     }
 
     for field, term in searches.items():
-        yield check_search, url, field, term, user[field]
+        check_search(url, field, term, user[field])
 
 
 @fixtures.user()
@@ -583,12 +587,15 @@ def test_search_on_summary_view(user, line, sip, extension):
     with a.line_endpoint_sip(line, sip), a.user_line(user, line), a.line_extension(
         line, extension
     ):
-        yield check_search, url, 'firstname', 'âbou', user['firstname']
-        yield check_search, url, 'lastname', 'man', user['lastname']
-        yield check_search, url, 'provisioning_code', line['provisioning_code'], line[
-            'provisioning_code'
-        ]
-        yield check_search, url, 'extension', extension['exten'], extension['exten']
+        check_search(url, 'firstname', 'âbou', user['firstname'])
+        check_search(url, 'lastname', 'man', user['lastname'])
+        check_search(
+            url,
+            'provisioning_code',
+            line['provisioning_code'],
+            line['provisioning_code'],
+        )
+        check_search(url, 'extension', extension['exten'], extension['exten'])
 
 
 def check_search(url, field, term, value):
@@ -643,15 +650,15 @@ def test_list_by_multiple_uuids(_, user2, user3):
 )
 def test_sorting_offset_limit(user1, user2):
     url = confd.users.get
-    yield s.check_sorting, url, user1, user2, 'firstname', 'firstname'
-    yield s.check_sorting, url, user1, user2, 'lastname', 'lastname'
-    yield s.check_sorting, url, user1, user2, 'email', 'email'
-    yield s.check_sorting, url, user1, user2, 'mobile_phone_number', '+555'
-    yield s.check_sorting, url, user1, user2, 'userfield', 'sort userfield'
-    yield s.check_sorting, url, user1, user2, 'description', 'description'
+    s.check_sorting(url, user1, user2, 'firstname', 'firstname')
+    s.check_sorting(url, user1, user2, 'lastname', 'lastname')
+    s.check_sorting(url, user1, user2, 'email', 'email')
+    s.check_sorting(url, user1, user2, 'mobile_phone_number', '+555')
+    s.check_sorting(url, user1, user2, 'userfield', 'sort userfield')
+    s.check_sorting(url, user1, user2, 'description', 'description')
 
-    yield s.check_offset, url, user1, user2, 'firstname', 'firstname'
-    yield s.check_limit, url, user1, user2, 'firstname', 'firstname'
+    s.check_offset(url, user1, user2, 'firstname', 'firstname')
+    s.check_limit(url, user1, user2, 'firstname', 'firstname')
 
 
 @fixtures.user()
@@ -972,9 +979,9 @@ def test_bus_events(user):
     body = {'firstname': 'test-event-user'}
     headers = {'tenant_uuid': user['tenant_uuid']}
 
-    yield s.check_event, 'user_created', headers, confd.users.post, body
-    yield s.check_event, 'user_edited', headers, url.put
-    yield s.check_event, 'user_deleted', headers, url.delete
+    s.check_event('user_created', headers, confd.users.post, body)
+    s.check_event('user_edited', headers, url.put)
+    s.check_event('user_deleted', headers, url.delete)
 
 
 class UserResources:
@@ -1486,7 +1493,7 @@ def test_post_update_delete_full_user_no_error(
             response.assert_status(404)
 
             # verify that voicemail is deleted
-            url = confd.lines(payload['voicemail']['id'])
+            url = confd.voicemails(payload['voicemail']['id'])
             response = url.get()
             response.assert_status(404)
 

--- a/integration_tests/suite/base/test_users_forwards.py
+++ b/integration_tests/suite/base/test_users_forwards.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import assert_that, has_key, has_entries, equal_to
@@ -21,15 +21,15 @@ def test_get_users_forwards(user):
 def test_get_for_each_user_forward(user):
     for forward in VALID_FORWARDS:
         forward_url = confd.users(user['uuid']).forwards(forward)
-        yield _read_forward, forward_url, False
+        _read_forward(forward_url, False)
 
 
 @fixtures.user()
 def test_put_for_each_user_forward(user):
     for forward in VALID_FORWARDS:
         forward_url = confd.users(user['uuid']).forwards(forward)
-        yield _update_forward, forward_url, False
-        yield _update_forward, forward_url, True, '123'
+        _update_forward(forward_url, False)
+        _update_forward(forward_url, True, '123')
 
 
 def _update_forward(forward_url, enabled, destination=None):
@@ -48,10 +48,15 @@ def _read_forward(forward_url, enabled, destination=None):
 @fixtures.user()
 def test_put_forwards(user):
     forwards_url = confd.users(user['uuid']).forwards
-    yield _update_forwards, forwards_url, {'enabled': True, 'destination': '123'}, {
-        'enabled': False,
-        'destination': '456',
-    }, {'enabled': False, 'destination': None}
+    _update_forwards(
+        forwards_url,
+        {'enabled': True, 'destination': '123'},
+        {
+            'enabled': False,
+            'destination': '456',
+        },
+        {'enabled': False, 'destination': None},
+    )
 
 
 def _update_forwards(forwards_url, busy={}, noanswer={}, unconditional={}):
@@ -81,18 +86,16 @@ def test_error_on_null_destination_when_enabled(user):
 @fixtures.user()
 def test_put_error(user):
     forward_url = confd.users(user['uuid']).forwards('busy').put
-    yield s.check_bogus_field_returns_error, forward_url, 'enabled', 'string'
-    yield s.check_bogus_field_returns_error, forward_url, 'enabled', None
-    yield s.check_bogus_field_returns_error, forward_url, 'enabled', 123
-    yield s.check_bogus_field_returns_error, forward_url, 'enabled', 1
-    yield s.check_bogus_field_returns_error, forward_url, 'enabled', 0
-    yield s.check_bogus_field_returns_error, forward_url, 'enabled', {}
-    yield s.check_bogus_field_returns_error, forward_url, 'destination', True
-    yield s.check_bogus_field_returns_error, forward_url, 'destination', 123
-    yield s.check_bogus_field_returns_error, forward_url, 'destination', s.random_string(
-        129
-    )
-    yield s.check_bogus_field_returns_error, forward_url, 'destination', {}
+    s.check_bogus_field_returns_error(forward_url, 'enabled', 'string')
+    s.check_bogus_field_returns_error(forward_url, 'enabled', None)
+    s.check_bogus_field_returns_error(forward_url, 'enabled', 123)
+    s.check_bogus_field_returns_error(forward_url, 'enabled', 1)
+    s.check_bogus_field_returns_error(forward_url, 'enabled', 0)
+    s.check_bogus_field_returns_error(forward_url, 'enabled', {})
+    s.check_bogus_field_returns_error(forward_url, 'destination', True)
+    s.check_bogus_field_returns_error(forward_url, 'destination', 123)
+    s.check_bogus_field_returns_error(forward_url, 'destination', s.random_string(129))
+    s.check_bogus_field_returns_error(forward_url, 'destination', {})
 
 
 @fixtures.user(

--- a/integration_tests/suite/base/test_users_func_keys.py
+++ b/integration_tests/suite/base/test_users_func_keys.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2020 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import assert_that, has_entries, has_key, is_not
@@ -13,23 +13,21 @@ FAKE_ID = 999999999
 @fixtures.user()
 def test_put_errors(user):
     fake_user = confd.users(FAKE_ID).funckeys(1).put
-    yield s.check_resource_not_found, fake_user, 'User'
+    s.check_resource_not_found(fake_user, 'User')
 
     url = confd.users(user['uuid']).funckeys(1).put
-    for check in error_funckey_checks(url):
-        yield check
+    error_funckey_checks(url)
 
     fake_user = confd.users(FAKE_ID).funckeys.put
-    yield s.check_resource_not_found, fake_user, 'User'
+    s.check_resource_not_found(fake_user, 'User')
 
     url = confd.users(user['uuid']).funckeys.put
-    for check in error_funckeys_checks(url):
-        yield check
+    error_funckeys_checks(url)
 
 
 def test_delete_errors():
     fake_user = confd.users(FAKE_ID).funckeys(1).delete
-    yield s.check_resource_not_found, fake_user, 'User'
+    s.check_resource_not_found(fake_user, 'User')
 
     # This should raise an error
     # fake_funckey = confd.users(self.user['id']).funckeys(FAKE_ID).delete
@@ -42,9 +40,9 @@ def test_get_errors(user):
     fake_user_2 = confd.users(FAKE_ID).funckeys(1).get
     fake_funckey = confd.users(user['uuid']).funckeys(FAKE_ID).get
 
-    yield s.check_resource_not_found, fake_user_1, 'User'
-    yield s.check_resource_not_found, fake_user_2, 'User'
-    yield s.check_resource_not_found, fake_funckey, 'FuncKey'
+    s.check_resource_not_found(fake_user_1, 'User')
+    s.check_resource_not_found(fake_user_2, 'User')
+    s.check_resource_not_found(fake_funckey, 'FuncKey')
 
 
 @fixtures.user()

--- a/integration_tests/suite/base/test_users_services.py
+++ b/integration_tests/suite/base/test_users_services.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import assert_that, equal_to, has_key, has_entry, has_entries
@@ -21,15 +21,15 @@ def test_get_users_services(user):
 def test_get_value_for_each_user_service(user):
     for service in VALID_SERVICES:
         service_url = confd.users(user['uuid']).services(service)
-        yield _read_service, service_url, False
+        _read_service(service_url, False)
 
 
 @fixtures.user()
 def test_put_value_for_each_user_service(user):
     for service in VALID_SERVICES:
         service_url = confd.users(user['uuid']).services(service)
-        yield _update_service, service_url, False
-        yield _update_service, service_url, True
+        _update_service(service_url, False)
+        _update_service(service_url, True)
 
 
 def _update_service(service_url, value):
@@ -46,7 +46,7 @@ def _read_service(service_url, value):
 @fixtures.user()
 def test_put_services(user):
     services_url = confd.users(user['uuid']).services
-    yield _update_services, services_url, {'enabled': True}, {'enabled': False}
+    _update_services(services_url, {'enabled': True}, {'enabled': False})
 
 
 def _update_services(services_url, dnd={}, incallfilter={}):
@@ -60,11 +60,11 @@ def _update_services(services_url, dnd={}, incallfilter={}):
 @fixtures.user()
 def test_put_error(user):
     service_url = confd.users(user['uuid']).services('dnd').put
-    yield s.check_bogus_field_returns_error, service_url, 'enabled', 'string'
-    yield s.check_bogus_field_returns_error, service_url, 'enabled', None
-    yield s.check_bogus_field_returns_error, service_url, 'enabled', 123
-    yield s.check_bogus_field_returns_error, service_url, 'enabled', []
-    yield s.check_bogus_field_returns_error, service_url, 'enabled', {}
+    s.check_bogus_field_returns_error(service_url, 'enabled', 'string')
+    s.check_bogus_field_returns_error(service_url, 'enabled', None)
+    s.check_bogus_field_returns_error(service_url, 'enabled', 123)
+    s.check_bogus_field_returns_error(service_url, 'enabled', [])
+    s.check_bogus_field_returns_error(service_url, 'enabled', {})
 
 
 @fixtures.user(services={'dnd': {'enabled': True}, 'incallfilter': {'enabled': True}})

--- a/integration_tests/suite/base/test_voicemail_general.py
+++ b/integration_tests/suite/base/test_voicemail_general.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import assert_that, has_entries
@@ -10,17 +10,16 @@ from ..helpers.config import TOKEN_SUB_TENANT
 
 def test_put_errors():
     url = confd.asterisk.voicemail.general.put
-    for check in error_checks(url):
-        yield check
+    error_checks(url)
 
 
 def error_checks(url):
-    yield s.check_bogus_field_returns_error, url, 'options', 123
-    yield s.check_bogus_field_returns_error, url, 'options', None
-    yield s.check_bogus_field_returns_error, url, 'options', 'string'
-    yield s.check_bogus_field_returns_error, url, 'options', [['ordered', 'option']]
-    yield s.check_bogus_field_returns_error, url, 'options', {'wrong_value': 23}
-    yield s.check_bogus_field_returns_error, url, 'options', {'none_value': None}
+    s.check_bogus_field_returns_error(url, 'options', 123)
+    s.check_bogus_field_returns_error(url, 'options', None)
+    s.check_bogus_field_returns_error(url, 'options', 'string')
+    s.check_bogus_field_returns_error(url, 'options', [['ordered', 'option']])
+    s.check_bogus_field_returns_error(url, 'options', {'wrong_value': 23})
+    s.check_bogus_field_returns_error(url, 'options', {'none_value': None})
 
 
 def test_get():
@@ -69,4 +68,4 @@ def test_bus_event_when_edited():
     url = confd.asterisk.voicemail.general
     headers = {}
 
-    yield s.check_event, 'voicemail_general_edited', headers, url.put, {'options': {}}
+    s.check_event('voicemail_general_edited', headers, url.put, {'options': {}})

--- a/integration_tests/suite/base/test_voicemail_zonemessages.py
+++ b/integration_tests/suite/base/test_voicemail_zonemessages.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from ..helpers import scenarios as s
@@ -10,64 +10,63 @@ from ..helpers.config import TOKEN_SUB_TENANT
 
 def test_put_errors():
     url = confd.asterisk.voicemail.zonemessages.put
-    for check in error_checks(url):
-        yield check
+    error_checks(url)
 
 
 def error_checks(url):
-    yield s.check_bogus_field_returns_error, url, 'items', 123
-    yield s.check_bogus_field_returns_error, url, 'items', None
-    yield s.check_bogus_field_returns_error, url, 'items', {}
-    yield s.check_bogus_field_returns_error, url, 'items', 'string'
-    yield s.check_bogus_field_returns_error, url, 'items', ['string']
-    yield s.check_bogus_field_returns_error, url, 'items', [{'key': 'value'}]
+    s.check_bogus_field_returns_error(url, 'items', 123)
+    s.check_bogus_field_returns_error(url, 'items', None)
+    s.check_bogus_field_returns_error(url, 'items', {})
+    s.check_bogus_field_returns_error(url, 'items', 'string')
+    s.check_bogus_field_returns_error(url, 'items', ['string'])
+    s.check_bogus_field_returns_error(url, 'items', [{'key': 'value'}])
 
     regex = r'items.*name'
-    yield s.check_bogus_field_returns_error_matching_regex, url, 'items', [
-        {'name': 123}
-    ], regex
-    yield s.check_bogus_field_returns_error_matching_regex, url, 'items', [
-        {'name': True}
-    ], regex
-    yield s.check_bogus_field_returns_error_matching_regex, url, 'items', [
-        {'name': None}
-    ], regex
-    yield s.check_bogus_field_returns_error_matching_regex, url, 'items', [
-        {'name': {}}
-    ], regex
-    yield s.check_bogus_field_returns_error_matching_regex, url, 'items', [
-        {'name': []}
-    ], regex
+    s.check_bogus_field_returns_error_matching_regex(
+        url, 'items', [{'name': 123}], regex
+    )
+    s.check_bogus_field_returns_error_matching_regex(
+        url, 'items', [{'name': True}], regex
+    )
+    s.check_bogus_field_returns_error_matching_regex(
+        url, 'items', [{'name': None}], regex
+    )
+    s.check_bogus_field_returns_error_matching_regex(
+        url, 'items', [{'name': {}}], regex
+    )
+    s.check_bogus_field_returns_error_matching_regex(
+        url, 'items', [{'name': []}], regex
+    )
     regex = r'items.*timezone'
-    yield s.check_bogus_field_returns_error_matching_regex, url, 'items', [
-        {'timezone': 123}
-    ], regex
-    yield s.check_bogus_field_returns_error_matching_regex, url, 'items', [
-        {'timezone': True}
-    ], regex
-    yield s.check_bogus_field_returns_error_matching_regex, url, 'items', [
-        {'timezone': None}
-    ], regex
-    yield s.check_bogus_field_returns_error_matching_regex, url, 'items', [
-        {'timezone': {}}
-    ], regex
-    yield s.check_bogus_field_returns_error_matching_regex, url, 'items', [
-        {'timezone': []}
-    ], regex
+    s.check_bogus_field_returns_error_matching_regex(
+        url, 'items', [{'timezone': 123}], regex
+    )
+    s.check_bogus_field_returns_error_matching_regex(
+        url, 'items', [{'timezone': True}], regex
+    )
+    s.check_bogus_field_returns_error_matching_regex(
+        url, 'items', [{'timezone': None}], regex
+    )
+    s.check_bogus_field_returns_error_matching_regex(
+        url, 'items', [{'timezone': {}}], regex
+    )
+    s.check_bogus_field_returns_error_matching_regex(
+        url, 'items', [{'timezone': []}], regex
+    )
 
     regex = r'items.*message'
-    yield s.check_bogus_field_returns_error_matching_regex, url, 'items', [
-        {'message': 123}
-    ], regex
-    yield s.check_bogus_field_returns_error_matching_regex, url, 'items', [
-        {'message': True}
-    ], regex
-    yield s.check_bogus_field_returns_error_matching_regex, url, 'items', [
-        {'message': {}}
-    ], regex
-    yield s.check_bogus_field_returns_error_matching_regex, url, 'items', [
-        {'message': []}
-    ], regex
+    s.check_bogus_field_returns_error_matching_regex(
+        url, 'items', [{'message': 123}], regex
+    )
+    s.check_bogus_field_returns_error_matching_regex(
+        url, 'items', [{'message': True}], regex
+    )
+    s.check_bogus_field_returns_error_matching_regex(
+        url, 'items', [{'message': {}}], regex
+    )
+    s.check_bogus_field_returns_error_matching_regex(
+        url, 'items', [{'message': []}], regex
+    )
 
 
 def test_get():
@@ -128,6 +127,4 @@ def test_bus_event_when_edited():
     url = confd.asterisk.voicemail.zonemessages
     headers = {}
 
-    yield s.check_event, 'voicemail_zonemessages_edited', headers, url.put, {
-        'items': []
-    }
+    s.check_event('voicemail_zonemessages_edited', headers, url.put, {'items': []})

--- a/integration_tests/suite/base/test_voicemails.py
+++ b/integration_tests/suite/base/test_voicemails.py
@@ -22,101 +22,99 @@ from ..helpers.config import MAIN_TENANT, SUB_TENANT
 
 def test_search_errors():
     url = confd.voicemails.get
-    for check in s.search_error_checks(url):
-        yield check
+    s.search_error_checks(url)
 
 
 def test_get_errors():
     fake_get = confd.voicemails(999999).get
-    yield s.check_resource_not_found, fake_get, 'Voicemail'
+    s.check_resource_not_found(fake_get, 'Voicemail')
 
 
 def test_post_errors():
     url = confd.voicemails.post
-    for check in error_checks(url):
-        yield check
+    error_checks(url)
 
-    for check in error_required_checks(url):
-        yield check
+    error_required_checks(url)
 
 
 @fixtures.voicemail()
 def test_put_errors(voicemail):
     fake_put = confd.voicemails(9999999).put
-    yield s.check_resource_not_found, fake_put, 'Voicemail'
+    s.check_resource_not_found(fake_put, 'Voicemail')
 
     url = confd.voicemails(voicemail['id']).put
-    for check in error_checks(url):
-        yield check
+    error_checks(url)
 
 
 def error_checks(url):
-    yield s.check_bogus_field_returns_error, url, 'name', 123
-    yield s.check_bogus_field_returns_error, url, 'name', None
-    yield s.check_bogus_field_returns_error, url, 'name', True
-    yield s.check_bogus_field_returns_error, url, 'name', s.random_string(81)
-    yield s.check_bogus_field_returns_error, url, 'number', 123
-    yield s.check_bogus_field_returns_error, url, 'number', None
-    yield s.check_bogus_field_returns_error, url, 'number', 'one'
-    yield s.check_bogus_field_returns_error, url, 'number', '#1234'
-    yield s.check_bogus_field_returns_error, url, 'number', '*1234'
-    yield s.check_bogus_field_returns_error, url, 'number', s.random_string(0)
-    yield s.check_bogus_field_returns_error, url, 'number', s.random_string(41)
-    yield s.check_bogus_field_returns_error, url, 'context', 123
-    yield s.check_bogus_field_returns_error, url, 'context', None
-    yield s.check_bogus_field_returns_error, url, 'context', True
-    yield s.check_bogus_field_returns_error, url, 'password', 123
-    yield s.check_bogus_field_returns_error, url, 'password', True
-    yield s.check_bogus_field_returns_error, url, 'password', 'one'
-    yield s.check_bogus_field_returns_error, url, 'password', '#1234'
-    yield s.check_bogus_field_returns_error, url, 'password', '*1234'
-    yield s.check_bogus_field_returns_error, url, 'password', s.random_string(0)
-    yield s.check_bogus_field_returns_error, url, 'password', s.random_string(81)
-    yield s.check_bogus_field_returns_error, url, 'email', 123
-    yield s.check_bogus_field_returns_error, url, 'email', True
-    yield s.check_bogus_field_returns_error, url, 'email', s.random_string(81)
-    yield s.check_bogus_field_returns_error, url, 'language', 123
-    yield s.check_bogus_field_returns_error, url, 'language', True
-    yield s.check_bogus_field_returns_error, url, 'timezone', 123
-    yield s.check_bogus_field_returns_error, url, 'timezone', True
-    yield s.check_bogus_field_returns_error, url, 'max_messages', 'string'
-    yield s.check_bogus_field_returns_error, url, 'max_messages', -1
-    yield s.check_bogus_field_returns_error, url, 'max_messages', {}
-    yield s.check_bogus_field_returns_error, url, 'max_messages', []
-    yield s.check_bogus_field_returns_error, url, 'attach_audio', 'false'
-    yield s.check_bogus_field_returns_error, url, 'attach_audio', {}
-    yield s.check_bogus_field_returns_error, url, 'attach_audio', []
-    yield s.check_bogus_field_returns_error, url, 'delete_messages', 'true'
-    yield s.check_bogus_field_returns_error, url, 'delete_messages', None
-    yield s.check_bogus_field_returns_error, url, 'delete_messages', {}
-    yield s.check_bogus_field_returns_error, url, 'delete_messages', []
-    yield s.check_bogus_field_returns_error, url, 'ask_password', 'false'
-    yield s.check_bogus_field_returns_error, url, 'ask_password', None
-    yield s.check_bogus_field_returns_error, url, 'ask_password', {}
-    yield s.check_bogus_field_returns_error, url, 'ask_password', []
-    yield s.check_bogus_field_returns_error, url, 'options', 'string'
-    yield s.check_bogus_field_returns_error, url, 'options', 1234
-    yield s.check_bogus_field_returns_error, url, 'options', True
-    yield s.check_bogus_field_returns_error, url, 'options', None
-    yield s.check_bogus_field_returns_error, url, 'options', {}
-    yield s.check_bogus_field_returns_error, url, 'options', ['string']
-    yield s.check_bogus_field_returns_error, url, 'options', ['string', 'string']
-    yield s.check_bogus_field_returns_error, url, 'options', [{'string': 'string'}]
-    yield s.check_bogus_field_returns_error, url, 'options', [['string']]
-    yield s.check_bogus_field_returns_error, url, 'options', [[None, None]]
-    yield s.check_bogus_field_returns_error, url, 'options', [
-        ['string', 'string', 'string']
-    ]
-    yield s.check_bogus_field_returns_error, url, 'options', [
-        ['string', 'string'],
-        ['string'],
-    ]
+    s.check_bogus_field_returns_error(url, 'name', 123)
+    s.check_bogus_field_returns_error(url, 'name', None)
+    s.check_bogus_field_returns_error(url, 'name', True)
+    s.check_bogus_field_returns_error(url, 'name', s.random_string(81))
+    s.check_bogus_field_returns_error(url, 'number', 123)
+    s.check_bogus_field_returns_error(url, 'number', None)
+    s.check_bogus_field_returns_error(url, 'number', 'one')
+    s.check_bogus_field_returns_error(url, 'number', '#1234')
+    s.check_bogus_field_returns_error(url, 'number', '*1234')
+    s.check_bogus_field_returns_error(url, 'number', s.random_string(0))
+    s.check_bogus_field_returns_error(url, 'number', s.random_string(41))
+    s.check_bogus_field_returns_error(url, 'context', 123)
+    s.check_bogus_field_returns_error(url, 'context', None)
+    s.check_bogus_field_returns_error(url, 'context', True)
+    s.check_bogus_field_returns_error(url, 'password', 123)
+    s.check_bogus_field_returns_error(url, 'password', True)
+    s.check_bogus_field_returns_error(url, 'password', 'one')
+    s.check_bogus_field_returns_error(url, 'password', '#1234')
+    s.check_bogus_field_returns_error(url, 'password', '*1234')
+    s.check_bogus_field_returns_error(url, 'password', s.random_string(0))
+    s.check_bogus_field_returns_error(url, 'password', s.random_string(81))
+    s.check_bogus_field_returns_error(url, 'email', 123)
+    s.check_bogus_field_returns_error(url, 'email', True)
+    s.check_bogus_field_returns_error(url, 'email', s.random_string(81))
+    s.check_bogus_field_returns_error(url, 'language', 123)
+    s.check_bogus_field_returns_error(url, 'language', True)
+    s.check_bogus_field_returns_error(url, 'timezone', 123)
+    s.check_bogus_field_returns_error(url, 'timezone', True)
+    s.check_bogus_field_returns_error(url, 'max_messages', 'string')
+    s.check_bogus_field_returns_error(url, 'max_messages', -1)
+    s.check_bogus_field_returns_error(url, 'max_messages', {})
+    s.check_bogus_field_returns_error(url, 'max_messages', [])
+    s.check_bogus_field_returns_error(url, 'attach_audio', 'false')
+    s.check_bogus_field_returns_error(url, 'attach_audio', {})
+    s.check_bogus_field_returns_error(url, 'attach_audio', [])
+    s.check_bogus_field_returns_error(url, 'delete_messages', 'true')
+    s.check_bogus_field_returns_error(url, 'delete_messages', None)
+    s.check_bogus_field_returns_error(url, 'delete_messages', {})
+    s.check_bogus_field_returns_error(url, 'delete_messages', [])
+    s.check_bogus_field_returns_error(url, 'ask_password', 'false')
+    s.check_bogus_field_returns_error(url, 'ask_password', None)
+    s.check_bogus_field_returns_error(url, 'ask_password', {})
+    s.check_bogus_field_returns_error(url, 'ask_password', [])
+    s.check_bogus_field_returns_error(url, 'options', 'string')
+    s.check_bogus_field_returns_error(url, 'options', 1234)
+    s.check_bogus_field_returns_error(url, 'options', True)
+    s.check_bogus_field_returns_error(url, 'options', None)
+    s.check_bogus_field_returns_error(url, 'options', {})
+    s.check_bogus_field_returns_error(url, 'options', ['string'])
+    s.check_bogus_field_returns_error(url, 'options', ['string', 'string'])
+    s.check_bogus_field_returns_error(url, 'options', [{'string': 'string'}])
+    s.check_bogus_field_returns_error(url, 'options', [['string']])
+    s.check_bogus_field_returns_error(url, 'options', [[None, None]])
+    s.check_bogus_field_returns_error(url, 'options', [['string', 'string', 'string']])
+    s.check_bogus_field_returns_error(
+        url,
+        'options',
+        [
+            ['string', 'string'],
+            ['string'],
+        ],
+    )
 
 
 def error_required_checks(url):
-    yield s.check_missing_required_field_returns_error, url, 'name'
-    yield s.check_missing_required_field_returns_error, url, 'number'
-    yield s.check_missing_required_field_returns_error, url, 'context'
+    s.check_missing_required_field_returns_error(url, 'name')
+    s.check_missing_required_field_returns_error(url, 'number')
+    s.check_missing_required_field_returns_error(url, 'context')
 
 
 @fixtures.voicemail
@@ -133,7 +131,7 @@ def test_fake_fields(voicemail):
             fields = _generate_fields()
             fields[field] = value
             response = request(fields)
-            yield response.assert_match, 400, e.not_found(error_field)
+            response.assert_match(400, e.not_found(error_field))
 
 
 def _generate_fields():
@@ -185,7 +183,7 @@ def test_search(voicemail, hidden):
     }
 
     for field, term in searches.items():
-        yield check_search, url, voicemail, hidden, field, term
+        check_search(url, voicemail, hidden, field, term)
 
 
 def check_search(url, voicemail, hidden, field, term):
@@ -221,13 +219,13 @@ def test_list_multi_tenant(main_ctx, sub_ctx):
 )
 def test_sorting_offset_limit(voicemail1, voicemail2):
     url = confd.voicemails.get
-    yield s.check_sorting, url, voicemail1, voicemail2, 'name', 'sort'
-    yield s.check_sorting, url, voicemail1, voicemail2, 'number', '800'
-    yield s.check_sorting, url, voicemail1, voicemail2, 'email', 'sort'
-    yield s.check_sorting, url, voicemail1, voicemail2, 'pager', 'sort'
+    s.check_sorting(url, voicemail1, voicemail2, 'name', 'sort')
+    s.check_sorting(url, voicemail1, voicemail2, 'number', '800')
+    s.check_sorting(url, voicemail1, voicemail2, 'email', 'sort')
+    s.check_sorting(url, voicemail1, voicemail2, 'pager', 'sort')
 
-    yield s.check_offset, url, voicemail1, voicemail2, 'name', 'sort'
-    yield s.check_limit, url, voicemail1, voicemail2, 'name', 'sort'
+    s.check_offset(url, voicemail1, voicemail2, 'name', 'sort')
+    s.check_limit(url, voicemail1, voicemail2, 'name', 'sort')
 
 
 @fixtures.voicemail()
@@ -495,4 +493,4 @@ def test_user_voicemail_edited_bus_event(user, voicemail):
         body = {'name': 'bostwana'}
         headers = {'tenant_uuid': voicemail['tenant_uuid']}
 
-        yield s.check_event, 'user_voicemail_edited', headers, url, body
+        s.check_event('user_voicemail_edited', headers, url, body)

--- a/integration_tests/suite/helpers/base.py
+++ b/integration_tests/suite/helpers/base.py
@@ -81,8 +81,14 @@ class IntegrationTest(AssetLaunchingTestCase):
         )
 
     @classmethod
-    def _create_auth_tenant(cls):
-        cls.mock_auth.set_tenants(*DEFAULT_TENANTS)
+    def _create_auth_tenant(cls, tenant_uuid):
+        new_tenant_candidates = [
+            tenant for tenant in ALL_TENANTS if tenant['uuid'] == tenant_uuid
+        ]
+        if not new_tenant_candidates:
+            raise Exception('Cannot create tenant {tenant_uuid}: tenant unknown')
+        new_tenant = new_tenant_candidates[0]
+        cls.mock_auth.set_tenants(new_tenant, *DEFAULT_TENANTS)
 
     @classmethod
     def _delete_auth_tenant(cls):
@@ -91,6 +97,10 @@ class IntegrationTest(AssetLaunchingTestCase):
     @classmethod
     def _reset_auth_tenants(cls):
         cls.mock_auth.set_tenants(*ALL_TENANTS)
+
+    @classmethod
+    def _reset_confd_tenants(cls):
+        cls.sync_db()
 
     @classmethod
     @contextmanager
@@ -104,9 +114,10 @@ class IntegrationTest(AssetLaunchingTestCase):
     @classmethod
     @contextmanager
     def create_auth_tenant(cls, tenant_uuid):  # tenant_uuid improve readability
-        cls._create_auth_tenant()  # FIXME pass tenant_uuid
+        cls._create_auth_tenant(tenant_uuid)
         yield
         cls._reset_auth_tenants()
+        cls._reset_confd_tenants()
 
     @classmethod
     def setup_provd(cls, *args, **kwargs):  # args seems needed for IsolatedAction

--- a/integration_tests/suite/helpers/bus.py
+++ b/integration_tests/suite/helpers/bus.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from wazo_test_helpers import bus
@@ -14,6 +14,8 @@ class BusClientWrapper:
 
     def __getattr__(self, attr):
         if self._bus is None:
+            if self.host is None:
+                raise AttributeError('BusClientWrapper is not initialized yet')
             self._bus = self._create_client()
         return getattr(self._bus, attr)
 

--- a/integration_tests/suite/helpers/config.py
+++ b/integration_tests/suite/helpers/config.py
@@ -35,12 +35,6 @@ DEFAULT_TENANTS = [
         'slug': 'slug3',
         'parent_uuid': MAIN_TENANT,
     },
-    {
-        'uuid': CREATED_TENANT,
-        'name': 'name4',
-        'slug': 'slug4',
-        'parent_uuid': MAIN_TENANT,
-    },
 ]
 ALL_TENANTS = DEFAULT_TENANTS + [
     {
@@ -48,7 +42,13 @@ ALL_TENANTS = DEFAULT_TENANTS + [
         'name': 'name3',
         'slug': 'slug3',
         'parent_uuid': MAIN_TENANT,
-    }
+    },
+    {
+        'uuid': CREATED_TENANT,
+        'name': 'name4',
+        'slug': 'slug4',
+        'parent_uuid': MAIN_TENANT,
+    },
 ]
 
 

--- a/integration_tests/suite/helpers/helpers/__init__.py
+++ b/integration_tests/suite/helpers/helpers/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2021 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from ..client import ConfdClient
@@ -15,6 +15,8 @@ class NewClientWrapper:
 
     def __getattr__(self, attr):
         if self._client is None:
+            if self.host is None:
+                raise AttributeError('BusClientWrapper is not initialized yet')
             self._client = self._create_client()
 
         # This trick is needed because the self._client.url cannot be "confd.users.import.post()"
@@ -40,6 +42,8 @@ class DatabaseWrapper:
 
     def __getattr__(self, attr):
         if self._db is None:
+            if self.host is None:
+                raise AttributeError('BusClientWrapper is not initialized yet')
             self._db = db_create_helper(host=self.host, port=self.port)
         return getattr(self._db, attr)
 
@@ -52,6 +56,8 @@ class ProvdWrapper:
 
     def __getattr__(self, attr):
         if self._provd is None:
+            if self.host is None:
+                raise AttributeError('BusClientWrapper is not initialized yet')
             from ..provd import create_helper as provd_create_helper
 
             self._provd = provd_create_helper(host=self.host, port=self.port)

--- a/integration_tests/suite/helpers/scenarios.py
+++ b/integration_tests/suite/helpers/scenarios.py
@@ -84,12 +84,12 @@ def check_event(event_name, expected_headers, url, body=None):
 
 
 def search_error_checks(url):
-    yield check_bogus_query_string_returns_error, url, 'order', 'invalid_column'
-    yield check_bogus_query_string_returns_error, url, 'direction', 'invalid'
-    yield check_bogus_query_string_returns_error, url, 'limit', -42
-    yield check_bogus_query_string_returns_error, url, 'limit', 'invalid'
-    yield check_bogus_query_string_returns_error, url, 'offset', -42
-    yield check_bogus_query_string_returns_error, url, 'offset', 'invalid'
+    check_bogus_query_string_returns_error(url, 'order', 'invalid_column')
+    check_bogus_query_string_returns_error(url, 'direction', 'invalid')
+    check_bogus_query_string_returns_error(url, 'limit', -42)
+    check_bogus_query_string_returns_error(url, 'limit', 'invalid')
+    check_bogus_query_string_returns_error(url, 'offset', -42)
+    check_bogus_query_string_returns_error(url, 'offset', 'invalid')
 
 
 def check_bogus_query_string_returns_error(request, query_string, bogus):

--- a/integration_tests/test-requirements.txt
+++ b/integration_tests/test-requirements.txt
@@ -3,9 +3,9 @@ https://github.com/wazo-platform/wazo-provd-client/archive/master.zip
 https://github.com/wazo-platform/wazo-test-helpers/archive/master.zip
 docker
 kombu
-nose
 openapi-spec-validator<0.6.0  # dependency conflict on requests version (>2.31.0) with wazo clients (=2.25.1)
 psycopg2-binary  # sqlalchemy engine
 pyhamcrest
+pytest
 requests
 sqlalchemy<2

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,2 @@
-[nosetests]
-exclude=integration_tests
-
 [tool:pytest]
 norecursedirs = integration_tests

--- a/tox.ini
+++ b/tox.ini
@@ -34,8 +34,6 @@ passenv =
     MANAGE_DB_DIR
 commands =
     make test-setup
-# Explicit match to avoid to include AssetLaunchingTestCase helper methods
-# This constraint must be removed when tests will be migrated to pytest
-    nosetests --match '^[Tt]est' -v {posargs}
+    pytest -v {posargs}
 allowlist_externals =
     make


### PR DESCRIPTION
## remove conflict between pytest and confd fixtures

How:

* Hack pytest to ignore the x first arguments, replacing the trick used
  for the mock library
* See also:
  https://github.com/pytest-dev/pytest/blob/main/src/_pytest/compat.py#L85

## agent tests: remove agents after creation to avoid conflict

Why:

* Subsequent tests were unable to create agent 1234

## helper bus: avoid early initialization

Why:

* pytest tries to access attributes on all global variables to detect
  which ones are fixtures
* this initializes the bus client too early, before the host and port
  are set

## meeting tests: add missing teardown

Why:

* Other tests will fail because the extension is missing because meetingjoin is disabled

## helpers: avoid early initialization

Why:

* pytest tries to access attributes on all global variables to
  detect which ones are fixtures
* this initializes the clients too early, before the host and
  port are set

## integration test sync db: fix default tenants

Why:

* the created tenant should not exist before the test
* the assertion of empty sip templates for CREATED_TENANT was failing
  with pytest

## test trunk: repair broken tests

Why:

* due to the aux() function, the yielded tests were never executed

## integration tests: fix global setup/teardown for pytest


## integration tests: replace yields with function calls

Why:

* pytest does not support test generators

## tests: replace nosetests with pytest