### PR TITLE
localization: remove tenant_uuid dump only attr

### DIFF
--- a/wazo_confd/plugins/localization/schema.py
+++ b/wazo_confd/plugins/localization/schema.py
@@ -12,7 +12,7 @@ from wazo_confd.helpers.mallow import BaseSchema
 
 
 class LocalizationSchema(BaseSchema):
-    tenant_uuid = fields.String(dump_only=True, allow_none=False, attribute='uuid')
+    tenant_uuid = fields.String(allow_none=False, attribute='uuid')
     country = fields.String(allow_none=True, default=None, validate=Length(equal=2))
 
     @validates('country')


### PR DESCRIPTION
Why: The field is not in the event payload otherwise

WAZO-4095