### PR TITLE
Pull request for WAZO-4113-users-import-performance

### DIFF
--- a/etc/nginx/locations/https-available/wazo-confd
+++ b/etc/nginx/locations/https-available/wazo-confd
@@ -4,13 +4,23 @@ location ^~ /api/confd/1.1/guests {
     include /etc/nginx/wazo-no-auth-shared[.]conf;
 }
 
+location ^~ /api/confd/1.1/users/import {
+    proxy_pass http://127.0.0.1:9486/1.1/users/import;
+    proxy_read_timeout 1800s;  # 30min
+    include /etc/nginx/wazo-confd-shared.conf;
+}
+
 location ^~ /api/confd/1.1/wizard {
     proxy_pass http://127.0.0.1:9486/1.1/wizard;
+    proxy_read_timeout 180s;
     include /etc/nginx/wazo-confd-shared.conf;
     include /etc/nginx/wazo-no-auth-shared[.]conf;
 }
 
 location ^~ /api/confd/ {
     proxy_pass http://127.0.0.1:9486/;
+    # Mostly used for /ha but can be useful for other
+    # endpoints on slow host (e.i. /devices)
+    proxy_read_timeout 180s;
     include /etc/nginx/wazo-confd-shared.conf;
 }

--- a/etc/nginx/wazo-confd-shared.conf
+++ b/etc/nginx/wazo-confd-shared.conf
@@ -1,7 +1,3 @@
-# Mostly used for /users/import and /ha but can be useful for other
-# endpoints on slow host (e.i. /devices)
-proxy_read_timeout 180s;
-
 # Mostly used for /moh and /sounds
 client_max_body_size 16m;
 

--- a/wazo_confd/plugins/line_endpoint/service.py
+++ b/wazo_confd/plugins/line_endpoint/service.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from xivo_dao.resources.line import dao as line_dao_module
-from wazo_confd.plugins.line.service import build_service as build_line_service
 
 from .notifier import (
     build_notifier_sip,
@@ -17,9 +16,8 @@ from .validator import (
 
 
 class LineEndpointSIPService:
-    def __init__(self, line_dao, line_service, validator, notifier):
+    def __init__(self, line_dao, validator, notifier):
         self.line_dao = line_dao
-        self.line_service = line_service
         self.validator = validator
         self.notifier = notifier
 
@@ -29,7 +27,7 @@ class LineEndpointSIPService:
 
         self.validator.validate_association(line, endpoint)
         self.line_dao.associate_endpoint_sip(line, endpoint)
-        self.line_service.edit(line, None)
+        self.line_dao.edit(line)
         self.notifier.associated(line, endpoint)
 
     def dissociate(self, line, endpoint):
@@ -38,14 +36,13 @@ class LineEndpointSIPService:
 
         self.validator.validate_dissociation(line, endpoint)
         self.line_dao.dissociate_endpoint_sip(line, endpoint)
-        self.line_service.edit(line, None)
+        self.line_dao.edit(line)
         self.notifier.dissociated(line, endpoint)
 
 
 class LineEndpointSCCPService:
-    def __init__(self, line_dao, line_service, validator, notifier):
+    def __init__(self, line_dao, validator, notifier):
         self.line_dao = line_dao
-        self.line_service = line_service
         self.validator = validator
         self.notifier = notifier
 
@@ -55,7 +52,7 @@ class LineEndpointSCCPService:
 
         self.validator.validate_association(line, endpoint)
         self.line_dao.associate_endpoint_sccp(line, endpoint)
-        self.line_service.edit(line, None)
+        self.line_dao.edit(line)
         self.notifier.associated(line, endpoint)
 
     def dissociate(self, line, endpoint):
@@ -64,14 +61,13 @@ class LineEndpointSCCPService:
 
         self.validator.validate_dissociation(line, endpoint)
         self.line_dao.dissociate_endpoint_sccp(line, endpoint)
-        self.line_service.edit(line, None)
+        self.line_dao.edit(line)
         self.notifier.dissociated(line, endpoint)
 
 
 class LineEndpointCustomService:
-    def __init__(self, line_dao, line_service, validator, notifier):
+    def __init__(self, line_dao, validator, notifier):
         self.line_dao = line_dao
-        self.line_service = line_service
         self.validator = validator
         self.notifier = notifier
 
@@ -81,7 +77,7 @@ class LineEndpointCustomService:
 
         self.validator.validate_association(line, endpoint)
         self.line_dao.associate_endpoint_custom(line, endpoint)
-        self.line_service.edit(line, None)
+        self.line_dao.edit(line)
         self.notifier.associated(line, endpoint)
 
     def dissociate(self, line, endpoint):
@@ -90,26 +86,23 @@ class LineEndpointCustomService:
 
         self.validator.validate_dissociation(line, endpoint)
         self.line_dao.dissociate_endpoint_custom(line, endpoint)
-        self.line_service.edit(line, None)
+        self.line_dao.edit(line)
         self.notifier.dissociated(line, endpoint)
 
 
 def build_service_sip(provd_client):
     validator = build_validator_sip()
-    line_service = build_line_service(provd_client)
     notifier = build_notifier_sip()
-    return LineEndpointSIPService(line_dao_module, line_service, validator, notifier)
+    return LineEndpointSIPService(line_dao_module, validator, notifier)
 
 
 def build_service_sccp(provd_client):
     validator = build_validator_sccp()
-    line_service = build_line_service(provd_client)
     notifier = build_notifier_sccp()
-    return LineEndpointSCCPService(line_dao_module, line_service, validator, notifier)
+    return LineEndpointSCCPService(line_dao_module, validator, notifier)
 
 
 def build_service_custom(provd_client):
     validator = build_validator_custom()
-    line_service = build_line_service(provd_client)
     notifier = build_notifier_custom()
-    return LineEndpointCustomService(line_dao_module, line_service, validator, notifier)
+    return LineEndpointCustomService(line_dao_module, validator, notifier)

--- a/wazo_confd/plugins/user_import/auth_client.py
+++ b/wazo_confd/plugins/user_import/auth_client.py
@@ -12,6 +12,7 @@ from xivo_dao.helpers.exception import ServiceError
 
 logger = logging.getLogger(__name__)
 
+MINUTE = 60
 auth_config = {}
 
 
@@ -47,8 +48,8 @@ class AuthClientProxy:
     @classmethod
     def from_config(cls, *args, **kwargs):
         client = AuthClient(*args, **kwargs)
-        # 30 minutes should be enought to import all users
-        token = client.token.new(expiration=30 * 30)['token']
+        # Set expiration that should be enought to import all users
+        token = client.token.new(expiration=30 * MINUTE)['token']
         client.set_token(token)
         return cls(client)
 


### PR DESCRIPTION
## user import: fix token expiration

why: it was 15 min before (comment was wrong), but 30min is useful when
having a big import (>2000 users)
All requests to wazo-auth and wazo-provd slowdown import process ...

## user import: fix nginx timeout to match token expiration


## line_endpoint: remove line validator/notify layer

why: the edit() method is used to call LineFixes helpers.
Using service directly only add an unused layer of validator and send
useless message on bus

The biggest impact is when importing users, the validator will query
wazo-provd for each association, which is ressource consuming

Depends-on: https://github.com/wazo-platform/xivo-dao/pull/303