### PR TITLE
Pull request for WAZO-1870-remove-global-parking

### DIFF
--- a/integration_tests/suite/base/test_func_keys.py
+++ b/integration_tests/suite/base/test_func_keys.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import unittest
@@ -186,8 +186,8 @@ class TestAllFuncKeyDestinations(BaseTestFuncKey):
         forward_number = '5000'
         custom_exten = '9999'
         paging_number = '1234'
-        parking = '700'
-        park_pos = 701
+        # parking = '700'
+        # park_pos = 701
 
         with self.db.queries() as queries:
             group_id = queries.insert_group(number=group_exten, tenant_uuid=MAIN_TENANT)
@@ -293,8 +293,8 @@ class TestAllFuncKeyDestinations(BaseTestFuncKey):
                     user_id=self.user['id'], agent_id=agent_id
                 ),
             },
-            '26': {'label': '', 'type': 'speeddial', 'line': 1, 'value': str(park_pos)},
-            '27': {'label': '', 'type': 'park', 'line': 1, 'value': parking},
+            # '26': {'label': '', 'type': 'speeddial', 'line': 1, 'value': str(park_pos)},
+            # '27': {'label': '', 'type': 'park', 'line': 1, 'value': parking},
             '28': {
                 'label': '',
                 'type': 'speeddial',
@@ -443,11 +443,11 @@ class TestAllFuncKeyDestinations(BaseTestFuncKey):
                     'agent_id': agent_id,
                 },
             },
-            '26': {
-                'blf': False,
-                'destination': {'type': 'park_position', 'position': park_pos},
-            },
-            '27': {'blf': False, 'destination': {'type': 'parking'}},
+            # '26': {
+            #     'blf': False,
+            #     'destination': {'type': 'park_position', 'position': park_pos},
+            # },
+            # '27': {'blf': False, 'destination': {'type': 'parking'}},
             '28': {
                 'blf': False,
                 'destination': {'type': 'paging', 'paging_id': paging_id},
@@ -559,12 +559,12 @@ class TestTemplateAssociation(BaseTestFuncKey):
 
         self.funckeys = {
             '1': {'destination': {'type': 'custom', 'exten': '9999'}},
-            '2': {'destination': {'type': 'parking'}},
+            '2': {'destination': {'type': 'transfer', 'transfer': 'blind'}},
         }
 
         self.provd_funckeys = {
             '1': {'label': '', 'type': 'blf', 'line': 1, 'value': '9999'},
-            '2': {'label': '', 'type': 'park', 'line': 1, 'value': '700'},
+            '2': {'label': '', 'type': 'speeddial', 'line': 1, 'value': '*1'},
         }
 
         response = confd.funckeys.templates.post(keys=self.funckeys)
@@ -1308,8 +1308,11 @@ class TestBlfFuncKeys(BaseTestFuncKey):
         self,
     ):
         position = '1'
-        funckey = {'blf': True, 'destination': {'type': 'parking'}}
-        provd_funckey = {'label': '', 'type': 'park', 'line': 1, 'value': '700'}
+        funckey = {
+            'blf': True,
+            'destination': {'type': 'transfer', 'transfer': 'blind'},
+        }
+        provd_funckey = {'label': '', 'type': 'speeddial', 'line': 1, 'value': '*1'}
 
         self.add_funckey_to_user(position, funckey)
         self.check_provd_has_funckey(position, provd_funckey)

