### PR TITLE
Use marshmallow version 3.18.0 from Bookworm

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ itsdangerous==1.1.0  # from flask
 jinja2==3.0.3  # from flask
 kombu==5.0.2
 markupsafe==2.0.1 # from jinja
-marshmallow==3.10.0
+marshmallow==3.18.0
 netifaces==0.10.9
 psycopg2-binary==2.8.6
 pycountry==20.7.3

--- a/wazo_confd/plugins/agent_skill/resource.py
+++ b/wazo_confd/plugins/agent_skill/resource.py
@@ -13,7 +13,9 @@ from wazo_confd.helpers.mallow import BaseSchema
 
 
 class AgentSkillSchema(BaseSchema):
-    skill_weight = fields.Integer(validate=Range(min=0), missing=0, attribute='weight')
+    skill_weight = fields.Integer(
+        validate=Range(min=0), load_default=0, attribute='weight'
+    )
 
 
 class AgentSkillItem(ConfdResource):

--- a/wazo_confd/plugins/application/schema.py
+++ b/wazo_confd/plugins/application/schema.py
@@ -12,9 +12,9 @@ from wazo_confd.helpers.mallow import BaseSchema, Link, ListLink, Nested
 class NodeApplicationDestinationOptionsSchema(BaseSchema):
     type = fields.String(attribute='type_', validate=OneOf(['holding']), required=True)
     music_on_hold = fields.String(
-        validate=Length(max=128), allow_none=True, missing=None
+        validate=Length(max=128), allow_none=True, load_default=None
     )
-    answer = fields.Boolean(missing=False)
+    answer = fields.Boolean(load_default=False)
 
 
 class ApplicationDestinationOptionsField(fields.Field):
@@ -44,9 +44,9 @@ class ApplicationSchema(BaseSchema):
     destination = fields.String(
         validate=OneOf(ApplicationDestinationOptionsField._options.keys()),
         allow_none=True,
-        default=None,
+        dump_default=None,
     )
