### PR TITLE
plugins.ingress_http Allow fallback to master tenant when empty

### DIFF
--- a/integration_tests/suite/base/test_ingress_http.py
+++ b/integration_tests/suite/base/test_ingress_http.py
@@ -99,11 +99,14 @@ def test_list_fallback_tenant(main):
     assert_that(response.items, has_items(main))
     assert_that(len(response.items), is_(1))
 
-    response = confd.ingresses.http.get(wazo_tenant=SUB_TENANT, fallback=True)
+    response = confd.ingresses.http.get(wazo_tenant=SUB_TENANT, view='fallback')
     assert_that(response.items, has_items(main))
     assert_that(len(response.items), is_(1))
 
-    response = confd.ingresses.http.get(wazo_tenant=SUB_TENANT, fallback=False)
+    response = confd.ingresses.http.get(wazo_tenant=SUB_TENANT, view='default')
+    assert_that(len(response.items), is_(0))
+
+    response = confd.ingresses.http.get(wazo_tenant=SUB_TENANT)
     assert_that(len(response.items), is_(0))
 
 

--- a/integration_tests/suite/base/test_ingress_http.py
+++ b/integration_tests/suite/base/test_ingress_http.py
@@ -9,6 +9,7 @@ from hamcrest import (
     has_entries,
     has_entry,
     has_items,
+    is_,
     is_not,
     not_,
 )
@@ -90,6 +91,20 @@ def test_list_multi_tenant(main, sub):
 
     response = confd.ingresses.http.get(wazo_tenant=MAIN_TENANT, recurse=True)
     assert_that(response.items, has_items(main, sub))
+
+
+@fixtures.ingress_http(wazo_tenant=MAIN_TENANT)
+def test_list_fallback_tenant(main):
+    response = confd.ingresses.http.get(wazo_tenant=MAIN_TENANT)
+    assert_that(response.items, has_items(main))
+    assert_that(len(response.items), is_(1))
+
+    response = confd.ingresses.http.get(wazo_tenant=SUB_TENANT, fallback=True)
+    assert_that(response.items, has_items(main))
+    assert_that(len(response.items), is_(1))
+
+    response = confd.ingresses.http.get(wazo_tenant=SUB_TENANT, fallback=False)
+    assert_that(len(response.items), is_(0))
 
 
 @fixtures.ingress_http(uri='sort1', wazo_tenant=MAIN_TENANT)

--- a/wazo_confd/helpers/restful.py
+++ b/wazo_confd/helpers/restful.py
@@ -75,10 +75,20 @@ class ListResource(ConfdResource):
         super().__init__()
         self.service = service
 
+    def unsafe_fallback_get(self, fallback_tenants=None):
+        params = self.search_params()
+        tenant_uuids = self._build_tenant_list(params)
+        if fallback_tenants:
+            tenant_uuids.extend(fallback_tenants)
+
+        return self._get(params, tenant_uuids)
+
     def get(self):
         params = self.search_params()
         tenant_uuids = self._build_tenant_list(params)
+        return self._get(params, tenant_uuids)
 
+    def _get(self, params, tenant_uuids):
         kwargs = {}
         if tenant_uuids is not None:
             kwargs['tenant_uuids'] = tenant_uuids

--- a/wazo_confd/helpers/restful.py
+++ b/wazo_confd/helpers/restful.py
@@ -75,20 +75,9 @@ class ListResource(ConfdResource):
         super().__init__()
         self.service = service
 
-    def unsafe_fallback_get(self, fallback_tenants=None):
-        params = self.search_params()
-        tenant_uuids = self._build_tenant_list(params)
-        if fallback_tenants:
-            tenant_uuids.extend(fallback_tenants)
-
-        return self._get(params, tenant_uuids)
-
     def get(self):
         params = self.search_params()
         tenant_uuids = self._build_tenant_list(params)
-        return self._get(params, tenant_uuids)
-
-    def _get(self, params, tenant_uuids):
         kwargs = {}
         if tenant_uuids is not None:
             kwargs['tenant_uuids'] = tenant_uuids

--- a/wazo_confd/plugins/ingress_http/api.yml
+++ b/wazo_confd/plugins/ingress_http/api.yml
@@ -14,7 +14,7 @@ paths:
       - $ref: '#/parameters/limit'
       - $ref: '#/parameters/offset'
       - $ref: '#/parameters/search'
-      - $ref: '#/parameters/fallback_to_master'
+      - $ref: '#/parameters/ingress_fallback_view'
       responses:
         '200':
           description: HTTP ingress list
@@ -103,14 +103,21 @@ parameters:
     type: string
     name: http_ingress_uuid
     in: path
-  fallback_to_master:
-    default: false
-    required: false
-    type: boolean
-    name: fallback
-    in: query
-    description: Allows to retrieve the Ingress of the master tenant when the tenant's Ingress is not set
+  ingress_fallback_view:
+    description: 'Allows to fallback on master tenant config if the current tenant has no ingress set.
 
+      When the `view` is omitted or the `default`value is passed, only the ingress of the current tenant
+      is returned. This is useful for configuration API.
+
+      For `fallback` view the API fallbacks to the master tenant ingress value.
+      '
+    enum:
+    - default
+    - fallback
+    in: query
+    name: view
+    required: false
+    type: string
 definitions:
   HTTPIngressItems:
     type: object

--- a/wazo_confd/plugins/ingress_http/api.yml
+++ b/wazo_confd/plugins/ingress_http/api.yml
@@ -14,6 +14,7 @@ paths:
       - $ref: '#/parameters/limit'
       - $ref: '#/parameters/offset'
       - $ref: '#/parameters/search'
+      - $ref: '#/parameters/fallback_to_master'
       responses:
         '200':
           description: HTTP ingress list
@@ -102,6 +103,13 @@ parameters:
     type: string
     name: http_ingress_uuid
     in: path
+  fallback_to_master:
+    default: false
+    required: false
+    type: boolean
+    name: fallback
+    in: query
+    description: Allows to retrieve the Ingress of the master tenant when the tenant's Ingress is not set
 
 definitions:
   HTTPIngressItems:

--- a/wazo_confd/plugins/ingress_http/schema.py
+++ b/wazo_confd/plugins/ingress_http/schema.py
@@ -13,3 +13,7 @@ class IngressHTTPSchema(BaseSchema):
     uri = fields.String(validate=Length(min=1, max=1024), required=True)
 
     links = ListLink(Link('ingresses_http', field='uuid'))
+
+
+class ExtraParamsSchema(BaseSchema):
+    fallback = fields.Boolean(required=False)

--- a/wazo_confd/plugins/ingress_http/schema.py
+++ b/wazo_confd/plugins/ingress_http/schema.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from marshmallow import fields
-from marshmallow.validate import Length
+from marshmallow.validate import Length, OneOf
 
 from wazo_confd.helpers.mallow import BaseSchema, Link, ListLink
 
@@ -15,5 +15,5 @@ class IngressHTTPSchema(BaseSchema):
     links = ListLink(Link('ingresses_http', field='uuid'))
 
 
-class ExtraParamsSchema(BaseSchema):
-    fallback = fields.Boolean(required=False)
+class IngressViewSchema(BaseSchema):
+    view = fields.String(validate=OneOf(['fallback', 'default']), required=False)


### PR DESCRIPTION
- added a new fallback query parameter to be able to retrieve a valid ingress from the master tenant if there's no ingress configured on the current tenant