### PR TITLE
Pull request for fix-user-export

### DIFF
--- a/integration_tests/Makefile
+++ b/integration_tests/Makefile
@@ -10,7 +10,7 @@ endif
 test-setup: egg-info build-confd update-db
 
 build-confd:
-	docker build -t wazoplatform/wazo-confd ..
+	docker build --no-cache -t wazoplatform/wazo-confd ..
 	docker build --no-cache -t wazo-confd-test -f Dockerfile ..
 
 update-db: $(UPDATE_DB_TARGET)


### PR DESCRIPTION
## user_export: use plain query for username/password

why: initially in xivo-dao, but was removed to use more optimized query.
However, user export still need to have this sub query. To avoid to be
used by error in another workflow, we scope it here instead of xivo-dao

## use --no-cache to build image

why: otherwise xivo-dao will be cached and won't be updated