### PR TITLE
[WAZO-4184]  expose subscription_type in view `summary`

### DIFF
--- a/integration_tests/suite/base/test_users.py
+++ b/integration_tests/suite/base/test_users.py
@@ -475,7 +475,7 @@ def test_summary_view_on_custom_endpoint(user, line, custom, extension):
         )
 
 
-@fixtures.user()
+@fixtures.user(subscription_type=1)
 def test_summary_view_on_user_without_line(user):
     response = confd.users.get(view='summary', id=user['id'])
     assert_that(
@@ -492,6 +492,7 @@ def test_summary_view_on_user_without_line(user):
                 context=none(),
                 enabled=True,
                 protocol=none(),
+                subscription_type=user['subscription_type'],
             )
         ),
     )

--- a/wazo_confd/plugins/user/api.yml
+++ b/wazo_confd/plugins/user/api.yml
@@ -422,6 +422,11 @@ definitions:
           type: integer
           default: 5
           description: Number of allowed simultaneous calls on a user's phone
+        subscription_type:
+          type: integer
+          description: The subscription type of the user (0-10)
+          minimum: 0
+          maximum: 10
         supervision_enabled:
           type: boolean
           default: true
@@ -701,6 +706,11 @@ definitions:
         type: integer
         default: 5
         description: Number of allowed simultaneous calls on a user's phone
+      subscription_type:
+        type: integer
+        description: The subscription type of the user (0-10)
+        minimum: 0
+        maximum: 10
       supervision_enabled:
         type: boolean
         default: true

--- a/wazo_confd/plugins/user/schema.py
+++ b/wazo_confd/plugins/user/schema.py
@@ -229,6 +229,7 @@ class UserSummarySchema(BaseSchema):
     provisioning_code = fields.String()
     protocol = fields.String()
     enabled = StrictBoolean()
+    subscription_type = fields.Integer(validate=Range(min=0, max=10))
 
 
 class UserSchemaNullable(UserSchema):


### PR DESCRIPTION
depends-on: https://github.com/wazo-platform/xivo-dao/pull/311

## Summary of changes

- Consume/expose `subscription_type` in view summary
