### PR TITLE
wizard.service: Changed NAMESERVER_REGEX

### DIFF
--- a/wazo_confd/plugins/wizard/service.py
+++ b/wazo_confd/plugins/wizard/service.py
@@ -18,7 +18,7 @@ from .notifier import build_notifier
 from .validator import build_validator
 
 USERNAME_VALUES = '2346789bcdfghjkmnpqrtvwxyzBCDFGHJKLMNPQRTVWXYZ'
-NAMESERVER_REGEX = r'^nameserver (\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})'
+NAMESERVER_REGEX = r'^nameserver\s(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})'
 DEFAULT_ROOT_POLICY = 'wazo_default_master_user_policy'
 ASTERISK_AUTOPROV_CONFIG_FILENAME = '/etc/asterisk/pjsip.d/05-autoprov-wizard.conf'
 ASTERISK_AUTOPROV_CONFIG_TPL = '''\

--- a/wazo_confd/plugins/wizard/tests/test_service.py
+++ b/wazo_confd/plugins/wizard/tests/test_service.py
@@ -117,6 +117,24 @@ class TestWizardService(unittest.TestCase):
         mopen.assert_called_once_with('/etc/resolv.conf', 'r')
         assert_that(result, equal_to(expected_result))
 
+    def test_get_nameservers_with_tabs(self):
+        resolv_conf = dedent(
+            '''
+            search\texample.com
+            nameserver\t192.168.2.0
+            nameserver\t192.168.2.1'''
+        )
+        expected_result = ['192.168.2.0', '192.168.2.1']
+        with patch(
+            'wazo_confd.plugins.wizard.service.open',
+            mock_open(read_data=resolv_conf),
+            create=True,
+        ) as mopen:
+            result = self.service.get_nameservers()
+
+        mopen.assert_called_once_with('/etc/resolv.conf', 'r')
+        assert_that(result, equal_to(expected_result))
+
     @patch('wazo_confd.plugins.wizard.service.open', create=True)
     def test_get_nameservers_return_none_if_no_file(self, mopen):
         mopen.side_effect = IOError()


### PR DESCRIPTION
to support tabs as separator