-    destination_options = ApplicationDestinationOptionsField(default={})
+    destination_options = ApplicationDestinationOptionsField(dump_default={})
     links = ListLink(Link('applications', field='uuid', target='application_uuid'))
 
     lines = Nested(

--- a/wazo_confd/plugins/call_filter_fallback/schema.py
+++ b/wazo_confd/plugins/call_filter_fallback/schema.py
@@ -10,7 +10,7 @@ from wazo_confd.helpers.destination import DestinationField
 
 class CallFilterFallbackSchema(BaseSchema):
     noanswer_destination = DestinationField(
-        attribute='noanswer', default=None, allow_none=True
+        attribute='noanswer', dump_default=None, allow_none=True
     )
 
     @post_load

--- a/wazo_confd/plugins/call_filter_user/schema.py
+++ b/wazo_confd/plugins/call_filter_user/schema.py
@@ -9,7 +9,7 @@ from wazo_confd.helpers.mallow import BaseSchema, Nested
 
 class CallFilterRecipientUserSchema(BaseSchema):
     uuid = fields.String(required=True)
-    timeout = fields.Integer(validate=Range(min=0), allow_none=True, missing=None)
+    timeout = fields.Integer(validate=Range(min=0), allow_none=True, load_default=None)
 
     @post_load
     def add_envelope(self, data, **kwargs):

--- a/wazo_confd/plugins/context/schema.py
+++ b/wazo_confd/plugins/context/schema.py
@@ -48,7 +48,7 @@ class ContextSchema(BaseSchema):
     label = fields.String(validate=Length(min=1, max=128), required=True)
     type = fields.String(
         validate=OneOf(['internal', 'incall', 'outcall', 'services', 'others']),
-        missing='internal',
+        load_default='internal',
     )
     user_ranges = Nested(RangeSchema, many=True)
     group_ranges = Nested(RangeSchema, many=True)

--- a/wazo_confd/plugins/context_range/schema.py
+++ b/wazo_confd/plugins/context_range/schema.py
@@ -9,7 +9,7 @@ from wazo_confd.helpers.restful import ListSchema as BaseListSchema
 
 class ListSchema(BaseListSchema):
     availability = fields.String(
-        missing='available', validate=OneOf(['available', 'all'])
+        load_default='available', validate=OneOf(['available', 'all'])
     )
 
 

--- a/wazo_confd/plugins/dhcp/schema.py
+++ b/wazo_confd/plugins/dhcp/schema.py
@@ -13,7 +13,7 @@ class DHCPSchema(BaseSchema):
     active = fields.Boolean(required=True)
     pool_start = fields.String()
     pool_end = fields.String()
-    network_interfaces = fields.List(fields.String(), missing=list)
+    network_interfaces = fields.List(fields.String(), load_default=list)
 
     @validates_schema
     def check_pool_if_active(self, data, **kwargs):

--- a/wazo_confd/plugins/email/schema.py
+++ b/wazo_confd/plugins/email/schema.py
@@ -23,21 +23,21 @@ class _RewriteRule(BaseSchema):
 
 class EmailConfigSchema(BaseSchema):
     domain_name = fields.String(
-        attribute='mydomain', validate=Length(max=255), missing=''
+        attribute='mydomain', validate=Length(max=255), load_default=''
     )
     from_ = fields.String(
-        attribute='origin', data_key='from', validate=Length(max=255), missing=''
+        attribute='origin', data_key='from', validate=Length(max=255), load_default=''
     )
     address_rewriting_rules = fields.List(
-        Nested(_RewriteRule, missing=None),
+        Nested(_RewriteRule, load_default=None),
         attribute='canonical_lines',
-        missing=[],
+        load_default=[],
     )
     smtp_host = fields.String(
-        attribute='relayhost', validate=Length(max=255), missing=''
+        attribute='relayhost', validate=Length(max=255), load_default=''
     )
     fallback_smtp_host = fields.String(
-        attribute='fallback_relayhost', validate=Length(max=255), missing=''
+        attribute='fallback_relayhost', validate=Length(max=255), load_default=''
     )
 
     @pre_dump

--- a/wazo_confd/plugins/endpoint_sip/schema.py
+++ b/wazo_confd/plugins/endpoint_sip/schema.py
@@ -28,7 +28,7 @@ class OptionsField(fields.List):
 
 
 class GETQueryStringSchema(BaseSchema):
-    view = fields.String(validate=OneOf(['merged']), missing=None)
+    view = fields.String(validate=OneOf(['merged']), load_default=None)
 
 
 class EndpointSIPRelationSchema(BaseSchema):
@@ -66,7 +66,7 @@ class _BaseSIPSchema(BaseSchema):
     registration_outbound_auth_section_options = OptionsField()
     outbound_auth_section_options = OptionsField()
 
-    templates = fields.List(Nested('EndpointSIPRelationSchema'), missing=[])
+    templates = fields.List(Nested('EndpointSIPRelationSchema'), load_default=[])
     transport = Nested('TransportRelationSchema', allow_none=True)
     asterisk_id = fields.String(validate=Length(max=1024), allow_none=True)
 

--- a/wazo_confd/plugins/func_key/schema.py
+++ b/wazo_confd/plugins/func_key/schema.py
@@ -35,7 +35,7 @@ class BaseDestinationSchema(Schema):
         required=True,
     )
 
-    href = fields.String(default=None, allow_none=True, dump_only=True)
+    href = fields.String(dump_default=None, allow_none=True, dump_only=True)
 
     @validates('type')
     def exclude_destination(self, data):
@@ -216,7 +216,7 @@ class BSFilterDestinationSchema(BaseDestinationSchema):
         '_BSFilterMemberDestinationSchema',
         attribute='filtermember',
         dump_only=True,
-        missing={},
+        load_default={},
     )
 
     @post_dump

--- a/wazo_confd/plugins/group_fallback/schema.py
+++ b/wazo_confd/plugins/group_fallback/schema.py
@@ -10,10 +10,10 @@ from wazo_confd.helpers.destination import DestinationField
 
 class GroupFallbackSchema(BaseSchema):
     noanswer_destination = DestinationField(
-        attribute='noanswer', default=None, allow_none=True
+        attribute='noanswer', dump_default=None, allow_none=True
     )
     congestion_destination = DestinationField(
-        attribute='congestion', default=None, allow_none=True
+        attribute='congestion', dump_default=None, allow_none=True
     )
 
     @post_load

