### PR TITLE
registrar: delete sccp backup config when IP is null

### DIFF
--- a/wazo_confd/plugins/registrar/service.py
+++ b/wazo_confd/plugins/registrar/service.py
@@ -78,4 +78,7 @@ class RegistrarService(CRUDService):
         if main:
             main['ip'] = registrar.proxy_main_host
         if backup:
-            backup['ip'] = registrar.proxy_backup_host
+            if registrar.proxy_backup_host:
+                backup['ip'] = registrar.proxy_backup_host
+            else:
+                del config['2']


### PR DESCRIPTION
Why: it should not be there at all and it affects HA disabling