### PR TITLE
[WAZO-3695] Sounds - calculate total before filtering

### DIFF
--- a/integration_tests/suite/base/test_sounds.py
+++ b/integration_tests/suite/base/test_sounds.py
@@ -7,10 +7,12 @@ from hamcrest import (
     any_of,
     contains,
     contains_inanyorder,
+    contains_exactly,
     empty,
     equal_to,
     has_entries,
     has_items,
+    has_length,
 )
 
 from ..helpers import errors as e
@@ -87,6 +89,11 @@ def test_list(sound1, sound2):
 
     response = confd.sounds.get(wazo_tenant=MAIN_TENANT, recurse=True)
     assert_that(response.items, has_items(sound1, sound2, has_entries(name='system')))
+
+    response = confd.sounds.get(wazo_tenant=SUB_TENANT, limit=1)
+    assert_that(response.items, contains_exactly(sound2))
+    assert_that(response.items, has_length(1))
+    assert_that(response.total, equal_to(2))
 
 
 @fixtures.sound()

--- a/wazo_confd/plugins/sound/service.py
+++ b/wazo_confd/plugins/sound/service.py
@@ -33,11 +33,11 @@ class SoundService:
 
     def search(self, parameters, tenant_uuids):
         sound_system = self._get_asterisk_sound(parameters)
-        sounds = self._storage.list_directories(parameters, tenant_uuids)
-        sounds.append(sound_system)
+        all_sounds = self._storage.list_directories(parameters, tenant_uuids)
+        all_sounds.append(sound_system)
 
-        sounds = self._filter_and_sort_categories(sounds, parameters)
-        total = len(sounds)
+        total = len(all_sounds)
+        sounds = self._filter_and_sort_categories(all_sounds, parameters)
         return total, sounds
 
     def _validate_parameters(self, parameters):


### PR DESCRIPTION
## Summary of changes

Fix sounds' pagination result to be like other resources. `total` is always the `total` of items for the given tenant, when using `limit`, we expect `items` to be limited.

## How to test
- Create 10 sounds on a tenant
- `GET /sounds?limit=2`
- Expect `items` to have 2 items and `total` to be 10