### PR TITLE
user import: fix and increase token expiration

### DIFF
--- a/wazo_confd/plugins/user_import/auth_client.py
+++ b/wazo_confd/plugins/user_import/auth_client.py
@@ -12,6 +12,7 @@ from xivo_dao.helpers.exception import ServiceError
 
 logger = logging.getLogger(__name__)
 
+MINUTE = 60
 auth_config = {}
 
 
@@ -47,8 +48,8 @@ class AuthClientProxy:
     @classmethod
     def from_config(cls, *args, **kwargs):
         client = AuthClient(*args, **kwargs)
-        # 30 minutes should be enought to import all users
-        token = client.token.new(expiration=30 * 30)['token']
+        # Set expiration that should be enought to import all users
+        token = client.token.new(expiration=60 * MINUTE)['token']
         client.set_token(token)
         return cls(client)
 


### PR DESCRIPTION
why: it was 15 min before (comment was wrong) and increase it to 1 hour
when having a big import (>2000 users)
All requests to wazo-auth and wazo-provd slowdown import process ...

edit: for now I'm not sure it's the right solution, since importing 2k users become more and more slow with time
- first users: < 1 second / user
- after 1000 users : > 5 seconds / user

... we may want to improve logic and reduce call to other services (if possible)