--- a/wazo_confd/plugins/ingress_http/schema.py
+++ b/wazo_confd/plugins/ingress_http/schema.py
@@ -16,4 +16,4 @@ class IngressHTTPSchema(BaseSchema):
 
 
 class IngressViewSchema(BaseSchema):
-    view = fields.String(validate=OneOf(['fallback', 'default']), missing=None)
+    view = fields.String(validate=OneOf(['fallback', 'default']), load_default=None)

--- a/wazo_confd/plugins/localization/schema.py
+++ b/wazo_confd/plugins/localization/schema.py
@@ -12,7 +12,9 @@ from wazo_confd.helpers.mallow import BaseSchema
 
 
 class LocalizationSchema(BaseSchema):
-    country = fields.String(allow_none=True, default=None, validate=Length(equal=2))
+    country = fields.String(
+        allow_none=True, dump_default=None, validate=Length(equal=2)
+    )
 
     @validates('country')
     def _validate_country(self, country, **kwargs):

--- a/wazo_confd/plugins/meeting/schema.py
+++ b/wazo_confd/plugins/meeting/schema.py
@@ -29,12 +29,12 @@ class MeetingSchema(BaseSchema):
     name = fields.String(validate=Length(max=512), required=True)
     ingress_http_uri = fields.Method('_uri', dump_only=True)
     guest_sip_authorization = fields.Method('_guest_sip_authorization', dump_only=True)
-    persistent = fields.Boolean(missing=False)
+    persistent = fields.Boolean(load_default=False)
     links = ListLink(Link('meetings', field='uuid'))
     tenant_uuid = fields.String(dump_only=True)
     creation_time = fields.DateTime(attribute='created_at', dump_only=True)
     exten = fields.Method('_exten', dump_only=True)
-    require_authorization = fields.Boolean(missing=False)
+    require_authorization = fields.Boolean(load_default=False)
 
     def _uri(self, meeting):
         if meeting.ingress_http:

--- a/wazo_confd/plugins/parking_lot/schema.py
+++ b/wazo_confd/plugins/parking_lot/schema.py
@@ -18,9 +18,9 @@ class ParkingLotSchema(BaseSchema):
     slots_end = fields.String(
         validate=(Length(max=40), Predicate('isdigit')), required=True
     )
-    timeout = fields.Integer(validate=Range(min=0), allow_none=True, missing=45)
+    timeout = fields.Integer(validate=Range(min=0), allow_none=True, load_default=45)
     music_on_hold = fields.String(
-        validate=Length(max=128), allow_none=True, missing='default'
+        validate=Length(max=128), allow_none=True, load_default='default'
     )
     links = ListLink(Link('parkinglots'))
 

--- a/wazo_confd/plugins/phone_number/schema.py
+++ b/wazo_confd/plugins/phone_number/schema.py
@@ -26,7 +26,7 @@ class PhoneNumberSchema(BaseSchema):
     number = number_field(required=True)
     caller_id_name = fields.String(validate=Length(min=1, max=256), allow_none=True)
     main = StrictBoolean(dump_only=True)
-    shared = StrictBoolean(default=False)
+    shared = StrictBoolean(dump_default=False)
     links = ListLink(Link('phone_numbers', field='uuid'))
 
 

--- a/wazo_confd/plugins/pjsip/schema.py
+++ b/wazo_confd/plugins/pjsip/schema.py
@@ -7,7 +7,7 @@ from wazo_confd.helpers.mallow import BaseSchema, PJSIPSection, PJSIPSectionOpti
 
 
 class PJSIPTransportDeleteRequestSchema(BaseSchema):
-    fallback = fields.UUID(missing=None)
+    fallback = fields.UUID(load_default=None)
 
 
 class PJSIPTransportSchema(BaseSchema):
@@ -16,5 +16,5 @@ class PJSIPTransportSchema(BaseSchema):
     options = fields.List(
         PJSIPSectionOption(),
         validate=Length(max=128),
-        missing=[],
+        load_default=[],
     )

