### PR TITLE
WAZO-3859 Pull request for user-restore-count-db-requests

### DIFF
--- a/integration_tests/suite/base/test_users.py
+++ b/integration_tests/suite/base/test_users.py
@@ -708,6 +708,7 @@ def test_get_db_requests(user, perm):
             1  # user + joins
             + 1  # groups
             + 1  # pickups
+            + 1  # tenant
             + 2  # rightcalls
             + 2  # dialactions
             + 1  # lines

--- a/integration_tests/suite/base/test_users.py
+++ b/integration_tests/suite/base/test_users.py
@@ -624,12 +624,18 @@ def test_list_by_multiple_uuids(_, user2, user3):
     assert_that(response.items, contains_inanyorder(user2, user3))
 
 
-# TODO(pc-m): fails when running all tests
-# @fixtures.user(firstname='Alice')
-# @fixtures.user(firstname='Bob')
-# @fixtures.user(firstname='Charles')
-# def test_list_db_requests(*_):
-#     s.check_db_requests(BaseIntegrationTest, confd.users.get, nb_requests=1)
+@fixtures.user(firstname='Alice', wazo_tenant=SUB_TENANT)
+@fixtures.user(firstname='Bob', wazo_tenant=SUB_TENANT)
+@fixtures.user(firstname='Charles', wazo_tenant=SUB_TENANT)
+def test_list_db_requests(*_):
+    expected_request_count = 1  # SELECT
+    expected_request_count += 1  # SELECT COUNT
+    s.check_db_requests(
+        BaseIntegrationTest,
+        confd.users.get,
+        wazo_tenant=SUB_TENANT,
+        nb_requests=expected_request_count,
+    )
 
 
 @fixtures.user(

--- a/integration_tests/suite/helpers/scenarios.py
+++ b/integration_tests/suite/helpers/scenarios.py
@@ -133,10 +133,10 @@ def check_limit(url, resource1, resource2, field, search, id_field='id'):
     )
 
 
-def check_db_requests(cls, url, nb_requests):
+def check_db_requests(cls, url, nb_requests, **kwargs):
     time_start = datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%S.%fZ')
     nb_logs_start = cls.count_database_logs(since=time_start)
-    url()
+    url(**kwargs)
     nb_logs_end = cls.count_database_logs(since=time_start)
     actual_count = nb_logs_end - nb_logs_start
     expected_count = OVERHEAD_DB_REQUESTS + nb_requests

--- a/integration_tests/suite/helpers/wrappers.py
+++ b/integration_tests/suite/helpers/wrappers.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import _pytest
@@ -61,8 +61,10 @@ class IsolatedAction:
             resource = self.__enter__()
             # Pass the resource as an argument to the test function
             new_args = list(args) + [resource]
-            result = func(*new_args, **kwargs)
-            self.__exit__()
+            try:
+                result = func(*new_args, **kwargs)
+            finally:
+                self.__exit__()
             return result
 
         return decorated


### PR DESCRIPTION
Depends-On: https://github.com/wazo-platform/wazo-test-helpers/pull/108

## user tests: restore test for db queries in list


## tests: remove fixtures after assertion error

Why:

* Avoid one failing tests cause failures on subsequent tests