### PR TITLE
fix-flaky-tests

### DIFF
--- a/integration_tests/suite/base/test_conference_extension.py
+++ b/integration_tests/suite/base/test_conference_extension.py
@@ -8,11 +8,11 @@ from ..helpers import errors as e
 from ..helpers import fixtures
 from ..helpers import scenarios as s
 from ..helpers.config import (
+    EXTEN_CONFERENCE_RANGE,
     EXTEN_OUTSIDE_RANGE,
     INCALL_CONTEXT,
     MAIN_TENANT,
     SUB_TENANT,
-    gen_conference_exten,
 )
 from . import confd
 
@@ -20,7 +20,7 @@ FAKE_ID = 999999999
 
 
 @fixtures.conference()
-@fixtures.extension(exten=gen_conference_exten())
+@fixtures.extension(exten_range=EXTEN_CONFERENCE_RANGE)
 def test_associate_errors(conference, extension):
     fake_conference = confd.conferences(FAKE_ID).extensions(extension['id']).put
     fake_extension = confd.conferences(conference['id']).extensions(FAKE_ID).put
@@ -30,7 +30,7 @@ def test_associate_errors(conference, extension):
 
 
 @fixtures.conference()
-@fixtures.extension(exten=gen_conference_exten())
+@fixtures.extension(exten_range=EXTEN_CONFERENCE_RANGE)
 def test_dissociate_errors(conference, extension):
     fake_conference = confd.conferences(FAKE_ID).extensions(extension['id']).delete
     fake_extension = confd.conferences(conference['id']).extensions(FAKE_ID).delete
@@ -39,7 +39,7 @@ def test_dissociate_errors(conference, extension):
     s.check_resource_not_found(fake_extension, 'Extension')
 
 
-@fixtures.extension(exten=gen_conference_exten())
+@fixtures.extension(exten_range=EXTEN_CONFERENCE_RANGE)
 @fixtures.conference()
 def test_associate(extension, conference):
     response = confd.conferences(conference['id']).extensions(extension['id']).put()
@@ -59,8 +59,8 @@ def test_associate(extension, conference):
     conference_room_ranges=[{'start': '4000', 'end': '4999'}],
 )
 def test_associate_multi_tenant(main, sub, main_ctx, sub_ctx):