--- a/wazo_confd/plugins/queue/schema.py
+++ b/wazo_confd/plugins/queue/schema.py
@@ -18,7 +18,7 @@ class QueueSchema(BaseSchema):
         validate=(Regexp(NAME_REGEX), NoneOf(['general']), Length(max=128)),
         required=True,
     )
-    label = fields.String(validate=Length(max=128), missing=None)
+    label = fields.String(validate=Length(max=128), load_default=None)
     data_quality = StrictBoolean(attribute='data_quality_bool')
     dtmf_hangup_callee_enabled = StrictBoolean()
     dtmf_hangup_caller_enabled = StrictBoolean()

--- a/wazo_confd/plugins/queue_fallback/schema.py
+++ b/wazo_confd/plugins/queue_fallback/schema.py
@@ -10,14 +10,16 @@ from wazo_confd.helpers.destination import DestinationField
 
 class QueueFallbackSchema(BaseSchema):
     noanswer_destination = DestinationField(
-        attribute='noanswer', default=None, allow_none=True
+        attribute='noanswer', dump_default=None, allow_none=True
     )
-    busy_destination = DestinationField(attribute='busy', default=None, allow_none=True)
+    busy_destination = DestinationField(
+        attribute='busy', dump_default=None, allow_none=True
+    )
     congestion_destination = DestinationField(
-        attribute='congestion', default=None, allow_none=True
+        attribute='congestion', dump_default=None, allow_none=True
     )
     fail_destination = DestinationField(
-        attribute='chanunavail', default=None, allow_none=True
+        attribute='chanunavail', dump_default=None, allow_none=True
     )
 
     @post_load

--- a/wazo_confd/plugins/queue_member/resource.py
+++ b/wazo_confd/plugins/queue_member/resource.py
@@ -13,12 +13,12 @@ from wazo_confd.helpers.mallow import BaseSchema
 
 
 class QueueMemberAgentSchema(BaseSchema):
-    penalty = fields.Integer(validate=Range(min=0), missing=0)
-    priority = fields.Integer(validate=Range(min=0), missing=0)
+    penalty = fields.Integer(validate=Range(min=0), load_default=0)
+    priority = fields.Integer(validate=Range(min=0), load_default=0)
 
 
 class QueueMemberUserSchema(BaseSchema):
-    priority = fields.Integer(validate=Range(min=0), missing=0)
+    priority = fields.Integer(validate=Range(min=0), load_default=0)
 
 
 class QueueMemberAgentItem(ConfdResource):

--- a/wazo_confd/plugins/register_iax/resource.py
+++ b/wazo_confd/plugins/register_iax/resource.py
@@ -43,7 +43,7 @@ class RegisterIAXSchema(BaseSchema):
         validate=Regexp(INVALID_CALLBACK_EXTENSION), allow_none=True
     )
     callback_context = fields.String(allow_none=True)
-    enabled = StrictBoolean(missing=True)
+    enabled = StrictBoolean(load_default=True)
     links = ListLink(Link('register_iax'))
 
     trunk = Nested('TrunkSchema', only=['id', 'links'], dump_only=True)

--- a/wazo_confd/plugins/registrar/schema.py
+++ b/wazo_confd/plugins/registrar/schema.py
@@ -8,7 +8,7 @@ from wazo_confd.helpers.mallow import BaseSchema, Link, ListLink
 
 class RegistrarSchema(BaseSchema):
     id = fields.String()
-    deletable = fields.Boolean(missing=True, default=True)
+    deletable = fields.Boolean(load_default=True, dump_default=True)
     name = fields.String(allow_none=True)
     main_host = fields.String(required=True)
     main_port = fields.Integer(allow_none=True)

