### PR TITLE
func_key:api.yml: added missing parameters

### DIFF
--- a/wazo_confd/plugins/func_key/api.yml
+++ b/wazo_confd/plugins/func_key/api.yml
@@ -21,6 +21,9 @@ paths:
       parameters:
         - $ref: '#/parameters/tenantuuid'
         - $ref: '#/parameters/recurse'
+        - $ref: '#/parameters/offset'
+        - $ref: '#/parameters/limit'
+        - $ref: '#/parameters/search'
       responses:
         '200':
           description: List Func key template


### PR DESCRIPTION
to GET /funckeys/templates API reference