-    @fixtures.extension(context=main_ctx['name'], exten=gen_conference_exten())
-    @fixtures.extension(context=sub_ctx['name'], exten=gen_conference_exten())
+    @fixtures.extension(context=main_ctx['name'], exten_range=EXTEN_CONFERENCE_RANGE)
+    @fixtures.extension(context=sub_ctx['name'], exten_range=EXTEN_CONFERENCE_RANGE)
     def aux(main_exten, sub_exten):
         response = (
             confd.conferences(sub['id'])
@@ -87,7 +87,7 @@ def test_associate_multi_tenant(main, sub, main_ctx, sub_ctx):
 
 
 @fixtures.conference()
-@fixtures.extension(exten=gen_conference_exten())
+@fixtures.extension(exten_range=EXTEN_CONFERENCE_RANGE)
 def test_associate_already_associated(conference, extension):
     with a.conference_extension(conference, extension):
         response = confd.conferences(conference['id']).extensions(extension['id']).put()
@@ -95,8 +95,8 @@ def test_associate_already_associated(conference, extension):
 
 
 @fixtures.conference()
-@fixtures.extension(exten=gen_conference_exten())
-@fixtures.extension(exten=gen_conference_exten())
+@fixtures.extension(exten_range=EXTEN_CONFERENCE_RANGE)
+@fixtures.extension(exten_range=EXTEN_CONFERENCE_RANGE)
 def test_associate_multiple_extensions_to_conference(
     conference, extension1, extension2
 ):
@@ -109,7 +109,7 @@ def test_associate_multiple_extensions_to_conference(
 
 @fixtures.conference()
 @fixtures.conference()
-@fixtures.extension(exten=gen_conference_exten())
+@fixtures.extension(exten_range=EXTEN_CONFERENCE_RANGE)
 def test_associate_multiple_conferences_to_extension(
     conference1, conference2, extension
 ):
@@ -131,14 +131,14 @@ def test_associate_when_user_already_associated(conference, user, line_sip, exte
 
 
 @fixtures.conference()
-@fixtures.extension(exten=gen_conference_exten(), context=INCALL_CONTEXT)
+@fixtures.extension(exten_range=EXTEN_CONFERENCE_RANGE, context=INCALL_CONTEXT)
 def test_associate_when_not_internal_context(conference, extension):
     response = confd.conferences(conference['id']).extensions(extension['id']).put()
     response.assert_status(400)
 
 
 @fixtures.conference()
-@fixtures.extension(exten=EXTEN_OUTSIDE_RANGE)
+@fixtures.extension(exten_range=EXTEN_OUTSIDE_RANGE)
 def test_associate_when_exten_outside_range(conference, extension):
     response = confd.conferences(conference['id']).extensions(extension['id']).put()
     response.assert_status(400)
@@ -152,7 +152,7 @@ def test_associate_when_exten_pattern(extension, conference):
 
 
 @fixtures.conference()
-@fixtures.extension(exten=gen_conference_exten())
+@fixtures.extension(exten_range=EXTEN_CONFERENCE_RANGE)
 def test_dissociate(conference, extension):
     with a.conference_extension(conference, extension, check=False):
         response = (
@@ -174,8 +174,8 @@ def test_dissociate(conference, extension):
     conference_room_ranges=[{'start': '4000', 'end': '4999'}],
 )
 def test_dissociate_multi_tenant(main, sub, main_ctx, sub_ctx):
-    @fixtures.extension(context=main_ctx['name'], exten=gen_conference_exten())
-    @fixtures.extension(context=sub_ctx['name'], exten=gen_conference_exten())
+    @fixtures.extension(context=main_ctx['name'], exten_range=EXTEN_CONFERENCE_RANGE)
+    @fixtures.extension(context=sub_ctx['name'], exten_range=EXTEN_CONFERENCE_RANGE)
     def aux(main_exten, sub_exten):
         response = (
             confd.conferences(sub['id'])
@@ -195,14 +195,14 @@ def test_dissociate_multi_tenant(main, sub, main_ctx, sub_ctx):
 
 
 @fixtures.conference()
-@fixtures.extension(exten=gen_conference_exten())
+@fixtures.extension(exten_range=EXTEN_CONFERENCE_RANGE)
 def test_dissociate_not_associated(conference, extension):
     response = confd.conferences(conference['id']).extensions(extension['id']).delete()
     response.assert_deleted()
 
 
 @fixtures.conference()
-@fixtures.extension(exten=gen_conference_exten())
+@fixtures.extension(exten_range=EXTEN_CONFERENCE_RANGE)
 def test_get_conference_relation(conference, extension):
     with a.conference_extension(conference, extension):
         response = confd.conferences(conference['id']).get()
@@ -220,7 +220,7 @@ def test_get_conference_relation(conference, extension):
         )
 
 
-@fixtures.extension(exten=gen_conference_exten())
+@fixtures.extension(exten_range=EXTEN_CONFERENCE_RANGE)
 @fixtures.conference()
 def test_get_extension_relation(extension, conference):
     with a.conference_extension(conference, extension):
@@ -234,7 +234,7 @@ def test_get_extension_relation(extension, conference):
 
 
 @fixtures.conference()
-@fixtures.extension(exten=gen_conference_exten())
+@fixtures.extension(exten_range=EXTEN_CONFERENCE_RANGE)
 def test_edit_context_to_incall_when_associated(conference, extension):
     with a.conference_extension(conference, extension):
         response = confd.extensions(extension['id']).put(context=INCALL_CONTEXT)
@@ -242,7 +242,7 @@ def test_edit_context_to_incall_when_associated(conference, extension):
 
 
 @fixtures.conference()
-@fixtures.extension(exten=gen_conference_exten())
+@fixtures.extension(exten_range=EXTEN_CONFERENCE_RANGE)
 def test_delete_conference_when_conference_and_extension_associated(
     conference, extension
 ):

--- a/integration_tests/suite/base/test_conferences.py
+++ b/integration_tests/suite/base/test_conferences.py
@@ -17,7 +17,7 @@ from ..helpers import associations as a
 from ..helpers import errors as e
 from ..helpers import fixtures
 from ..helpers import scenarios as s
-from ..helpers.config import MAIN_TENANT, SUB_TENANT, gen_conference_exten
+from ..helpers.config import EXTEN_CONFERENCE_RANGE, MAIN_TENANT, SUB_TENANT
 from . import confd
 
 
@@ -86,7 +86,7 @@ def error_checks(url):
     s.check_bogus_field_returns_error(url, 'admin_pin', {})
 
 
-@fixtures.extension(exten=gen_conference_exten())
+@fixtures.extension(exten_range=EXTEN_CONFERENCE_RANGE)
 @fixtures.conference(name='search', preprocess_subroutine='search')
 @fixtures.conference(name='hidden', preprocess_subroutine='hidden')
 def test_search(extension, conference, hidden):

--- a/integration_tests/suite/base/test_extensions.py
+++ b/integration_tests/suite/base/test_extensions.py
@@ -28,13 +28,13 @@ from ..helpers import helpers as h
 from ..helpers import scenarios as s
 from ..helpers.config import (
     CONTEXT,
+    EXTEN_CONFERENCE_RANGE,
+    EXTEN_GROUP_RANGE,
     EXTEN_OUTSIDE_RANGE,
+    EXTEN_QUEUE_RANGE,
+    EXTEN_USER_RANGE,
     MAIN_TENANT,
     SUB_TENANT,
-    gen_conference_exten,
-    gen_group_exten,
-    gen_line_exten,
-    gen_queue_exten,
 )
 from . import BaseIntegrationTest, confd, provd
 
@@ -240,7 +240,7 @@ def test_edit_extension_with_same_exten(extension1, extension2):
     response.assert_status(400)
 
 
-@fixtures.extension(exten=gen_conference_exten(), context=CONTEXT)
+@fixtures.extension(exten_range=EXTEN_CONFERENCE_RANGE, context=CONTEXT)
 @fixtures.conference()
 def test_edit_extension_conference_with_exten_outside_range(extension, conference):
     with a.conference_extension(conference, extension):
@@ -248,7 +248,7 @@ def test_edit_extension_conference_with_exten_outside_range(extension, conferenc
         response.assert_match(400, outside_range_regex)
 
 
-@fixtures.extension(exten=gen_group_exten(), context=CONTEXT)
+@fixtures.extension(exten_range=EXTEN_GROUP_RANGE, context=CONTEXT)
 @fixtures.group()
 def test_edit_extension_group_with_exten_outside_range(extension, group):
     with a.group_extension(group, extension):
@@ -256,7 +256,7 @@ def test_edit_extension_group_with_exten_outside_range(extension, group):
         response.assert_match(400, outside_range_regex)
 
 
-@fixtures.extension(exten=gen_queue_exten(), context=CONTEXT)
+@fixtures.extension(exten_range=EXTEN_QUEUE_RANGE, context=CONTEXT)
 @fixtures.queue()
 def test_edit_extension_queue_with_exten_outside_range(extension, queue):
     with a.queue_extension(queue, extension):
@@ -264,7 +264,7 @@ def test_edit_extension_queue_with_exten_outside_range(extension, queue):
         response.assert_match(400, outside_range_regex)
 
 
-@fixtures.extension(exten=gen_line_exten(), context=CONTEXT)
+@fixtures.extension(exten_range=EXTEN_USER_RANGE, context=CONTEXT)
 @fixtures.line_sip()
 def test_edit_extension_line_with_exten_outside_range(extension, line):
     with a.line_extension(line, extension):

--- a/integration_tests/suite/base/test_group_extension.py
+++ b/integration_tests/suite/base/test_group_extension.py
@@ -8,18 +8,18 @@ from ..helpers import errors as e
 from ..helpers import fixtures
 from ..helpers import scenarios as s
 from ..helpers.config import (
+    EXTEN_GROUP_RANGE,
     EXTEN_OUTSIDE_RANGE,
     INCALL_CONTEXT,
     MAIN_TENANT,
     SUB_TENANT,
-    gen_group_exten,
 )
 from . import confd
 
 FAKE_ID = 999999999
 
 
-@fixtures.extension(exten=gen_group_exten())
+@fixtures.extension(exten_range=EXTEN_GROUP_RANGE)
 @fixtures.group()
 def test_associate_errors(extension, group):
     fake_group = confd.groups(FAKE_ID).extensions(extension['id']).put
@@ -33,7 +33,7 @@ def test_associate_errors(extension, group):
     s.check_resource_not_found(fake_extension, 'Extension')
 
 
-@fixtures.extension(exten=gen_group_exten())
+@fixtures.extension(exten_range=EXTEN_GROUP_RANGE)
 @fixtures.group()
 def test_dissociate_errors(extension, group):
     fake_group = confd.groups(FAKE_ID).extensions(extension['id']).delete
@@ -47,21 +47,21 @@ def test_dissociate_errors(extension, group):
     s.check_resource_not_found(fake_extension, 'Extension')
 
 
-@fixtures.extension(exten=gen_group_exten())
+@fixtures.extension(exten_range=EXTEN_GROUP_RANGE)
 @fixtures.group()
 def test_associate(extension, group):
     response = confd.groups(group['uuid']).extensions(extension['id']).put()
     response.assert_updated()
 
 
-@fixtures.extension(exten=gen_group_exten())
+@fixtures.extension(exten_range=EXTEN_GROUP_RANGE)
 @fixtures.group()
 def test_associate_by_id(extension, group):
     response = confd.groups(group['id']).extensions(extension['id']).put()
     response.assert_updated()
 
 
-@fixtures.extension(exten=gen_group_exten())
+@fixtures.extension(exten_range=EXTEN_GROUP_RANGE)
 @fixtures.group()
 def test_associate_already_associated(extension, group):
     with a.group_extension(group, extension):
@@ -69,8 +69,8 @@ def test_associate_already_associated(extension, group):
         response.assert_updated()
 
 
-@fixtures.extension(exten=gen_group_exten())
-@fixtures.extension(exten=gen_group_exten())
+@fixtures.extension(exten_range=EXTEN_GROUP_RANGE)
+@fixtures.extension(exten_range=EXTEN_GROUP_RANGE)
 @fixtures.group()
 def test_associate_multiple_extensions_to_group(extension1, extension2, group):
     with a.group_extension(group, extension1):
@@ -78,7 +78,7 @@ def test_associate_multiple_extensions_to_group(extension1, extension2, group):
         response.assert_match(400, e.resource_associated('Group', 'Extension'))
 
 
-@fixtures.extension(exten=gen_group_exten())
+@fixtures.extension(exten_range=EXTEN_GROUP_RANGE)
 @fixtures.group()
 @fixtures.group()
 def test_associate_multiple_groups_to_extension(extension, group1, group2):
@@ -97,7 +97,7 @@ def test_associate_when_user_already_associated(extension, group, user, line_sip
         response.assert_match(400, e.resource_associated('user', 'Extension'))
 
 
-@fixtures.extension(exten=gen_group_exten(), context=INCALL_CONTEXT)
+@fixtures.extension(exten_range=EXTEN_GROUP_RANGE, context=INCALL_CONTEXT)
 @fixtures.group()
 def test_associate_when_not_internal_context(extension, group):
     response = confd.groups(group['uuid']).extensions(extension['id']).put()
@@ -123,8 +123,8 @@ def test_associate_when_exten_pattern(extension, group):
 @fixtures.context(wazo_tenant=MAIN_TENANT, label='main-internal')
 @fixtures.context(wazo_tenant=SUB_TENANT, label='sub-internal')
 def test_associate_multi_tenant(main_group, sub_group, main_ctx, sub_ctx):
-    @fixtures.extension(context=main_ctx['name'], exten=gen_group_exten())
-    @fixtures.extension(context=sub_ctx['name'], exten=gen_group_exten())
+    @fixtures.extension(context=main_ctx['name'], exten_range=EXTEN_GROUP_RANGE)
+    @fixtures.extension(context=sub_ctx['name'], exten_range=EXTEN_GROUP_RANGE)
     def aux(main_exten, sub_exten):
         response = (
             confd.groups(sub_group['uuid'])
@@ -150,7 +150,7 @@ def test_associate_multi_tenant(main_group, sub_group, main_ctx, sub_ctx):
     aux()
 
 
-@fixtures.extension(exten=gen_group_exten())
+@fixtures.extension(exten_range=EXTEN_GROUP_RANGE)
 @fixtures.group()
 def test_dissociate(extension, group):
     with a.group_extension(group, extension, check=False):
@@ -158,7 +158,7 @@ def test_dissociate(extension, group):
         response.assert_deleted()
 
 
-@fixtures.extension(exten=gen_group_exten())
+@fixtures.extension(exten_range=EXTEN_GROUP_RANGE)
 @fixtures.group()
 def test_dissociate_by_id(extension, group):
     with a.group_extension(group, extension, check=False):
@@ -166,7 +166,7 @@ def test_dissociate_by_id(extension, group):
         response.assert_deleted()
 
 
-@fixtures.extension(exten=gen_group_exten())
+@fixtures.extension(exten_range=EXTEN_GROUP_RANGE)
 @fixtures.group()
 def test_dissociate_not_associated(extension, group):
     response = confd.groups(group['uuid']).extensions(extension['id']).delete()
@@ -178,8 +178,8 @@ def test_dissociate_not_associated(extension, group):
 @fixtures.context(wazo_tenant=MAIN_TENANT, label='main-internal')
 @fixtures.context(wazo_tenant=SUB_TENANT, label='sub-internal')
 def test_dissociate_multi_tenant(main_group, sub_group, main_ctx, sub_ctx):
-    @fixtures.extension(context=main_ctx['name'], exten=gen_group_exten())
-    @fixtures.extension(context=sub_ctx['name'], exten=gen_group_exten())
+    @fixtures.extension(context=main_ctx['name'], exten_range=EXTEN_GROUP_RANGE)
+    @fixtures.extension(context=sub_ctx['name'], exten_range=EXTEN_GROUP_RANGE)
     def aux(main_exten, sub_exten):
         response = (
             confd.groups(sub_group['uuid'])
@@ -198,7 +198,7 @@ def test_dissociate_multi_tenant(main_group, sub_group, main_ctx, sub_ctx):
     aux()
 
 
-@fixtures.extension(exten=gen_group_exten())
+@fixtures.extension(exten_range=EXTEN_GROUP_RANGE)
 @fixtures.group()
 def test_get_group_relation(extension, group):
     with a.group_extension(group, extension):
@@ -217,7 +217,7 @@ def test_get_group_relation(extension, group):
         )
 
 
-@fixtures.extension(exten=gen_group_exten())
+@fixtures.extension(exten_range=EXTEN_GROUP_RANGE)
 @fixtures.group()
 def test_get_extension_relation(extension, group):
     with a.group_extension(group, extension):
@@ -234,7 +234,7 @@ def test_get_extension_relation(extension, group):
         )
 
 
-@fixtures.extension(exten=gen_group_exten())
+@fixtures.extension(exten_range=EXTEN_GROUP_RANGE)
 @fixtures.group()
 def test_edit_context_to_incall_when_associated(extension, group):
     with a.group_extension(group, extension):
@@ -242,7 +242,7 @@ def test_edit_context_to_incall_when_associated(extension, group):
         response.assert_status(400)
 
 
-@fixtures.extension(exten=gen_group_exten())
+@fixtures.extension(exten_range=EXTEN_GROUP_RANGE)
 @fixtures.group()
 def test_delete_group_when_group_and_extension_associated(extension, group):
     with a.group_extension(group, extension, check=False):
@@ -255,7 +255,7 @@ def test_delete_extension_when_group_and_extension_associated():
     pass
 
 
-@fixtures.extension(exten=gen_group_exten())
+@fixtures.extension(exten_range=EXTEN_GROUP_RANGE)
 @fixtures.group()
 def test_bus_events(extension, group):
     url = confd.groups(group['uuid']).extensions(extension['id'])

--- a/integration_tests/suite/base/test_groups.py
+++ b/integration_tests/suite/base/test_groups.py
@@ -18,7 +18,7 @@ from ..helpers import associations as a
 from ..helpers import errors as e
 from ..helpers import fixtures
 from ..helpers import scenarios as s
-from ..helpers.config import MAIN_TENANT, SUB_TENANT, gen_group_exten
+from ..helpers.config import EXTEN_GROUP_RANGE, MAIN_TENANT, SUB_TENANT
 from . import confd
 
 
@@ -116,7 +116,7 @@ def error_checks(url):
     s.check_bogus_field_returns_error(url, 'max_calls', [])
 
 
-@fixtures.extension(exten=gen_group_exten())
+@fixtures.extension(exten_range=EXTEN_GROUP_RANGE)
 @fixtures.group(label='hidden', preprocess_subroutine='hidden')
 @fixtures.group(label='search', preprocess_subroutine='search')
 def test_search(extension, hidden, group):

--- a/integration_tests/suite/base/test_line_extension.py
+++ b/integration_tests/suite/base/test_line_extension.py
@@ -20,10 +20,10 @@ from ..helpers import scenarios as s
 from ..helpers.config import (
     CONTEXT,
     EXTEN_OUTSIDE_RANGE,
+    EXTEN_QUEUE_RANGE,
     INCALL_CONTEXT,
     MAIN_TENANT,
     SUB_TENANT,
-    gen_queue_exten,
 )
 from . import confd
 from .test_extensions import error_checks
@@ -282,7 +282,7 @@ def test_associate_line_to_extension_already_associated(extension, line):
         response.assert_updated()
 
 
-@fixtures.extension(exten=gen_queue_exten())
+@fixtures.extension(exten_range=EXTEN_QUEUE_RANGE)
 @fixtures.queue()
 @fixtures.line_sip()
 def test_associate_line_to_extension_already_associated_to_other_resource(

--- a/integration_tests/suite/base/test_queue_extension.py
+++ b/integration_tests/suite/base/test_queue_extension.py
@@ -9,17 +9,17 @@ from ..helpers import fixtures
 from ..helpers import scenarios as s
 from ..helpers.config import (
     EXTEN_OUTSIDE_RANGE,
+    EXTEN_QUEUE_RANGE,
     INCALL_CONTEXT,
     MAIN_TENANT,
     SUB_TENANT,
-    gen_queue_exten,
 )
 from . import confd
 
 FAKE_ID = 999999999
 
 
-@fixtures.extension(exten=gen_queue_exten())
+@fixtures.extension(exten_range=EXTEN_QUEUE_RANGE)
 @fixtures.queue()
 def test_associate_errors(extension, queue):
     fake_queue = confd.queues(FAKE_ID).extensions(extension['id']).put
@@ -29,7 +29,7 @@ def test_associate_errors(extension, queue):
     s.check_resource_not_found(fake_extension, 'Extension')
 
 
-@fixtures.extension(exten=gen_queue_exten())
+@fixtures.extension(exten_range=EXTEN_QUEUE_RANGE)
 @fixtures.queue()
 def test_dissociate_errors(extension, queue):
     fake_queue = confd.queues(FAKE_ID).extensions(extension['id']).delete
@@ -39,14 +39,14 @@ def test_dissociate_errors(extension, queue):
     s.check_resource_not_found(fake_extension, 'Extension')
 
 
-@fixtures.extension(exten=gen_queue_exten())
+@fixtures.extension(exten_range=EXTEN_QUEUE_RANGE)
 @fixtures.queue()
 def test_associate(extension, queue):
     response = confd.queues(queue['id']).extensions(extension['id']).put()
     response.assert_updated()
 
 
-@fixtures.extension(exten=gen_queue_exten())
+@fixtures.extension(exten_range=EXTEN_QUEUE_RANGE)
 @fixtures.queue()
 def test_associate_already_associated(extension, queue):
     with a.queue_extension(queue, extension):
@@ -54,8 +54,8 @@ def test_associate_already_associated(extension, queue):
         response.assert_updated()
 
 
-@fixtures.extension(exten=gen_queue_exten())
-@fixtures.extension(exten=gen_queue_exten())
+@fixtures.extension(exten_range=EXTEN_QUEUE_RANGE)
+@fixtures.extension(exten_range=EXTEN_QUEUE_RANGE)
 @fixtures.queue()
 def test_associate_multiple_extensions_to_queue(extension1, extension2, queue):
     with a.queue_extension(queue, extension1):
@@ -63,7 +63,7 @@ def test_associate_multiple_extensions_to_queue(extension1, extension2, queue):
         response.assert_match(400, e.resource_associated('Queue', 'Extension'))
 
 
-@fixtures.extension(exten=gen_queue_exten())
+@fixtures.extension(exten_range=EXTEN_QUEUE_RANGE)
 @fixtures.queue()
 @fixtures.queue()
 def test_associate_multiple_queues_to_extension(extension, queue1, queue2):
@@ -82,7 +82,7 @@ def test_associate_when_user_already_associated(extension, queue, user, line_sip
         response.assert_match(400, e.resource_associated('user', 'Extension'))
 
 
-@fixtures.extension(exten=gen_queue_exten(), context=INCALL_CONTEXT)
+@fixtures.extension(exten_range=EXTEN_QUEUE_RANGE, context=INCALL_CONTEXT)
 @fixtures.queue()
 def test_associate_when_not_internal_context(extension, queue):
     response = confd.queues(queue['id']).extensions(extension['id']).put()
@@ -109,10 +109,10 @@ def test_associate_when_exten_pattern(extension, queue):
 @fixtures.context(wazo_tenant=SUB_TENANT, label='sub-internal')
 def test_associate_multi_tenant(main_queue, sub_queue, main_ctx, sub_ctx):
     with fixtures.extension(
-        context=main_ctx['name'], exten=gen_queue_exten()
+        context=main_ctx['name'], exten_range=EXTEN_QUEUE_RANGE
     ) as main_exten:
         with fixtures.extension(
-            context=sub_ctx['name'], exten=gen_queue_exten()
+            context=sub_ctx['name'], exten_range=EXTEN_QUEUE_RANGE
         ) as sub_exten:
             response = (
                 confd.queues(sub_queue['id'])
@@ -136,7 +136,7 @@ def test_associate_multi_tenant(main_queue, sub_queue, main_ctx, sub_ctx):
             response.assert_match(400, e.different_tenant())
 
 
-@fixtures.extension(exten=gen_queue_exten())
+@fixtures.extension(exten_range=EXTEN_QUEUE_RANGE)
 @fixtures.queue()
 def test_dissociate(extension, queue):
     with a.queue_extension(queue, extension, check=False):
@@ -144,7 +144,7 @@ def test_dissociate(extension, queue):
         response.assert_deleted()
 
 
-@fixtures.extension(exten=gen_queue_exten())
+@fixtures.extension(exten_range=EXTEN_QUEUE_RANGE)
 @fixtures.queue()
 def test_dissociate_not_associated(extension, queue):
     response = confd.queues(queue['id']).extensions(extension['id']).delete()
@@ -157,10 +157,10 @@ def test_dissociate_not_associated(extension, queue):
 @fixtures.context(wazo_tenant=SUB_TENANT, label='sub-internal')
 def test_dissociate_multi_tenant(main_queue, sub_queue, main_ctx, sub_ctx):
     with fixtures.extension(
-        context=main_ctx['name'], exten=gen_queue_exten()
+        context=main_ctx['name'], exten_range=EXTEN_QUEUE_RANGE
     ) as main_exten:
         with fixtures.extension(
-            context=sub_ctx['name'], exten=gen_queue_exten()
+            context=sub_ctx['name'], exten_range=EXTEN_QUEUE_RANGE
         ) as sub_exten:
             response = (
                 confd.queues(sub_queue['id'])
@@ -177,7 +177,7 @@ def test_dissociate_multi_tenant(main_queue, sub_queue, main_ctx, sub_ctx):
             response.assert_match(404, e.not_found('Queue'))
 
 
-@fixtures.extension(exten=gen_queue_exten())
+@fixtures.extension(exten_range=EXTEN_QUEUE_RANGE)
 @fixtures.queue()
 def test_get_queue_relation(extension, queue):
     with a.queue_extension(queue, extension):
@@ -196,7 +196,7 @@ def test_get_queue_relation(extension, queue):
         )
 
 
-@fixtures.extension(exten=gen_queue_exten())
+@fixtures.extension(exten_range=EXTEN_QUEUE_RANGE)
 @fixtures.queue()
 def test_get_extension_relation(extension, queue):
     with a.queue_extension(queue, extension):
@@ -207,7 +207,7 @@ def test_get_extension_relation(extension, queue):
         )
 
 
-@fixtures.extension(exten=gen_queue_exten())
+@fixtures.extension(exten_range=EXTEN_QUEUE_RANGE)
 @fixtures.queue()
 def test_edit_context_to_incall_when_associated(extension, queue):
     with a.queue_extension(queue, extension):
@@ -215,7 +215,7 @@ def test_edit_context_to_incall_when_associated(extension, queue):
         response.assert_status(400)
 
 
-@fixtures.extension(exten=gen_queue_exten())
+@fixtures.extension(exten_range=EXTEN_QUEUE_RANGE)
 @fixtures.queue()
 def test_delete_queue_when_queue_and_extension_associated(extension, queue):
     with a.queue_extension(queue, extension, check=False):
@@ -232,7 +232,7 @@ def test_delete_extension_associated_to_queue(extension, queue):
         response.assert_match(400, e.resource_associated('Extension', 'queue'))
 
 
-@fixtures.extension(exten=gen_queue_exten())
+@fixtures.extension(exten_range=EXTEN_QUEUE_RANGE)
 @fixtures.queue()
 def test_bus_events(extension, queue):
     url = confd.queues(queue['id']).extensions(extension['id'])

--- a/integration_tests/suite/base/test_queues.py
+++ b/integration_tests/suite/base/test_queues.py
@@ -18,7 +18,7 @@ from ..helpers import associations as a
 from ..helpers import errors as e
 from ..helpers import fixtures
 from ..helpers import scenarios as s
-from ..helpers.config import MAIN_TENANT, SUB_TENANT, gen_queue_exten
+from ..helpers.config import EXTEN_QUEUE_RANGE, MAIN_TENANT, SUB_TENANT
 from ..helpers.helpers.destination import invalid_destinations, valid_destinations
 from . import confd
 
@@ -245,7 +245,7 @@ def unique_error_checks(url, queue, group):
     s.check_bogus_field_returns_error(url, 'name', group['name'])
 
 
-@fixtures.extension(exten=gen_queue_exten())
+@fixtures.extension(exten_range=EXTEN_QUEUE_RANGE)
 @fixtures.queue(name='hidden', label='hidden', preprocess_subroutine='hidden')
 @fixtures.queue(name='search', label='search', preprocess_subroutine='search')
 def test_search(extension, hidden, queue):

--- a/integration_tests/suite/base/test_tenants.py
+++ b/integration_tests/suite/base/test_tenants.py
@@ -16,10 +16,10 @@ from ..helpers.config import (
     ALL_TENANTS,
     DEFAULT_TENANTS,
     DELETED_TENANT,
+    EXTEN_GROUP_RANGE,
+    EXTEN_USER_RANGE,
     MAIN_TENANT,
     SUB_TENANT,
-    gen_group_exten,
-    gen_line_exten,
 )
 from ..helpers.database import DatabaseQueries
 from . import BaseIntegrationTest, confd, db
@@ -223,7 +223,7 @@ def _create_tenant_ready_for_deletion():
             fixtures.call_permission(
                 mode='allow',
                 enabled=True,
-                extensions=[gen_group_exten()],
+                extensions=['2001'],
                 wazo_tenant=DELETED_TENANT,
             )
         )
@@ -232,7 +232,7 @@ def _create_tenant_ready_for_deletion():
         trunk = stack.enter_context(fixtures.trunk(wazo_tenant=DELETED_TENANT))
         stack.enter_context(
             fixtures.ivr(
-                choices=[{'exten': gen_group_exten(), 'destination': {'type': 'none'}}],
+                choices=[{'exten': '2001', 'destination': {'type': 'none'}}],
                 wazo_tenant=DELETED_TENANT,
             )
         )
@@ -298,13 +298,13 @@ def _create_tenant_ready_for_deletion():
             )
         )
         group_extension = stack.enter_context(
-            fixtures.extension(exten=gen_group_exten(), context=context['name'])
+            fixtures.extension(exten_range=EXTEN_GROUP_RANGE, context=context['name'])
         )
         incall_extension = stack.enter_context(
-            fixtures.extension(exten=gen_line_exten(), context=context['name'])
+            fixtures.extension(exten_range=EXTEN_USER_RANGE, context=context['name'])
         )
         outcall_extension = stack.enter_context(
-            fixtures.extension(exten=gen_line_exten(), context=context['name'])
+            fixtures.extension(exten_range=EXTEN_USER_RANGE, context=context['name'])
         )
         stack.enter_context(
             fixtures.funckey_template(

--- a/integration_tests/suite/base/test_users.py
+++ b/integration_tests/suite/base/test_users.py
@@ -30,11 +30,11 @@ from ..helpers import helpers as h
 from ..helpers import scenarios as s
 from ..helpers.config import (
     CONTEXT,
+    EXTEN_GROUP_RANGE,
     INCALL_CONTEXT,
     MAIN_TENANT,
     OUTCALL_CONTEXT,
     SUB_TENANT,
-    gen_group_exten,
 )
 from . import BaseIntegrationTest
 from . import auth as authentication
@@ -1131,7 +1131,7 @@ def generate_user_resources_bodies(
     )
 
 
-@fixtures.extension(exten=gen_group_exten())
+@fixtures.extension(exten_range=EXTEN_GROUP_RANGE)
 @fixtures.group()
 @fixtures.funckey_template(
     keys={'1': {'destination': {'type': 'custom', 'exten': '123'}}}
@@ -1552,7 +1552,7 @@ def test_post_update_delete_full_user_no_error(
             response.assert_status(404)
 
 
-@fixtures.extension(exten=gen_group_exten())
+@fixtures.extension(exten_range=EXTEN_GROUP_RANGE)
 @fixtures.group()
 @fixtures.funckey_template(
     keys={'1': {'destination': {'type': 'custom', 'exten': '123'}}}
@@ -1746,7 +1746,7 @@ def test_post_delete_minimalistic_user_with_non_existing_device_id_error():
     )
 
 
-@fixtures.extension(exten=gen_group_exten())
+@fixtures.extension(exten_range=EXTEN_GROUP_RANGE)
 @fixtures.user()
 @fixtures.voicemail()
 def test_delete_voicemail_2_users_not_deleted(

--- a/integration_tests/suite/helpers/config.py
+++ b/integration_tests/suite/helpers/config.py
@@ -1,13 +1,14 @@
-# Copyright 2015-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2025 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
-
-import random
 
 CONTEXT = 'default'
 INCALL_CONTEXT = 'from-extern'
 OUTCALL_CONTEXT = 'to-extern'
+EXTEN_CONFERENCE_RANGE = list(range(4000, 5000))
+EXTEN_GROUP_RANGE = list(range(2000, 3000))
 EXTEN_OUTSIDE_RANGE = str('99999')
-USER_EXTENSION_RANGE = list(range(1000, 2000))
+EXTEN_QUEUE_RANGE = list(range(3000, 4000))
+EXTEN_USER_RANGE = list(range(1000, 2000))
 MAIN_TENANT = 'eeeeeeee-eeee-eeee-eeee-eeeeeeeeeee1'
 SUB_TENANT = 'eeeeeeee-eeee-eeee-eeee-eeeeeeeeeee2'
 SUB_TENANT2 = 'eeeeeeee-eeee-eeee-eeee-eeeeeeeeeee3'
@@ -50,19 +51,3 @@ ALL_TENANTS = DEFAULT_TENANTS + [
         'parent_uuid': MAIN_TENANT,
     },
 ]
-
-
-def gen_line_exten():
-    return str(random.randint(1000, 1999))
-
-
-def gen_group_exten():
-    return str(random.randint(2000, 2999))
-
-
-def gen_queue_exten():
-    return str(random.randint(3000, 3999))
-
-
-def gen_conference_exten():
-    return str(random.randint(4000, 4999))

--- a/integration_tests/suite/helpers/config.py
+++ b/integration_tests/suite/helpers/config.py
@@ -4,11 +4,11 @@
 CONTEXT = 'default'
 INCALL_CONTEXT = 'from-extern'
 OUTCALL_CONTEXT = 'to-extern'
-EXTEN_CONFERENCE_RANGE = list(range(4000, 5000))
-EXTEN_GROUP_RANGE = list(range(2000, 3000))
+EXTEN_CONFERENCE_RANGE = range(4000, 5000)
+EXTEN_GROUP_RANGE = range(2000, 3000)
 EXTEN_OUTSIDE_RANGE = str('99999')
-EXTEN_QUEUE_RANGE = list(range(3000, 4000))
-EXTEN_USER_RANGE = list(range(1000, 2000))
+EXTEN_QUEUE_RANGE = range(3000, 4000)
+EXTEN_USER_RANGE = range(1000, 2000)
 MAIN_TENANT = 'eeeeeeee-eeee-eeee-eeee-eeeeeeeeeee1'
 SUB_TENANT = 'eeeeeeee-eeee-eeee-eeee-eeeeeeeeeee2'
 SUB_TENANT2 = 'eeeeeeee-eeee-eeee-eeee-eeeeeeeeeee3'

--- a/integration_tests/suite/helpers/helpers/extension.py
+++ b/integration_tests/suite/helpers/helpers/extension.py
@@ -1,26 +1,26 @@
 # Copyright 2015-2025 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from ..config import CONTEXT, USER_EXTENSION_RANGE
+from ..config import CONTEXT, EXTEN_USER_RANGE
 from . import confd
 
 
 def generate_extension(**parameters):
+    exten_range = parameters.pop('exten_range', EXTEN_USER_RANGE)
     parameters.setdefault('context', CONTEXT)
-    parameters.setdefault('exten', find_available_exten(parameters['context']))
+    parameters.setdefault(
+        'exten',
+        find_available_exten(parameters['context'], exten_range),
+    )
     return add_extension(**parameters)
 
 
-def find_available_exten(context, exclude=None):
+def find_available_exten(context, exten_range=EXTEN_USER_RANGE, exclude=None):
     exclude = {int(n) for n in exclude} if exclude else set()
-    response = confd.extensions.get()
-    numbers = [
-        int(e['exten'])
-        for e in response.items
-        if e['context'] == context and e['exten'].isdigit()
-    ]
+    response = confd.extensions.get(context=context, recurse=True)
+    numbers = [int(e['exten']) for e in response.items if e['exten'].isdigit()]
 
-    available = set(USER_EXTENSION_RANGE) - set(numbers) - exclude
+    available = set(exten_range) - set(numbers) - exclude
     return str(available.pop())
 
 

--- a/integration_tests/suite/helpers/helpers/voicemail.py
+++ b/integration_tests/suite/helpers/helpers/voicemail.py
@@ -32,7 +32,7 @@ def find_available_number(context=config.CONTEXT, exclude=None):
         if v['context'] == context and v['number'].isdigit()
     ]
 
-    available_numbers = set(config.USER_EXTENSION_RANGE) - set(numbers) - exclude
+    available_numbers = set(config.EXTEN_USER_RANGE) - set(numbers) - exclude
     return str(available_numbers.pop())
 
 


### PR DESCRIPTION
why: to remove flaky test when an extension already exists