--- a/wazo_confd/plugins/schedule/schema.py
+++ b/wazo_confd/plugins/schedule/schema.py
@@ -17,11 +17,11 @@ class ScheduleOpenPeriod(BaseSchema):
     hours_start = fields.String(validate=Regexp(HOUR_REGEX), required=True)
     hours_end = fields.String(validate=Regexp(HOUR_REGEX), required=True)
     week_days = fields.List(
-        fields.Integer(validate=Range(min=1, max=7)), missing=[1, 2, 3, 4, 5, 6, 7]
+        fields.Integer(validate=Range(min=1, max=7)), load_default=[1, 2, 3, 4, 5, 6, 7]
     )
     month_days = fields.List(
         fields.Integer(validate=Range(min=1, max=31)),
-        missing=[
+        load_default=[
             1,
             2,
             3,
@@ -58,7 +58,7 @@ class ScheduleOpenPeriod(BaseSchema):
     months = fields.List(
         fields.Integer(validate=Range(min=1, max=12)),
         attribute='months_list',
-        missing=[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
+        load_default=[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
     )
 
     @validates_schema

--- a/wazo_confd/plugins/switchboard_fallback/schema.py
+++ b/wazo_confd/plugins/switchboard_fallback/schema.py
@@ -10,7 +10,7 @@ from wazo_confd.helpers.destination import DestinationField
 
 class SwitchboardFallbackSchema(BaseSchema):
     noanswer_destination = DestinationField(
-        attribute='noanswer', default=None, allow_none=True
+        attribute='noanswer', dump_default=None, allow_none=True
     )
 
     @post_load

--- a/wazo_confd/plugins/trunk/schema.py
+++ b/wazo_confd/plugins/trunk/schema.py
@@ -12,7 +12,7 @@ class TrunkSchema(BaseSchema):
     context = fields.String(allow_none=True)
     twilio_incoming = StrictBoolean(allow_none=True)
     outgoing_caller_id_format = fields.String(
-        missing='+E164', validate=OneOf(['+E164', 'E164', 'national'])
+        load_default='+E164', validate=OneOf(['+E164', 'E164', 'national'])
     )
     links = ListLink(Link('trunks'))
 

--- a/wazo_confd/plugins/user/schema.py
+++ b/wazo_confd/plugins/user/schema.py
@@ -31,15 +31,15 @@ CALL_PERMISSION_PASSWORD_REGEX = r"^[0-9#\*]{1,16}$"
 class WazoAuthUserSchema(BaseSchema):
     uuid = fields.UUID(dump_only=True)
     username = fields.String(
-        validate=Length(min=1, max=256), missing=None, allow_none=True
+        validate=Length(min=1, max=256), load_default=None, allow_none=True
     )
     password = fields.String(validate=Length(min=1), allow_none=True)
-    firstname = fields.String(missing=None, allow_none=True)
-    lastname = fields.String(missing=None, allow_none=True)
+    firstname = fields.String(load_default=None, allow_none=True)
+    lastname = fields.String(load_default=None, allow_none=True)
     purpose = fields.String(
-        missing='user', validate=OneOf(['user', 'internal', 'external_api'])
+        load_default='user', validate=OneOf(['user', 'internal', 'external_api'])
     )
-    enabled = fields.Boolean(missing=True)
+    enabled = fields.Boolean(load_default=True)
     email_address = fields.Email(allow_none=True)
 
 
@@ -208,8 +208,8 @@ class UserSchema(BaseSchema):
 class UserDirectorySchema(BaseSchema):
     id = fields.Integer()
     uuid = fields.String()
-    line_id = fields.Integer(default=None)
-    agent_id = fields.String(default=None)
+    line_id = fields.Integer(dump_default=None)
+    agent_id = fields.String(dump_default=None)
     firstname = fields.String()
     lastname = fields.String()
     email = fields.String()
@@ -336,8 +336,8 @@ class UserSwitchboardSchema(BaseSchema):
 
 class UserAgentQueueSchema(BaseSchema):
     id = fields.Integer()
-    penalty = fields.Integer(validate=Range(min=0), missing=0)
-    priority = fields.Integer(validate=Range(min=0), missing=0)
+    penalty = fields.Integer(validate=Range(min=0), load_default=0)
+    priority = fields.Integer(validate=Range(min=0), load_default=0)
 
 
 class UserAgentSchema(AgentSchema):

--- a/wazo_confd/plugins/user_external_app/schema.py
+++ b/wazo_confd/plugins/user_external_app/schema.py
@@ -8,7 +8,7 @@ from wazo_confd.helpers.mallow import BaseSchema
 
 
 class GETQueryStringSchema(BaseSchema):
-    view = fields.String(validate=OneOf(['fallback']), missing=None)
+    view = fields.String(validate=OneOf(['fallback']), load_default=None)
 
 
 class UserExternalAppSchema(BaseSchema):

--- a/wazo_confd/plugins/user_fallback/schema.py
+++ b/wazo_confd/plugins/user_fallback/schema.py
@@ -10,14 +10,16 @@ from wazo_confd.helpers.destination import DestinationField
 
 class UserFallbackSchema(BaseSchema):
     noanswer_destination = DestinationField(
-        attribute='noanswer', default=None, allow_none=True
+        attribute='noanswer', dump_default=None, allow_none=True
     )
-    busy_destination = DestinationField(attribute='busy', default=None, allow_none=True)
+    busy_destination = DestinationField(
+        attribute='busy', dump_default=None, allow_none=True
+    )
     congestion_destination = DestinationField(
-        attribute='congestion', default=None, allow_none=True
+        attribute='congestion', dump_default=None, allow_none=True
     )
     fail_destination = DestinationField(
-        attribute='chanunavail', default=None, allow_none=True
+        attribute='chanunavail', dump_default=None, allow_none=True
     )
 
     @post_load

--- a/wazo_confd/plugins/voicemail_zonemessages/resource.py
+++ b/wazo_confd/plugins/voicemail_zonemessages/resource.py
@@ -16,7 +16,7 @@ from wazo_confd.helpers.restful import ConfdResource
 class VoicemailZoneMessagesOption(BaseSchema):
     name = fields.String(required=True, validate=(Length(max=128)))
     timezone = fields.String(required=True)
-    message = fields.String(allow_none=True, missing=None)
+    message = fields.String(allow_none=True, load_default=None)
 
     @post_load
     def convert_to_sqlalchemy(self, data, **kwargs):

--- a/wazo_confd/plugins/wizard/resource.py
+++ b/wazo_confd/plugins/wizard/resource.py
@@ -38,13 +38,13 @@ class WizardNetworkSchema(BaseSchema):
 
 
 class WizardStepsSchema(BaseSchema):
-    database = fields.Boolean(missing=True)
-    manage_services = fields.Boolean(missing=True)
-    manage_hosts_file = fields.Boolean(missing=True)
-    manage_resolv_file = fields.Boolean(missing=True)
-    commonconf = fields.Boolean(missing=True)
-    provisioning = fields.Boolean(missing=True)
-    admin = fields.Boolean(missing=True)
+    database = fields.Boolean(load_default=True)
+    manage_services = fields.Boolean(load_default=True)
+    manage_hosts_file = fields.Boolean(load_default=True)
+    manage_resolv_file = fields.Boolean(load_default=True)
+    commonconf = fields.Boolean(load_default=True)
+    provisioning = fields.Boolean(load_default=True)
+    admin = fields.Boolean(load_default=True)
 
 
 class WizardSchema(BaseSchema):
@@ -52,10 +52,10 @@ class WizardSchema(BaseSchema):
     admin_username = fields.Constant(constant='root', dump_only=True)
     admin_password = fields.String(validate=Regexp(ADMIN_PASSWORD_REGEX), required=True)
     license = StrictBoolean(validate=Equal(True), required=True)
-    language = fields.String(validate=OneOf(['en_US', 'fr_FR']), missing='en_US')
+    language = fields.String(validate=OneOf(['en_US', 'fr_FR']), load_default='en_US')
     timezone = fields.String(validate=Length(max=128), required=True)
     network = Nested(WizardNetworkSchema, required=True)
-    steps = Nested(WizardStepsSchema, missing=WizardStepsSchema().load({}))
+    steps = Nested(WizardStepsSchema, load_default=WizardStepsSchema().load({}))
 
 
 class ConfiguredSchema(BaseSchema):


### PR DESCRIPTION
This change uses the Bookworm version of marshmallow to reduce the scope of changes that are going to happen when doing the upgrade