--- a/integration_tests/suite/base/test_func_keys.py
+++ b/integration_tests/suite/base/test_func_keys.py
@@ -70,10 +70,10 @@ invalid_destinations = [
     {'type': 'paging', 'bad_field': 123},
     {'type': 'paging', 'paging_id': 'invalid'},
     {'type': 'paging', 'paging_id': None},
-    {'type': 'park_position'},
-    {'type': 'park_position', 'bad_field': 123},
-    {'type': 'park_position', 'position': 'invalid'},
-    {'type': 'park_position', 'position': None},
+    # {'type': 'park_position'},
+    # {'type': 'park_position', 'bad_field': 123},
+    # {'type': 'park_position', 'position': 'invalid'},
+    # {'type': 'park_position', 'position': None},
     {'type': 'queue'},
     {'type': 'queue', 'bad_field': 123},
     {'type': 'queue', 'queue_id': 'string'},
@@ -1096,7 +1096,7 @@ class TestBlfFuncKeys(BaseTestFuncKey):
         conf_exten = '4000'
         forward_number = '5000'
         custom_exten = '9999'
-        park_pos = 701
+        # park_pos = 701
 
         with self.db.queries() as queries:
             conference_id = queries.insert_conference(
@@ -1150,7 +1150,7 @@ class TestBlfFuncKeys(BaseTestFuncKey):
                     'agent_id': agent_id,
                 }
             },
-            '26': {'destination': {'type': 'park_position', 'position': park_pos}},
+            # '26': {'destination': {'type': 'park_position', 'position': park_pos}},
             '29': {
                 'destination': {
                     'type': 'bsfilter',
@@ -1258,7 +1258,7 @@ class TestBlfFuncKeys(BaseTestFuncKey):
                     user_id=self.user['id'], agent_id=agent_id
                 ),
             },
