### PR TITLE
default sip template: added 'set_var' option to default global sip template

### DIFF
--- a/wazo_confd/plugins/event_handlers/service.py
+++ b/wazo_confd/plugins/event_handlers/service.py
@@ -80,6 +80,7 @@ class DefaultSIPTemplateService:
                 ['trust_id_inbound', 'no'],
                 ['allow_subscribe', 'yes'],
                 ['allow', '!all,ulaw'],
+                ['set_var', 'TIMEOUT(absolute)=36000'],
                 ['notify_early_inuse_ringing', 'yes'],
             ],
             'registration_section_options': [],


### PR DESCRIPTION
 in order to limit maximum call duration using `TIMEOUT(absolute)`