-            '26': {'label': '', 'type': 'blf', 'line': 1, 'value': str(park_pos)},
+            # '26': {'label': '', 'type': 'blf', 'line': 1, 'value': str(park_pos)},
             '29': {
                 'label': '',
                 'type': 'blf',

--- a/integration_tests/suite/base/test_users_func_keys.py
+++ b/integration_tests/suite/base/test_users_func_keys.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import assert_that, has_entries, has_key, is_not
@@ -91,25 +91,25 @@ def test_put_position(user, line_sip, extension, device):
     modified_funckey = {
         'blf': False,
         'label': 'myfunckey',
-        'destination': {'type': 'park_position', 'position': 701},
+        'destination': {'type': 'service', 'service': 'recsnd'},
     }
     uuid_funckey = {
         'blf': False,
         'label': 'myfunckey',
-        'destination': {'type': 'park_position', 'position': 702},
+        'destination': {'type': 'service', 'service': 'phonestatus'},
     }
 
     provd_funckey = {
         'label': 'myfunckey',
         'type': 'speeddial',
         'line': 1,
-        'value': '701',
+        'value': '*9',
     }
     provd_uuid_funckey = {
         'label': 'myfunckey',
         'type': 'speeddial',
         'line': 1,
-        'value': '702',
+        'value': '*10',
     }
     position = 1
 

--- a/wazo_confd/plugins/device/generators.py
+++ b/wazo_confd/plugins/device/generators.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 
@@ -58,7 +58,7 @@ class ExtensionGenerator:
             'exten_fwd_no_answer': self.find_exten('fwdrna'),
             'exten_fwd_busy': self.find_exten('fwdbusy'),
             'exten_fwd_disable_all': self.find_exten('fwdundoall'),
-            'exten_park': self.find_exten('parkext'),
+            'exten_park': None,
             'exten_pickup_group': self.find_exten('pickupexten'),
             'exten_pickup_call': self.find_exten('pickup'),
             'exten_voicemail': self.find_exten('vmusermsg'),

--- a/wazo_confd/plugins/features/resource.py
+++ b/wazo_confd/plugins/features/resource.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from flask import request
@@ -16,7 +16,6 @@ from marshmallow.exceptions import ValidationError
 
 from xivo_dao.alchemy.features import Features
 from xivo_dao.resources.features.search import (
-    PARKING_OPTIONS,
     FUNC_KEY_FEATUREMAP_FOREIGN_KEY,
     FUNC_KEY_APPLICATIONMAP_FOREIGN_KEY,
 )
@@ -26,6 +25,23 @@ from wazo_confd.helpers.mallow import BaseSchema, Nested
 from wazo_confd.helpers.restful import ConfdResource
 
 PARKING_ERROR = "The parking options can only be defined with the parkinglots API"
+PARKING_OPTIONS = [
+    'comebacktoorigin',
+    'context',
+    'courtesytone',
+    'findslot',
+    'parkedcallhangup',
+    'parkedcallrecording',
+    'parkedcallreparking',
+    'parkedcalltransfers',
+    'parkeddynamic',
+    'parkedmusicclass',
+    'parkedplay',
+    'parkext',
+    'parkinghints',
+    'parkingtime',
+    'parkpos',
+]
 
 
 class AsteriskOptionSchema(BaseSchema):

--- a/wazo_confd/plugins/func_key/resource.py
+++ b/wazo_confd/plugins/func_key/resource.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from flask import url_for, request
@@ -10,13 +10,11 @@ from xivo_dao.alchemy.func_key_dest_conference import FuncKeyDestConference
 from xivo_dao.alchemy.func_key_dest_features import (
     FuncKeyDestTransfer,
     FuncKeyDestOnlineRecording,
-    FuncKeyDestParking,
 )
 from xivo_dao.alchemy.func_key_dest_forward import FuncKeyDestForward
 from xivo_dao.alchemy.func_key_dest_group import FuncKeyDestGroup
 from xivo_dao.alchemy.func_key_dest_group_member import FuncKeyDestGroupMember
 from xivo_dao.alchemy.func_key_dest_paging import FuncKeyDestPaging
-from xivo_dao.alchemy.func_key_dest_park_position import FuncKeyDestParkPosition
 from xivo_dao.alchemy.func_key_dest_queue import FuncKeyDestQueue
 from xivo_dao.alchemy.func_key_dest_service import FuncKeyDestService
 from xivo_dao.alchemy.func_key_dest_user import FuncKeyDestUser
@@ -44,8 +42,8 @@ models_destination = {
     'groupmember': FuncKeyDestGroupMember,
     'onlinerec': FuncKeyDestOnlineRecording,
     'paging': FuncKeyDestPaging,
-    'park_position': FuncKeyDestParkPosition,
-    'parking': FuncKeyDestParking,
+    # 'park_position': FuncKeyDestParkPosition,
+    # 'parking': FuncKeyDestParking,
     'queue': FuncKeyDestQueue,
     'service': FuncKeyDestService,
     'transfer': FuncKeyDestTransfer,

--- a/wazo_confd/plugins/func_key/schema.py
+++ b/wazo_confd/plugins/func_key/schema.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from flask import url_for
@@ -24,8 +24,8 @@ class BaseDestinationSchema(Schema):
                 'groupmember',
                 'onlinerec',
                 'paging',
-                'park_position',
-                'parking',
+                # 'park_position',
+                # 'parking',
                 'queue',
                 'service',
                 'transfer',

--- a/wazo_confd/plugins/func_key/tests/test_validator.py
+++ b/wazo_confd/plugins/func_key/tests/test_validator.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import unittest
@@ -11,7 +11,6 @@ from xivo_dao.alchemy.callfiltermember import Callfiltermember as CallFilterMemb
 from xivo_dao.alchemy.func_key_dest_bsfilter import FuncKeyDestBSFilter
 from xivo_dao.alchemy.func_key_dest_custom import FuncKeyDestCustom
 from xivo_dao.alchemy.func_key_dest_forward import FuncKeyDestForward
-from xivo_dao.alchemy.func_key_dest_park_position import FuncKeyDestParkPosition
 from xivo_dao.alchemy.func_key_dest_service import FuncKeyDestService
 from xivo_dao.alchemy.func_key_mapping import FuncKeyMapping as FuncKey
 from xivo_dao.alchemy.func_key_template import FuncKeyTemplate
@@ -25,7 +24,6 @@ from wazo_confd.plugins.func_key.validator import (
     CustomValidator,
     ForwardValidator,
     FuncKeyModelValidator,
-    ParkPositionValidator,
     PrivateTemplateValidator,
     SimilarFuncKeyValidator,
 )
@@ -195,48 +193,6 @@ class TestForwardValidator(unittest.TestCase):
         destination = FuncKeyDestForward(forward='noanswer', exten='hello')
 
         self.validator.validate(destination)
-
-
-class TestParkPositionValidator(unittest.TestCase):
-    def setUp(self):
-        self.dao = Mock()
-        self.dao.find_park_position_range.return_value = (701, 750)
-        self.validator = ParkPositionValidator(self.dao)
-
-    def test_given_position_under_minimum_then_raises_error(self):
-        destination = FuncKeyDestParkPosition(position=600)
-
-        assert_that(
-            calling(self.validator.validate).with_args(destination), raises(InputError)
-        )
-
-    def test_given_position_over_maximum_then_raises_error(self):
-        destination = FuncKeyDestParkPosition(position=800)
-
-        assert_that(
-            calling(self.validator.validate).with_args(destination), raises(InputError)
-        )
-
-    def test_given_position_on_minimum_position_then_validation_passes(self):
-        destination = FuncKeyDestParkPosition(position=701)
-
-        self.validator.validate(destination)
-
-        self.dao.find_park_position_range.assert_called_once_with()
-
-    def test_given_position_on_maximum_position_then_validation_passes(self):
-        destination = FuncKeyDestParkPosition(position=750)
-
-        self.validator.validate(destination)
-
-        self.dao.find_park_position_range.assert_called_once_with()
-
-    def test_given_position_inside_range_then_validation_passes(self):
-        destination = FuncKeyDestParkPosition(position=710)
-
-        self.validator.validate(destination)
-
-        self.dao.find_park_position_range.assert_called_once_with()
 
 
 class TestCustomValidator(unittest.TestCase):

--- a/wazo_confd/plugins/func_key/validator.py
+++ b/wazo_confd/plugins/func_key/validator.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from collections import Counter
@@ -7,7 +7,6 @@ from xivo_dao.helpers import errors
 from xivo_dao.resources.agent import dao as agent_dao
 from xivo_dao.resources.call_filter import dao as call_filter_dao
 from xivo_dao.resources.conference import dao as conference_dao
-from xivo_dao.resources.features import dao as feature_dao
 from xivo_dao.resources.group import dao as group_dao
 from xivo_dao.resources.paging import dao as paging_dao
 from xivo_dao.resources.queue import dao as queue_dao
@@ -109,18 +108,6 @@ class ForwardValidator(FuncKeyValidator):
         self.validate_text(destination.exten, 'exten')
 
 
-class ParkPositionValidator(FuncKeyValidator):
-    def __init__(self, dao):
-        self.dao = dao
-
-    def validate(self, destination):
-        min_pos, max_pos = self.dao.find_park_position_range()
-        position = destination.position
-
-        if not min_pos <= position <= max_pos:
-            raise errors.outside_park_range(position, min=min_pos, max=max_pos)
-
-
 class CustomValidator(FuncKeyValidator):
     def validate(self, destination):
         self.validate_text(destination.exten, 'exten')
@@ -150,8 +137,8 @@ def build_validator():
         'groupmember': [GetResource('group_id', group_dao.get, 'Group')],
         'onlinerec': [],
         'paging': [GetResource('paging_id', paging_dao.get, 'Paging')],
-        'park_position': [ParkPositionValidator(feature_dao)],
-        'parking': [],
+        # 'park_position': [],
+        # 'parking': [],
         'queue': [GetResource('queue_id', queue_dao.get, 'Queue')],
         'service': [],
         'transfer': [],


### PR DESCRIPTION
Depends-On: https://github.com/wazo-platform/xivo-dao/pull/259

## funckeys: remove validation for global parking extens


## features: move rejected parking options from dao

Why:

* the DAO does not need it anymore, since the options are removed from
  the database. Those options are now only needed for API validation.

## devices: remove generation of global parking extension


## tests: ignore parking function keys

Why:

* They will be reinstated after the funckeys can use parking lots
  instead of the global parking