### PR TITLE
basic typing

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,6 +15,16 @@ repos:
     hooks:
       - id: isort
         args: [--filter-files]
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.19.1
+    hooks:
+      - id: mypy
+        language_version: "3.11"
+        exclude: (build|integration_tests)/.*
+        additional_dependencies:
+          - "types-pyyaml"
+          - "types-requests"
+          - "types-setuptools"
   - repo: https://github.com/wazo-platform/wazo-git-hooks.git
     rev: 1.1.3
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,3 +22,10 @@ py_version = 311
 
 [tool.pytest]
 testpaths = ["wazo_confd"]
+
+[tool.mypy]
+python_version = "3.11"
+show_error_codes = true
+check_untyped_defs = true
+warn_unused_configs = true
+ignore_missing_imports = true

--- a/wazo_confd/_bus.py
+++ b/wazo_confd/_bus.py
@@ -1,7 +1,8 @@
-# Copyright 2015-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from collections import deque
+from typing import Any
 
 from wazo_bus.base import Base
 from wazo_bus.consumer import BusConsumer as Consumer
@@ -10,11 +11,11 @@ from xivo.status import Status
 
 
 class FlushMixin:
-    __saved_state = {}
+    __saved_state: dict[str, Any] = {}
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self.__deque = deque()
+        self.__deque: deque[tuple[Any, dict[str, str] | None]] = deque()
 
     def queue_event(self, event, *, extra_headers=None):
         self.__deque.append((event, extra_headers))

--- a/wazo_confd/_bus.py
+++ b/wazo_confd/_bus.py
@@ -1,16 +1,23 @@
 # Copyright 2015-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+from __future__ import annotations
+
 from collections import deque
-from typing import Any
+from typing import TYPE_CHECKING, Any, TypeAlias
 
 from wazo_bus.base import Base
 from wazo_bus.consumer import BusConsumer as Consumer
 from wazo_bus.mixins import PublisherMixin, WazoEventMixin
 from xivo.status import Status
 
+if TYPE_CHECKING:
+    _FlushMixinBase: TypeAlias = PublisherMixin
+else:
+    _FlushMixinBase: TypeAlias = object
 
-class FlushMixin:
+
+class FlushMixin(_FlushMixinBase):
     __saved_state: dict[str, Any] = {}
 
     def __init__(self, **kwargs):

--- a/wazo_confd/_sysconfd.py
+++ b/wazo_confd/_sysconfd.py
@@ -1,5 +1,7 @@
-# Copyright 2013-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2013-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
+
+from collections.abc import Sequence
 
 import requests
 from xivo_dao.resources.configuration import dao as configuration_dao
@@ -142,7 +144,9 @@ class SysconfdPublisher:
     def flush_handlers(self, session):
         if len(self.handlers) > 0:
             url = "{}/exec_request_handlers".format(self.base_url)
-            body = {key: tuple(commands) for key, commands in self.handlers.items()}
+            body: dict[str, Sequence] = {
+                key: tuple(commands) for key, commands in self.handlers.items()
+            }
             if self.handlers_contexts:
                 body['context'] = self.handlers_contexts
             response = session.request('POST', url, json=body)

--- a/wazo_confd/helpers/asterisk.py
+++ b/wazo_confd/helpers/asterisk.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import gzip
@@ -55,7 +55,7 @@ class AsteriskConfigurationSchema(BaseSchema):
 class AsteriskConfigurationList(ConfdResource):
     model = AsteriskFileVariable
     schema = AsteriskConfigurationSchema
-    section_name = None
+    section_name: str | None = None
 
     def __init__(self, service):
         super().__init__()
@@ -73,7 +73,7 @@ class AsteriskConfigurationList(ConfdResource):
 
 
 class AsteriskConfigurationService:
-    file_name = None
+    file_name: str | None = None
 
     def __init__(self, dao, notifier):
         self.dao = dao

--- a/wazo_confd/helpers/destination.py
+++ b/wazo_confd/helpers/destination.py
@@ -593,7 +593,7 @@ class GetMohFromActionArg2Resource(Validator):
 
 
 class DestinationValidator:
-    _VALIDATORS = {
+    _VALIDATORS: dict[str, list[Validator]] = {
         'application:callbackdisa': [],
         'application:custom': [
             GetResource('actionarg1', application_dao.get, 'Application')

--- a/wazo_confd/helpers/destination.py
+++ b/wazo_confd/helpers/destination.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import json
@@ -523,9 +523,9 @@ class DestinationField(Nested):
         self.kwargs["unknown"] = EXCLUDE
         super().__init__(BaseDestinationSchema, **self.kwargs)
 
-    def _deserialize(self, value, attr, data, **kwargs):
+    def _deserialize(self, value, attr, data, partial=None, **kwargs):
         self.schema.context = self.context
-        base = super()._deserialize(value, attr, data, **kwargs)
+        base = super()._deserialize(value, attr, data, partial=partial, **kwargs)
         schema = self.destination_schemas[base['type']]
 
         if base['type'] == 'application':

--- a/wazo_confd/helpers/destination.py
+++ b/wazo_confd/helpers/destination.py
@@ -542,7 +542,7 @@ class DestinationField(Nested):
 
         return Nested(schema, **self.kwargs)._deserialize(value, attr, data, **kwargs)
 
-    def _serialize(self, nested_obj, attr, obj):
+    def _serialize(self, nested_obj, attr, obj):  # type: ignore[override]
         base = super()._serialize(nested_obj, attr, obj)
         if not base:
             return base

--- a/wazo_confd/helpers/mallow.py
+++ b/wazo_confd/helpers/mallow.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import re
@@ -80,7 +80,7 @@ class Link(fields.Field):
         self.field = field
         self.target = target or field
 
-    def _serialize(self, value, key, obj):
+    def _serialize(self, value, key, obj):  # type: ignore[override]
         value = self.extract_value(obj)
         if value:
             options = {self.target: value, '_external': True}
@@ -100,7 +100,7 @@ class ListLink(fields.Field):
         super().__init__(dump_only=True, **kwargs)
         self.links = links
 
-    def _serialize(self, value, key, obj):
+    def _serialize(self, value, key, obj):  # type: ignore[override]
         output = []
         for link in self.links:
             link_obj = link.serialize(key, obj)

--- a/wazo_confd/helpers/resource.py
+++ b/wazo_confd/helpers/resource.py
@@ -1,10 +1,10 @@
-# Copyright 2013-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2013-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from xivo_dao.helpers.db_manager import Session
 
 
-class CRUDService:
+class ReadService:
     def __init__(self, dao, validator, notifier, extra_parameters=None):
         self.dao = dao
         self.validator = validator
@@ -23,6 +23,8 @@ class CRUDService:
     def get_by(self, **criteria):
         return self.dao.get_by(**criteria)
 
+
+class CRUDService(ReadService):
     def create(self, resource):
         self.validator.validate_create(resource)
         created_resource = self.dao.create(resource)

--- a/wazo_confd/helpers/resource.py
+++ b/wazo_confd/helpers/resource.py
@@ -1,10 +1,10 @@
-# Copyright 2013-2026 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2013-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from xivo_dao.helpers.db_manager import Session
 
 
-class ReadService:
+class CRUDService:
     def __init__(self, dao, validator, notifier, extra_parameters=None):
         self.dao = dao
         self.validator = validator
@@ -23,8 +23,6 @@ class ReadService:
     def get_by(self, **criteria):
         return self.dao.get_by(**criteria)
 
-
-class CRUDService(ReadService):
     def create(self, resource):
         self.validator.validate_create(resource)
         created_resource = self.dao.create(resource)

--- a/wazo_confd/helpers/restful.py
+++ b/wazo_confd/helpers/restful.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import marshmallow
@@ -74,14 +74,14 @@ class ListResource(ConfdResource):
         super().__init__()
         self.service = service
 
-    def get(self):
+    def get(self, *args, **kwargs):
         params = self.search_params()
         tenant_uuids = self._build_tenant_list(params)
-        kwargs = {}
+        search_kwargs = {}
         if tenant_uuids is not None:
-            kwargs['tenant_uuids'] = tenant_uuids
+            search_kwargs['tenant_uuids'] = tenant_uuids
 
-        total, items = self.service.search(params, **kwargs)
+        total, items = self.service.search(params, **search_kwargs)
         return {'total': total, 'items': self.schema().dump(items, many=True)}
 
     def search_params(self):
@@ -96,7 +96,7 @@ class ListResource(ConfdResource):
         form['tenant_uuid'] = tenant.uuid
         return form
 
-    def post(self):
+    def post(self, *args, **kwargs):
         form = self.schema().load(request.get_json(force=True))
         form = self.add_tenant_to_form(form)
         model = self.model(**form)

--- a/wazo_confd/helpers/tests/test_destination.py
+++ b/wazo_confd/helpers/tests/test_destination.py
@@ -1,4 +1,4 @@
-# Copyright 2021-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2021-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from unittest import TestCase
@@ -15,7 +15,7 @@ class TestUserDestinationSchema(TestCase):
     def test_actionarg2_serialisation(self):
         moh_uuid = '53ff7e19-1872-4547-9bb7-bd00a20f840f'
         base_body = {'type': 'user', 'user_id': 42}
-        samples = [
+        samples: list[tuple[dict, str]] = [
             ({}, ''),
             ({'moh_uuid': moh_uuid}, ';{}'.format(moh_uuid)),
             ({'ring_time': 0}, '0.0'),

--- a/wazo_confd/helpers/validator.py
+++ b/wazo_confd/helpers/validator.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2021 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import abc
@@ -13,7 +13,7 @@ LANGUAGE_REGEX = r"^[a-z]{2}_[A-Z]{2}$"
 
 class Validator(metaclass=abc.ABCMeta):
     @abc.abstractmethod
-    def validate(self, model):
+    def validate(self, model, /):
         return
 
     def validate_with_tenant_uuids(self, model, tenant_uuids):
@@ -22,7 +22,7 @@ class Validator(metaclass=abc.ABCMeta):
 
 class ValidatorAssociation(metaclass=abc.ABCMeta):
     @abc.abstractmethod
-    def validate(self, model1, model2):
+    def validate(self, model1, model2, /):
         return
 
 

--- a/wazo_confd/http_server.py
+++ b/wazo_confd/http_server.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
@@ -23,7 +23,7 @@ from .helpers.converter import FilenameConverter
 logger = logging.getLogger(__name__)
 app = Flask('wazo_confd')
 api = Api(app, prefix="/1.1")
-_do_not_log_data_endpoints = []
+_do_not_log_data_endpoints: list[str] = []
 
 
 def get_bus_publisher():

--- a/wazo_confd/plugins/application/schema.py
+++ b/wazo_confd/plugins/application/schema.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from marshmallow import fields, post_load, pre_dump
@@ -26,7 +26,7 @@ class ApplicationDestinationOptionsField(fields.Field):
             return {}
         return concrete_options._deserialize(value, attr, data, **kwargs)
 
-    def _serialize(self, value, attr, obj):
+    def _serialize(self, value, attr, obj):  # type: ignore[override]
         if not obj.dest_node:
             return {}
         destination = obj.destination

--- a/wazo_confd/plugins/dhcp/exceptions.py
+++ b/wazo_confd/plugins/dhcp/exceptions.py
@@ -10,8 +10,9 @@ class InvalidInterfaces(DHCPError, HTTPException):
     description = 'Network interfaces specified are invalid'
 
     def __init__(self, invalid_interfaces: list[str] | None = None, response=None):
-        super().__init__(
-            description=f'Invalid network interfaces: {", ".join(invalid_interfaces)}',
+        HTTPException.__init__(
+            self,
+            description=f'Invalid network interfaces: {", ".join(invalid_interfaces or [])}',
             response=response,
         )
         self.invalid_interfaces = invalid_interfaces

--- a/wazo_confd/plugins/dhcp/exceptions.py
+++ b/wazo_confd/plugins/dhcp/exceptions.py
@@ -9,7 +9,7 @@ class InvalidInterfaces(DHCPError, HTTPException):
     code = 400
     description = 'Network interfaces specified are invalid'
 
-    def __init__(self, invalid_interfaces: list[str] = None, response=None):
+    def __init__(self, invalid_interfaces: list[str] | None = None, response=None):
         super().__init__(
             description=f'Invalid network interfaces: {", ".join(invalid_interfaces)}',
             response=response,

--- a/wazo_confd/plugins/endpoint_sip/middleware.py
+++ b/wazo_confd/plugins/endpoint_sip/middleware.py
@@ -1,4 +1,4 @@
-# Copyright 2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2023-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from xivo_dao.alchemy.endpoint_sip import EndpointSIP
@@ -7,10 +7,14 @@ from xivo_dao.helpers.exception import NotFoundError
 from xivo_dao.resources.endpoint_sip import dao as sip_dao
 from xivo_dao.resources.pjsip_transport import dao as transport_dao
 
+from wazo_confd.helpers.mallow import BaseSchema
+
 from .schema import EndpointSIPSchema, TemplateSIPSchema
 
 
 class BaseSIPMiddleWare:
+    _Schema: type[BaseSchema]
+
     def __init__(self, service):
         self._service = service
 

--- a/wazo_confd/plugins/endpoint_sip/tests/test_schema.py
+++ b/wazo_confd/plugins/endpoint_sip/tests/test_schema.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import uuid
@@ -43,7 +43,7 @@ class TestGETQueryStringSchema(TestCase):
         )
 
     def test_view_not_specified(self):
-        query_string = {}
+        query_string: dict[str, str] = {}
 
         loaded = self.schema.load(query_string)
 

--- a/wazo_confd/plugins/extension/service.py
+++ b/wazo_confd/plugins/extension/service.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
@@ -6,7 +6,7 @@ import logging
 from xivo_dao.helpers.db_manager import Session
 from xivo_dao.resources.extension import dao as extension_dao_module
 
-from wazo_confd.helpers.resource import CRUDService
+from wazo_confd.helpers.resource import ReadService
 from wazo_confd.plugins.device import builder as device_builder
 
 from .notifier import build_notifier
@@ -15,7 +15,7 @@ from .validator import build_validator
 logger = logging.getLogger(__name__)
 
 
-class ExtensionService(CRUDService):
+class ExtensionService(ReadService):
     def __init__(self, dao, validator, notifier, device_updater):
         super().__init__(dao, validator, notifier)
         self.device_updater = device_updater
@@ -40,6 +40,11 @@ class ExtensionService(CRUDService):
 
         if updated_fields is None or updated_fields:
             self.device_updater.update_for_extension(extension)
+
+    def delete(self, resource):
+        self.validator.validate_delete(resource)
+        self.dao.delete(resource)
+        self.notifier.deleted(resource)
 
 
 def build_service(provd_client):

--- a/wazo_confd/plugins/extension/service.py
+++ b/wazo_confd/plugins/extension/service.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2026 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
@@ -6,7 +6,7 @@ import logging
 from xivo_dao.helpers.db_manager import Session
 from xivo_dao.resources.extension import dao as extension_dao_module
 
-from wazo_confd.helpers.resource import ReadService
+from wazo_confd.helpers.resource import CRUDService
 from wazo_confd.plugins.device import builder as device_builder
 
 from .notifier import build_notifier
@@ -15,7 +15,7 @@ from .validator import build_validator
 logger = logging.getLogger(__name__)
 
 
-class ExtensionService(ReadService):
+class ExtensionService(CRUDService):
     def __init__(self, dao, validator, notifier, device_updater):
         super().__init__(dao, validator, notifier)
         self.device_updater = device_updater
@@ -40,11 +40,6 @@ class ExtensionService(ReadService):
 
         if updated_fields is None or updated_fields:
             self.device_updater.update_for_extension(extension)
-
-    def delete(self, resource):
-        self.validator.validate_delete(resource)
-        self.dao.delete(resource)
-        self.notifier.deleted(resource)
 
 
 def build_service(provd_client):

--- a/wazo_confd/plugins/extension/service.py
+++ b/wazo_confd/plugins/extension/service.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
@@ -20,7 +20,7 @@ class ExtensionService(CRUDService):
         super().__init__(dao, validator, notifier)
         self.device_updater = device_updater
 
-    def create(self, extension, tenant_uuids):
+    def create(self, extension, tenant_uuids):  # type: ignore[override]
         self.validator.validate_create(extension, tenant_uuids)
         created_extension = self.dao.create(extension)
         self.notifier.created(created_extension)

--- a/wazo_confd/plugins/extension/tests/test_notifier.py
+++ b/wazo_confd/plugins/extension/tests/test_notifier.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import unittest
@@ -75,7 +75,7 @@ class TestExtensionNotifier(unittest.TestCase):
         self.sysconfd.exec_request_handlers.assert_called_once_with(expected_handlers)
 
     def test_when_extension_edited_and_no_change_then_handlers_not_sent(self):
-        updated_fields = []
+        updated_fields: list[str] = []
         self.notifier.edited(self.extension, updated_fields)
 
         self.sysconfd.exec_request_handlers.assert_not_called()

--- a/wazo_confd/plugins/extension_feature/service.py
+++ b/wazo_confd/plugins/extension_feature/service.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from xivo_dao.helpers.db_manager import Session
@@ -11,10 +11,10 @@ from .validator import build_validator
 
 
 class FeatureExtensionService(CRUDService):
-    def search(self, parameters):
+    def search(self, parameters):  # type: ignore[override]
         return self.dao.search(**parameters)
 
-    def get(self, resource_uuid):
+    def get(self, resource_uuid):  # type: ignore[override]
         return self.dao.get_by(uuid=resource_uuid)
 
     def edit(self, resource, updated_fields=None):

--- a/wazo_confd/plugins/extension_feature/service.py
+++ b/wazo_confd/plugins/extension_feature/service.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2026 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from xivo_dao.helpers.db_manager import Session
@@ -11,11 +11,11 @@ from .validator import build_validator
 
 
 class FeatureExtensionService(CRUDService):
-    def search(self, parameters, tenant_uuids=None):
+    def search(self, parameters):
         return self.dao.search(**parameters)
 
-    def get(self, resource_id, **kwargs):
-        return self.dao.get_by(uuid=resource_id)
+    def get(self, resource_uuid):
+        return self.dao.get_by(uuid=resource_uuid)
 
     def edit(self, resource, updated_fields=None):
         with Session.no_autoflush:

--- a/wazo_confd/plugins/extension_feature/service.py
+++ b/wazo_confd/plugins/extension_feature/service.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from xivo_dao.helpers.db_manager import Session
@@ -11,11 +11,11 @@ from .validator import build_validator
 
 
 class FeatureExtensionService(CRUDService):
-    def search(self, parameters):
+    def search(self, parameters, tenant_uuids=None):
         return self.dao.search(**parameters)
 
-    def get(self, resource_uuid):
-        return self.dao.get_by(uuid=resource_uuid)
+    def get(self, resource_id, **kwargs):
+        return self.dao.get_by(uuid=resource_id)
 
     def edit(self, resource, updated_fields=None):
         with Session.no_autoflush:

--- a/wazo_confd/plugins/extension_feature/tests/test_notifier.py
+++ b/wazo_confd/plugins/extension_feature/tests/test_notifier.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import unittest
@@ -26,7 +26,7 @@ class TestExtensionFeatureNotifier(unittest.TestCase):
         self.sysconfd.exec_request_handlers.assert_called_once_with(expected_handlers)
 
     def test_when_extension_edited_and_no_change_then_handlers_not_sent(self):
-        updated_fields = []
+        updated_fields: list[str] = []
 
         self.notifier.edited(self.feature_extension, updated_fields)
 
@@ -34,7 +34,7 @@ class TestExtensionFeatureNotifier(unittest.TestCase):
 
     def test_when_extension_edited_then_event_sent_on_bus(self):
         expected_event = ExtensionFeatureEditedEvent(self.feature_extension.uuid)
-        updated_fields = []
+        updated_fields: list[str] = []
 
         self.notifier.edited(self.feature_extension, updated_fields)
 

--- a/wazo_confd/plugins/features/resource.py
+++ b/wazo_confd/plugins/features/resource.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from flask import request
@@ -120,7 +120,7 @@ class FeaturesApplicationmapSchema(FeaturesConfigurationSchema):
 class FeaturesConfigurationList(ConfdResource):
     model = Features
     schema = FeaturesConfigurationSchema
-    section_name = None
+    section_name: str | None = None
 
     def __init__(self, service):
         super().__init__()

--- a/wazo_confd/plugins/func_key/schema.py
+++ b/wazo_confd/plugins/func_key/schema.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from flask import url_for
@@ -265,9 +265,9 @@ class FuncKeyDestinationField(Nested):
         kwargs['unknown'] = EXCLUDE
         super().__init__(*args, **kwargs)
 
-    def _deserialize(self, value, attr, data, **kwargs):
+    def _deserialize(self, value, attr, data, partial=None, **kwargs):
         self.schema.context = self.context
-        base = super()._deserialize(value, attr, data, **kwargs)
+        base = super()._deserialize(value, attr, data, partial=partial, **kwargs)
         return Nested(
             self.destination_schemas[base['type']], unknown=self.unknown
         )._deserialize(value, attr, data, **kwargs)

--- a/wazo_confd/plugins/func_key/schema.py
+++ b/wazo_confd/plugins/func_key/schema.py
@@ -272,7 +272,7 @@ class FuncKeyDestinationField(Nested):
             self.destination_schemas[base['type']], unknown=self.unknown
         )._deserialize(value, attr, data, **kwargs)
 
-    def _serialize(self, nested_obj, attr, obj):
+    def _serialize(self, nested_obj, attr, obj):  # type: ignore[override]
         base = super()._serialize(nested_obj, attr, obj)
         return Nested(
             self.destination_schemas[base['type']], unknown=self.unknown
@@ -312,7 +312,7 @@ class FuncKeyPositionField(fields.Field):
             template[position] = funckey
         return template
 
-    def _serialize(self, value, attr, obj):
+    def _serialize(self, value, attr, obj):  # type: ignore[override]
         template = {}
         for raw_position, raw_funckey in value.items():
             position = self.key_field._serialize(raw_position, attr, obj)

--- a/wazo_confd/plugins/func_key/validator.py
+++ b/wazo_confd/plugins/func_key/validator.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from collections import Counter
@@ -22,6 +22,7 @@ from wazo_confd.helpers.validator import (
     ValidationAssociation,
     ValidationGroup,
     Validator,
+    ValidatorAssociation,
 )
 
 
@@ -33,7 +34,7 @@ class PrivateTemplateValidator(Validator):
             )
 
 
-class AssociatePrivateTemplateValidator(Validator):
+class AssociatePrivateTemplateValidator(ValidatorAssociation):
     def validate(self, user, template):
         if template.private:
             raise errors.not_permitted(
@@ -42,7 +43,7 @@ class AssociatePrivateTemplateValidator(Validator):
             )
 
 
-class AssociateSameTenant(Validator):
+class AssociateSameTenant(ValidatorAssociation):
     def validate(self, user, template):
         if user.tenant_uuid != template.tenant_uuid:
             raise errors.different_tenants(
@@ -141,7 +142,7 @@ class CustomValidator(FuncKeyValidator):
         self.validate_text(destination.exten, 'exten')
 
 
-class BSFilterValidator(FuncKeyValidator):
+class BSFilterValidator(ValidatorAssociation):
     def validate(self, user, funckey):
         if funckey.destination.type != 'bsfilter':
             return

--- a/wazo_confd/plugins/group_call_permission/validator.py
+++ b/wazo_confd/plugins/group_call_permission/validator.py
@@ -1,12 +1,12 @@
-# Copyright 2018-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from xivo_dao.helpers import errors
 
-from wazo_confd.helpers.validator import ValidationAssociation, Validator
+from wazo_confd.helpers.validator import ValidationAssociation, ValidatorAssociation
 
 
-class AssociateGroupCallPermission(Validator):
+class AssociateGroupCallPermission(ValidatorAssociation):
     def validate(self, group, call_permission):
         self.validate_same_tenant(group, call_permission)
 

--- a/wazo_confd/plugins/line/service.py
+++ b/wazo_confd/plugins/line/service.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2020 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from xivo_dao.helpers.db_manager import Session
@@ -41,13 +41,13 @@ class LineService(CRUDService):
     def find_all_by(self, **criteria):
         return self.dao.find_all_by(**criteria)
 
-    def create(self, resource, tenant_uuids):
+    def create(self, resource, tenant_uuids):  # type: ignore[override]
         self.validator.validate_create(resource, tenant_uuids=tenant_uuids)
         created_resource = self.dao.create(resource)
         self.notifier.created(created_resource)
         return created_resource
 
-    def edit(self, line, tenant_uuids, updated_fields=None):
+    def edit(self, line, tenant_uuids, updated_fields=None):  # type: ignore[override]
         with Session.no_autoflush:
             self.validator.validate_edit(line, tenant_uuids=tenant_uuids)
         self.dao.edit(line)

--- a/wazo_confd/plugins/line/service.py
+++ b/wazo_confd/plugins/line/service.py
@@ -1,10 +1,10 @@
-# Copyright 2015-2020 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from xivo_dao.helpers.db_manager import Session
 from xivo_dao.resources.line import dao as line_dao_module
 
-from wazo_confd.helpers.resource import CRUDService
+from wazo_confd.helpers.resource import ReadService
 from wazo_confd.plugins.device import builder as device_builder
 from wazo_confd.plugins.line_device.service import (
     build_service as line_device_build_service,
@@ -18,7 +18,7 @@ from .notifier import build_notifier
 from .validator import build_validator
 
 
-class LineService(CRUDService):
+class LineService(ReadService):
     def __init__(
         self,
         dao,

--- a/wazo_confd/plugins/line/service.py
+++ b/wazo_confd/plugins/line/service.py
@@ -1,10 +1,10 @@
-# Copyright 2015-2026 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from xivo_dao.helpers.db_manager import Session
 from xivo_dao.resources.line import dao as line_dao_module
 
-from wazo_confd.helpers.resource import ReadService
+from wazo_confd.helpers.resource import CRUDService
 from wazo_confd.plugins.device import builder as device_builder
 from wazo_confd.plugins.line_device.service import (
     build_service as line_device_build_service,
@@ -18,7 +18,7 @@ from .notifier import build_notifier
 from .validator import build_validator
 
 
-class LineService(ReadService):
+class LineService(CRUDService):
     def __init__(
         self,
         dao,

--- a/wazo_confd/plugins/line/tests/test_notifier.py
+++ b/wazo_confd/plugins/line/tests/test_notifier.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import unittest
@@ -62,7 +62,7 @@ class TestLineNotifier(unittest.TestCase):
         self.sysconfd.exec_request_handlers.assert_called_once_with(SYSCONFD_HANDLERS)
 
     def test_when_line_edited_and_no_change_then_sip_not_reloaded(self):
-        updated_fields = []
+        updated_fields: list[str] = []
         self.notifier.edited(self.line, updated_fields)
 
         self.sysconfd.exec_request_handlers.assert_not_called()

--- a/wazo_confd/plugins/line_endpoint/middleware.py
+++ b/wazo_confd/plugins/line_endpoint/middleware.py
@@ -12,7 +12,7 @@ class _BaseLineEndpointMiddleWare:
         self._service = service
 
     def _get_endpoint(self, endpoint_id, tenant_uuids):
-        raise NotImplementedError
+        raise NotImplementedError()
 
     def associate(self, line_id, endpoint_id, tenant_uuids):
         line = line_dao.get(line_id, tenant_uuids=tenant_uuids)

--- a/wazo_confd/plugins/line_endpoint/middleware.py
+++ b/wazo_confd/plugins/line_endpoint/middleware.py
@@ -1,4 +1,4 @@
-# Copyright 2022-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2022-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from xivo_dao.resources.endpoint_custom import dao as endpoint_custom_dao
@@ -10,6 +10,9 @@ from xivo_dao.resources.line import dao as line_dao
 class _BaseLineEndpointMiddleWare:
     def __init__(self, service):
         self._service = service
+
+    def _get_endpoint(self, endpoint_id, tenant_uuids):
+        raise NotImplementedError
 
     def associate(self, line_id, endpoint_id, tenant_uuids):
         line = line_dao.get(line_id, tenant_uuids=tenant_uuids)

--- a/wazo_confd/plugins/meeting/resource.py
+++ b/wazo_confd/plugins/meeting/resource.py
@@ -1,4 +1,4 @@
-# Copyright 2021-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2021-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
@@ -14,7 +14,9 @@ from xivo_dao.alchemy.meeting import Meeting
 from xivo_dao.helpers import errors
 
 from wazo_confd.auth import master_tenant_uuid, no_auth, required_acl
+from wazo_confd.helpers.resource import CRUDService
 from wazo_confd.helpers.restful import ItemResource, ListResource, ListSchema
+from wazo_confd.plugins.extension_feature.service import FeatureExtensionService
 
 from .exceptions import MeetingGuestSIPTemplateNotFound
 from .schema import MeetingSchema
@@ -23,6 +25,9 @@ logger = logging.getLogger(__name__)
 
 
 class _SchemaMixin:
+    _ingress_http_service: CRUDService
+    _extension_features_service: FeatureExtensionService
+
     def _init_schema(self):
         self._schema = MeetingSchema()
 

--- a/wazo_confd/plugins/meeting_authorization/resource.py
+++ b/wazo_confd/plugins/meeting_authorization/resource.py
@@ -1,4 +1,4 @@
-# Copyright 2021-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2021-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from flask import request, url_for
@@ -72,7 +72,7 @@ class GuestMeetingAuthorizationItem(ItemResource):
         try:
             model = self._service.get(
                 ids['meeting_uuid'],
-                ids['authorization_uuid'],
+                authorization_uuid=ids['authorization_uuid'],
                 guest_uuid=ids['guest_uuid'],
             )
         except NotFoundError as e:
@@ -132,7 +132,7 @@ class UserMeetingAuthorizationList(ListResource, _MeResourceMixin):
 
         params = self.search_params()
 
-        total, items = self.service.search(params, ids['meeting_uuid'])
+        total, items = self.service.search(params, meeting_uuid=ids['meeting_uuid'])
         return {'total': total, 'items': self.schema().dump(items, many=True)}
 
     @required_acl('confd.users.me.meetings.{meeting_uuid}.authorizations.create')

--- a/wazo_confd/plugins/meeting_authorization/resource.py
+++ b/wazo_confd/plugins/meeting_authorization/resource.py
@@ -1,4 +1,4 @@
-# Copyright 2021-2026 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2021-2025 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from flask import request, url_for
@@ -72,7 +72,7 @@ class GuestMeetingAuthorizationItem(ItemResource):
         try:
             model = self._service.get(
                 ids['meeting_uuid'],
-                authorization_uuid=ids['authorization_uuid'],
+                ids['authorization_uuid'],
                 guest_uuid=ids['guest_uuid'],
             )
         except NotFoundError as e:
@@ -132,7 +132,7 @@ class UserMeetingAuthorizationList(ListResource, _MeResourceMixin):
 
         params = self.search_params()
 
-        total, items = self.service.search(params, meeting_uuid=ids['meeting_uuid'])
+        total, items = self.service.search(params, ids['meeting_uuid'])
         return {'total': total, 'items': self.schema().dump(items, many=True)}
 
     @required_acl('confd.users.me.meetings.{meeting_uuid}.authorizations.create')

--- a/wazo_confd/plugins/meeting_authorization/service.py
+++ b/wazo_confd/plugins/meeting_authorization/service.py
@@ -1,4 +1,4 @@
-# Copyright 2021-2026 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2021-2025 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from xivo_dao.resources.meeting import dao as meeting_dao
@@ -10,8 +10,7 @@ from .validator import build_validator
 
 
 class MeetingAuthorizationService(CRUDService):
-    def search(self, parameters, tenant_uuids=None, **kwargs):
-        meeting_uuid = kwargs.get('meeting_uuid')
+    def search(self, parameters, meeting_uuid):
         return self.dao.search(meeting_uuid, **parameters)
 
     def create(self, meeting_authorization):
@@ -24,9 +23,8 @@ class MeetingAuthorizationService(CRUDService):
             'pending' if meeting.require_authorization else 'accepted'
         )
 
-    def get(self, resource_id, **kwargs):
-        authorization_uuid = kwargs.pop('authorization_uuid', None)
-        return self.dao.get(resource_id, authorization_uuid, **kwargs)
+    def get(self, meeting_uuid, authorization_uuid, **kwargs):
+        return self.dao.get(meeting_uuid, authorization_uuid, **kwargs)
 
     def accept(self, meeting_authorization):
         meeting_authorization.status = 'accepted'

--- a/wazo_confd/plugins/meeting_authorization/service.py
+++ b/wazo_confd/plugins/meeting_authorization/service.py
@@ -1,4 +1,4 @@
-# Copyright 2021-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2021-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from xivo_dao.resources.meeting import dao as meeting_dao
@@ -10,7 +10,7 @@ from .validator import build_validator
 
 
 class MeetingAuthorizationService(CRUDService):
-    def search(self, parameters, meeting_uuid):
+    def search(self, parameters, meeting_uuid):  # type: ignore[override]
         return self.dao.search(meeting_uuid, **parameters)
 
     def create(self, meeting_authorization):
@@ -23,7 +23,7 @@ class MeetingAuthorizationService(CRUDService):
             'pending' if meeting.require_authorization else 'accepted'
         )
 
-    def get(self, meeting_uuid, authorization_uuid, **kwargs):
+    def get(self, meeting_uuid, authorization_uuid, **kwargs):  # type: ignore[override]
         return self.dao.get(meeting_uuid, authorization_uuid, **kwargs)
 
     def accept(self, meeting_authorization):

--- a/wazo_confd/plugins/meeting_authorization/service.py
+++ b/wazo_confd/plugins/meeting_authorization/service.py
@@ -1,4 +1,4 @@
-# Copyright 2021-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2021-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from xivo_dao.resources.meeting import dao as meeting_dao
@@ -10,7 +10,8 @@ from .validator import build_validator
 
 
 class MeetingAuthorizationService(CRUDService):
-    def search(self, parameters, meeting_uuid):
+    def search(self, parameters, tenant_uuids=None, **kwargs):
+        meeting_uuid = kwargs.get('meeting_uuid')
         return self.dao.search(meeting_uuid, **parameters)
 
     def create(self, meeting_authorization):
@@ -23,8 +24,9 @@ class MeetingAuthorizationService(CRUDService):
             'pending' if meeting.require_authorization else 'accepted'
         )
 
-    def get(self, meeting_uuid, authorization_uuid, **kwargs):
-        return self.dao.get(meeting_uuid, authorization_uuid, **kwargs)
+    def get(self, resource_id, **kwargs):
+        authorization_uuid = kwargs.pop('authorization_uuid', None)
+        return self.dao.get(resource_id, authorization_uuid, **kwargs)
 
     def accept(self, meeting_authorization):
         meeting_authorization.status = 'accepted'

--- a/wazo_confd/plugins/moh/service.py
+++ b/wazo_confd/plugins/moh/service.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from xivo_dao.resources.moh import dao as moh_dao
@@ -21,7 +21,7 @@ class MohService(CRUDService):
             self._update_resource(resource)
         return total, resources
 
-    def get(self, resource_id, tenant_uuids=None):
+    def get(self, resource_id, tenant_uuids=None):  # type: ignore[override]
         resource = self.dao.get(resource_id, tenant_uuids=tenant_uuids)
         self._update_resource(resource)
         return resource

--- a/wazo_confd/plugins/moh/service.py
+++ b/wazo_confd/plugins/moh/service.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2026 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2025 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from xivo_dao.resources.moh import dao as moh_dao
@@ -21,7 +21,7 @@ class MohService(CRUDService):
             self._update_resource(resource)
         return total, resources
 
-    def get(self, resource_id, tenant_uuids=None, **kwargs):
+    def get(self, resource_id, tenant_uuids=None):
         resource = self.dao.get(resource_id, tenant_uuids=tenant_uuids)
         self._update_resource(resource)
         return resource

--- a/wazo_confd/plugins/moh/service.py
+++ b/wazo_confd/plugins/moh/service.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from xivo_dao.resources.moh import dao as moh_dao
@@ -21,7 +21,7 @@ class MohService(CRUDService):
             self._update_resource(resource)
         return total, resources
 
-    def get(self, resource_id, tenant_uuids=None):
+    def get(self, resource_id, tenant_uuids=None, **kwargs):
         resource = self.dao.get(resource_id, tenant_uuids=tenant_uuids)
         self._update_resource(resource)
         return resource

--- a/wazo_confd/plugins/outcall_call_permission/validator.py
+++ b/wazo_confd/plugins/outcall_call_permission/validator.py
@@ -1,12 +1,12 @@
-# Copyright 2018-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from xivo_dao.helpers import errors
 
-from wazo_confd.helpers.validator import ValidationAssociation, Validator
+from wazo_confd.helpers.validator import ValidationAssociation, ValidatorAssociation
 
 
-class AssociateOutcallCallPermission(Validator):
+class AssociateOutcallCallPermission(ValidatorAssociation):
     def validate(self, outcall, call_permission):
         self.validate_same_tenant(outcall, call_permission)
 

--- a/wazo_confd/plugins/phone_number/service.py
+++ b/wazo_confd/plugins/phone_number/service.py
@@ -1,9 +1,8 @@
-# Copyright 2024-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2024-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 from __future__ import annotations
 
 import logging
-from typing import Literal
 
 from xivo_dao.alchemy.phone_number import PhoneNumber
 from xivo_dao.helpers.errors import ResourceError
@@ -11,7 +10,7 @@ from xivo_dao.resources.phone_number import dao
 
 from wazo_confd.helpers.resource import CRUDService
 
-from .notifier import PhoneNumberNotifier, build_notifier
+from .notifier import build_notifier
 from .utils import (
     PhoneNumberMainSpec,
     PhoneNumberRangeSpec,
@@ -23,10 +22,7 @@ logger = logging.getLogger(__name__)
 
 
 class PhoneNumberService(CRUDService):
-    dao: Literal[dao] = dao
-    notifier: PhoneNumberNotifier
-
-    def __init__(self, dao: dao, validator, notifier):
+    def __init__(self, dao, validator, notifier):
         super().__init__(dao, validator, notifier)
 
     def find_all_by(self, **criteria) -> list[PhoneNumber]:

--- a/wazo_confd/plugins/pjsip/resource.py
+++ b/wazo_confd/plugins/pjsip/resource.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2026 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2020-2025 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from flask import request, url_for
@@ -97,5 +97,5 @@ class PJSIPTransportItem(ItemResource):
         fallback = params['fallback']
         if fallback:
             fallback = self.service.get(fallback)
-        self.service.delete_with_fallback(transport, fallback=fallback)
+        self.service.delete(transport, fallback=fallback)
         return '', 204

--- a/wazo_confd/plugins/pjsip/resource.py
+++ b/wazo_confd/plugins/pjsip/resource.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2020-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from flask import request, url_for
@@ -97,5 +97,5 @@ class PJSIPTransportItem(ItemResource):
         fallback = params['fallback']
         if fallback:
             fallback = self.service.get(fallback)
-        self.service.delete(transport, fallback=fallback)
+        self.service.delete_with_fallback(transport, fallback=fallback)
         return '', 204

--- a/wazo_confd/plugins/pjsip/service.py
+++ b/wazo_confd/plugins/pjsip/service.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2026 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2020-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
@@ -39,7 +39,7 @@ def build_service(pjsip_doc):
 
 
 class PJSIPTransportService(CRUDService):
-    def delete_with_fallback(self, transport, fallback):
+    def delete(self, transport, fallback):
         for validator in self.validator.delete:
             validator.validate(transport, fallback)
         self.dao.delete(transport, fallback)

--- a/wazo_confd/plugins/pjsip/service.py
+++ b/wazo_confd/plugins/pjsip/service.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2020-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
@@ -39,7 +39,7 @@ def build_service(pjsip_doc):
 
 
 class PJSIPTransportService(CRUDService):
-    def delete(self, transport, fallback):
+    def delete_with_fallback(self, transport, fallback):
         for validator in self.validator.delete:
             validator.validate(transport, fallback)
         self.dao.delete(transport, fallback)

--- a/wazo_confd/plugins/pjsip/service.py
+++ b/wazo_confd/plugins/pjsip/service.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2020-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
@@ -39,7 +39,7 @@ def build_service(pjsip_doc):
 
 
 class PJSIPTransportService(CRUDService):
-    def delete(self, transport, fallback):
+    def delete(self, transport, fallback):  # type: ignore[override]
         for validator in self.validator.delete:
             validator.validate(transport, fallback)
         self.dao.delete(transport, fallback)

--- a/wazo_confd/plugins/pjsip/validator.py
+++ b/wazo_confd/plugins/pjsip/validator.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2020-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from functools import partial
@@ -12,11 +12,11 @@ from wazo_confd.helpers.validator import (
     UniqueField,
     UniqueFieldChanged,
     ValidationGroup,
-    Validator,
+    ValidatorAssociation,
 )
 
 
-class TransportDeleteValidator(Validator):
+class TransportDeleteValidator(ValidatorAssociation):
     def __init__(self, sip_dao):
         self.sip_dao = sip_dao
 

--- a/wazo_confd/plugins/register_iax/resource.py
+++ b/wazo_confd/plugins/register_iax/resource.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import re
@@ -102,6 +102,7 @@ class RegisterIAXSchema(BaseSchema):
     @pre_dump
     def convert_from_chaniax(self, data, **kwargs):
         register = REGISTER_REGEX.match(data.var_val)
+        assert register is not None
         result = register.groupdict()
         result['id'] = data.id
         result['enabled'] = data.enabled

--- a/wazo_confd/plugins/registrar/service.py
+++ b/wazo_confd/plugins/registrar/service.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2026 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2025 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
@@ -19,7 +19,7 @@ class RegistrarService(CRUDService):
         self.device_updater = device_updater
         self.provd_client = provd_client
 
-    def search(self, parameters, tenant_uuids=None):
+    def search(self, parameters):
         return self.dao.search(**parameters)
 
     def create(self, registrar):

--- a/wazo_confd/plugins/registrar/service.py
+++ b/wazo_confd/plugins/registrar/service.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
@@ -19,7 +19,7 @@ class RegistrarService(CRUDService):
         self.device_updater = device_updater
         self.provd_client = provd_client
 
-    def search(self, parameters):
+    def search(self, parameters, tenant_uuids=None):
         return self.dao.search(**parameters)
 
     def create(self, registrar):

--- a/wazo_confd/plugins/registrar/service.py
+++ b/wazo_confd/plugins/registrar/service.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
@@ -19,7 +19,7 @@ class RegistrarService(CRUDService):
         self.device_updater = device_updater
         self.provd_client = provd_client
 
-    def search(self, parameters):
+    def search(self, parameters):  # type: ignore[override]
         return self.dao.search(**parameters)
 
     def create(self, registrar):

--- a/wazo_confd/plugins/schedule/tests/test_validator.py
+++ b/wazo_confd/plugins/schedule/tests/test_validator.py
@@ -1,4 +1,4 @@
-# Copyright 2021-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2021-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from unittest import TestCase
@@ -15,7 +15,7 @@ class TestUserDestinationSchema(TestCase):
     def test_fallback_actionargs_serialisation(self):
         moh_uuid = '53ff7e19-1872-4547-9bb7-bd00a20f840f'
         base_body = {'type': 'user', 'user_id': 42}
-        samples = [
+        samples: list[tuple[dict, str]] = [
             ({}, ''),
             ({'moh_uuid': moh_uuid}, ';{}'.format(moh_uuid)),
             ({'ring_time': 0}, '0.0'),

--- a/wazo_confd/plugins/sound/storage.py
+++ b/wazo_confd/plugins/sound/storage.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import errno
@@ -28,17 +28,17 @@ class _SoundFilesystemStorage:
         self._base_path = base_path
 
     def _build_path(self, *fragments):
-        fragments = [fragment for fragment in fragments if fragment]
+        filtered = [fragment for fragment in fragments if fragment]
 
         dangerous_fragments = [
-            fragment for fragment in fragments if '..' in fragment or '/' in fragment
+            fragment for fragment in filtered if '..' in fragment or '/' in fragment
         ]
         if dangerous_fragments:
             raise errors.not_permitted(
                 'Dangerous path fragment: "{}"'.format(dangerous_fragments)
             )
 
-        return os.path.join(self._base_path, *fragments)
+        return os.path.join(self._base_path, *filtered)
 
     def list_directories(self, parameters, tenant_uuids):
         result = []

--- a/wazo_confd/plugins/switchboard/resource.py
+++ b/wazo_confd/plugins/switchboard/resource.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from flask import request, url_for
@@ -14,7 +14,8 @@ from .schema import SwitchboardSchema
 
 class _BaseSwitchboardResource:
     def __init__(self, service, moh_dao):
-        super().__init__(service)
+        # super() resolves to ListResource or ItemResource in subclasses
+        super().__init__(service)  # type: ignore[call-arg]
         self._moh_dao = moh_dao
 
     def _update_moh_fields(self, form, tenant_uuids):

--- a/wazo_confd/plugins/trunk_endpoint/validator.py
+++ b/wazo_confd/plugins/trunk_endpoint/validator.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from xivo_dao.helpers import errors
@@ -48,6 +48,9 @@ class _TrunkEndpointAssociationValidator(ValidatorAssociation):
                 endpoint=protocol,
                 endpoint_id=protocol_id,
             )
+
+    def validate_not_associated_to_trunk(self, trunk, endpoint):
+        pass
 
     def validate_not_associated_to_line(self, trunk, endpoint):
         pass

--- a/wazo_confd/plugins/user/middleware.py
+++ b/wazo_confd/plugins/user/middleware.py
@@ -1,4 +1,4 @@
-# Copyright 2023-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2023-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from http import HTTPStatus
@@ -369,8 +369,8 @@ class UserMiddleWare(ResourceMiddleware):
                 new_extension = self.create_or_get(extension_body, tenant_uuids)
                 return new_extension
 
-        existing_incalls_ids = {}
-        existing_extensions_ids = {}
+        existing_incalls_ids: dict[int, None] = {}
+        existing_extensions_ids: dict[int, None] = {}
         # dissociate all existing incalls / extensions
         for i in user.incalls:
             existing_incalls_ids[i.id] = None

--- a/wazo_confd/plugins/user/middleware.py
+++ b/wazo_confd/plugins/user/middleware.py
@@ -434,9 +434,9 @@ class UserMiddleWare(ResourceMiddleware):
         for e in existing_extensions_ids:
             try:
                 self._middleware_handle.get('extension').delete(e, tenant_uuids)
-            except ResourceError as e:
-                if not str(e).startswith('Resource Error - Extension is associated'):
-                    raise e
+            except ResourceError as exc:
+                if not str(exc).startswith('Resource Error - Extension is associated'):
+                    raise exc
 
     def update(self, user_id, body, tenant_uuid, tenant_uuids, recursive=False):
         user = self._service.get(user_id, tenant_uuids=tenant_uuids)

--- a/wazo_confd/plugins/user/middleware.py
+++ b/wazo_confd/plugins/user/middleware.py
@@ -515,7 +515,7 @@ class UserMiddleWare(ResourceMiddleware):
                     tenant_uuids,
                 )
 
-            if agent:
+            if agent and isinstance(agent, dict):
                 existing_agent_id = user.agentid
                 provided_agent_id = agent.get('id', None)
 

--- a/wazo_confd/plugins/user/service.py
+++ b/wazo_confd/plugins/user/service.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2026 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2013-2025 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from xivo_dao.resources.func_key import dao as func_key_dao
@@ -14,8 +14,8 @@ from .validator import build_validator, build_validator_forward
 
 
 class UserBaseService(CRUDService):
-    def get(self, resource_id, tenant_uuids=None, **kwargs):
-        return self.dao.get_by_id_uuid(resource_id, tenant_uuids)
+    def get(self, user_id, tenant_uuids=None):
+        return self.dao.get_by_id_uuid(user_id, tenant_uuids)
 
 
 class UserService(UserBaseService):
@@ -69,10 +69,10 @@ def build_service(provd_client, paginated_user_strategy_threshold):
 
 
 class UserCallServiceService(UserBaseService):
-    def edit(self, user, updated_fields=None):
+    def edit(self, user, schema):
         self.validator.validate_edit(user)
         self.dao.edit(user)
-        self.notifier.edited(user, updated_fields)
+        self.notifier.edited(user, schema)
 
 
 def build_service_callservice():
@@ -80,10 +80,10 @@ def build_service_callservice():
 
 
 class UserForwardService(UserBaseService):
-    def edit(self, user, updated_fields=None):
+    def edit(self, user, schema):
         self.validator.validate_edit(user)
         self.dao.edit(user)
-        self.notifier.edited(user, updated_fields)
+        self.notifier.edited(user, schema)
 
 
 def build_service_forward():

--- a/wazo_confd/plugins/user/service.py
+++ b/wazo_confd/plugins/user/service.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2013-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from xivo_dao.resources.func_key import dao as func_key_dao
@@ -14,7 +14,7 @@ from .validator import build_validator, build_validator_forward
 
 
 class UserBaseService(CRUDService):
-    def get(self, user_id, tenant_uuids=None):
+    def get(self, user_id, tenant_uuids=None):  # type: ignore[override]
         return self.dao.get_by_id_uuid(user_id, tenant_uuids)
 
 
@@ -69,7 +69,7 @@ def build_service(provd_client, paginated_user_strategy_threshold):
 
 
 class UserCallServiceService(UserBaseService):
-    def edit(self, user, schema):
+    def edit(self, user, schema):  # type: ignore[override]
         self.validator.validate_edit(user)
         self.dao.edit(user)
         self.notifier.edited(user, schema)
@@ -80,7 +80,7 @@ def build_service_callservice():
 
 
 class UserForwardService(UserBaseService):
-    def edit(self, user, schema):
+    def edit(self, user, schema):  # type: ignore[override]
         self.validator.validate_edit(user)
         self.dao.edit(user)
         self.notifier.edited(user, schema)

--- a/wazo_confd/plugins/user/service.py
+++ b/wazo_confd/plugins/user/service.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2013-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from xivo_dao.resources.func_key import dao as func_key_dao
@@ -14,8 +14,8 @@ from .validator import build_validator, build_validator_forward
 
 
 class UserBaseService(CRUDService):
-    def get(self, user_id, tenant_uuids=None):
-        return self.dao.get_by_id_uuid(user_id, tenant_uuids)
+    def get(self, resource_id, tenant_uuids=None, **kwargs):
+        return self.dao.get_by_id_uuid(resource_id, tenant_uuids)
 
 
 class UserService(UserBaseService):
@@ -69,10 +69,10 @@ def build_service(provd_client, paginated_user_strategy_threshold):
 
 
 class UserCallServiceService(UserBaseService):
-    def edit(self, user, schema):
+    def edit(self, user, updated_fields=None):
         self.validator.validate_edit(user)
         self.dao.edit(user)
-        self.notifier.edited(user, schema)
+        self.notifier.edited(user, updated_fields)
 
 
 def build_service_callservice():
@@ -80,10 +80,10 @@ def build_service_callservice():
 
 
 class UserForwardService(UserBaseService):
-    def edit(self, user, schema):
+    def edit(self, user, updated_fields=None):
         self.validator.validate_edit(user)
         self.dao.edit(user)
-        self.notifier.edited(user, schema)
+        self.notifier.edited(user, updated_fields)
 
 
 def build_service_forward():

--- a/wazo_confd/plugins/user_blocklist/service.py
+++ b/wazo_confd/plugins/user_blocklist/service.py
@@ -1,9 +1,8 @@
-# Copyright 2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2025-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 from __future__ import annotations
 
 import logging
-from typing import Literal
 
 from xivo_dao.alchemy.blocklist import Blocklist
 from xivo_dao.alchemy.blocklist_number import BlocklistNumber
@@ -13,17 +12,14 @@ from xivo_dao.resources.user import dao as user_dao
 
 from wazo_confd.helpers.resource import CRUDService
 
-from .notifier import UserBlocklistNotifier, build_notifier
+from .notifier import build_notifier
 from .validator import build_validator
 
 logger = logging.getLogger(__name__)
 
 
 class UserBlocklistService(CRUDService):
-    dao: Literal[dao] = dao
-    notifier: UserBlocklistNotifier
-
-    def __init__(self, dao: dao, validator, notifier, user_dao: user_dao):
+    def __init__(self, dao, validator, notifier, user_dao):
         super().__init__(dao, validator, notifier)
         self.user_dao = user_dao
 

--- a/wazo_confd/plugins/user_call_permission/validator.py
+++ b/wazo_confd/plugins/user_call_permission/validator.py
@@ -1,12 +1,12 @@
-# Copyright 2018-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from xivo_dao.helpers import errors
 
-from wazo_confd.helpers.validator import ValidationAssociation, Validator
+from wazo_confd.helpers.validator import ValidationAssociation, ValidatorAssociation
 
 
-class AssociateUserCallPermission(Validator):
+class AssociateUserCallPermission(ValidatorAssociation):
     def validate(self, user, call_permission):
         self.validate_same_tenant(user, call_permission)
 

--- a/wazo_confd/plugins/user_callerid/resource.py
+++ b/wazo_confd/plugins/user_callerid/resource.py
@@ -1,4 +1,4 @@
-# Copyright 2024 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2024-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from wazo_confd.auth import required_acl
@@ -17,7 +17,7 @@ class UserCallerIDList(ListResource):
 
     @required_acl('confd.users.{user_id}.callerids.outgoing.read')
     def get(self, user_id):
-        params = {}  # NOTE(fblackburn): search is not implemented
+        params: dict[str, str] = {}  # NOTE(fblackburn): search is not implemented
         tenant_uuids = self._build_tenant_list({'recurse': True})
         user = self.user_dao.get_by_id_uuid(user_id, tenant_uuids=tenant_uuids)
         total, items = self.service.search(user.id, user.tenant_uuid, params)

--- a/wazo_confd/plugins/user_callerid/schema.py
+++ b/wazo_confd/plugins/user_callerid/schema.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2024-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from marshmallow import fields
+from marshmallow import fields, post_dump
 
 from wazo_confd.helpers.mallow import BaseSchema
 
@@ -9,3 +9,9 @@ from wazo_confd.helpers.mallow import BaseSchema
 class UserCallerIDSchema(BaseSchema):
     number = fields.String(dump_only=True)
     type = fields.String(dump_only=True)
+
+    @post_dump
+    def omit_number_for_anonymous(self, data, **kwargs):
+        if data.get('type') == 'anonymous':
+            data.pop('number', None)
+        return data

--- a/wazo_confd/plugins/user_callerid/service.py
+++ b/wazo_confd/plugins/user_callerid/service.py
@@ -1,4 +1,4 @@
-# Copyright 2024-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2024-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from dataclasses import dataclass
@@ -11,14 +11,13 @@ from xivo_dao.resources.user import dao as user_dao
 from .types import CallerIDType
 
 
-class CallerIDAnonymous:
-    type = 'anonymous'
-
-
 @dataclass()
 class CallerID:
     type: CallerIDType
-    number: str
+    number: str = ''
+
+
+CallerIDAnonymous = CallerID(type='anonymous')
 
 
 def same_phone_number(number1: str, number2: str) -> bool:

--- a/wazo_confd/plugins/user_callerid/service.py
+++ b/wazo_confd/plugins/user_callerid/service.py
@@ -11,7 +11,7 @@ from xivo_dao.resources.user import dao as user_dao
 from .types import CallerIDType
 
 
-@dataclass()
+@dataclass(frozen=True)
 class CallerID:
     type: CallerIDType
     number: str = ''

--- a/wazo_confd/plugins/user_external_app/service.py
+++ b/wazo_confd/plugins/user_external_app/service.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2020-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from xivo_dao.helpers import errors
@@ -19,7 +19,7 @@ class UserExternalAppService(CRUDService):
         self.validator = validator
         self.notifier = notifier
 
-    def search(self, user_uuid, tenant_uuid, parameters):
+    def search(self, user_uuid, tenant_uuid, parameters):  # type: ignore[override]
         if 'fallback' == parameters.get('view'):
             # NOTE(fblackburn): pagination and sorting are disabled with fallback
             _, result_by_user = self.dao.search(user_uuid)
@@ -30,7 +30,7 @@ class UserExternalAppService(CRUDService):
 
         return self.dao.search(user_uuid, **parameters)
 
-    def get(self, user_uuid, tenant_uuid, name, view=None):
+    def get(self, user_uuid, tenant_uuid, name, view=None):  # type: ignore[override]
         result = self.dao.find(user_uuid, name)
         if result:
             return result
@@ -42,7 +42,7 @@ class UserExternalAppService(CRUDService):
 
         raise errors.not_found('UserExternalApp', name=name)
 
-    def create(self, app, tenant_uuid):
+    def create(self, app, tenant_uuid):  # type: ignore[override]
         self.validator.validate_create(app)
         created_resource = self.dao.create(app)
         self.notifier.created(created_resource, tenant_uuid)
@@ -54,7 +54,7 @@ class UserExternalAppService(CRUDService):
         self.dao.edit(app)
         self.notifier.edited(app, tenant_uuid)
 
-    def delete(self, app, tenant_uuid):
+    def delete(self, app, tenant_uuid):  # type: ignore[override]
         self.validator.validate_delete(app)
         self.dao.delete(app)
         self.notifier.deleted(app, tenant_uuid)

--- a/wazo_confd/plugins/user_external_app/service.py
+++ b/wazo_confd/plugins/user_external_app/service.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2020-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from xivo_dao.helpers import errors
@@ -6,13 +6,11 @@ from xivo_dao.helpers.db_manager import Session
 from xivo_dao.resources.external_app import dao as external_app_dao
 from xivo_dao.resources.user_external_app import dao as user_external_app_dao
 
-from wazo_confd.helpers.resource import CRUDService
-
 from .notifier import build_notifier
 from .validator import build_validator
 
 
-class UserExternalAppService(CRUDService):
+class UserExternalAppService:
     def __init__(self, dao, external_app_dao, validator, notifier):
         self.dao = dao
         self.external_app_dao = external_app_dao

--- a/wazo_confd/plugins/user_external_app/service.py
+++ b/wazo_confd/plugins/user_external_app/service.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2026 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2020-2025 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from xivo_dao.helpers import errors
@@ -6,11 +6,13 @@ from xivo_dao.helpers.db_manager import Session
 from xivo_dao.resources.external_app import dao as external_app_dao
 from xivo_dao.resources.user_external_app import dao as user_external_app_dao
 
+from wazo_confd.helpers.resource import CRUDService
+
 from .notifier import build_notifier
 from .validator import build_validator
 
 
-class UserExternalAppService:
+class UserExternalAppService(CRUDService):
     def __init__(self, dao, external_app_dao, validator, notifier):
         self.dao = dao
         self.external_app_dao = external_app_dao

--- a/wazo_confd/plugins/user_import/auth_client.py
+++ b/wazo_confd/plugins/user_import/auth_client.py
@@ -1,7 +1,8 @@
-# Copyright 2018-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
+from typing import Any
 
 from flask import g
 from requests import HTTPError
@@ -12,7 +13,7 @@ from xivo_dao.helpers.exception import ServiceError
 logger = logging.getLogger(__name__)
 
 MINUTE = 60
-auth_config = {}
+auth_config: dict[str, Any] = {}
 
 
 class AuthClientProxy:

--- a/wazo_confd/plugins/user_import/auth_client.py
+++ b/wazo_confd/plugins/user_import/auth_client.py
@@ -33,7 +33,7 @@ class AuthClientProxy:
 
     def edit_user(self, *args, **kwargs):
         # rollback system can be added here
-        self.auth_client.users.edit(*args, **kwargs)
+        self._auth_client.users.edit(*args, **kwargs)
 
     def rollback(self):
         for user in self._users_created:

--- a/wazo_confd/plugins/user_import/creators.py
+++ b/wazo_confd/plugins/user_import/creators.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import abc
@@ -27,6 +27,8 @@ from .wazo_user_schema import WazoUserSchema
 
 
 class Creator(metaclass=abc.ABCMeta):
+    schema: type | None = None
+
     def __init__(self, service):
         self.service = service
 
@@ -39,7 +41,7 @@ class Creator(metaclass=abc.ABCMeta):
         pass
 
     def update(self, fields, model):
-        if getattr(self, 'schema', False):
+        if self.schema is not None:
             fields = self.schema(handle_error=False).load(fields, partial=True)
 
         self.update_model(fields, model)

--- a/wazo_confd/plugins/user_import/csvparse.py
+++ b/wazo_confd/plugins/user_import/csvparse.py
@@ -1,9 +1,10 @@
-# Copyright 2015-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import csv
 import time
 from collections import namedtuple
+from typing import Any
 
 from flask import request
 from xivo_dao.helpers import errors
@@ -183,7 +184,7 @@ class CsvRow:
         }
 
     def parse_rules(self, rules):
-        entry = {}
+        entry: dict[str, Any] = {}
         for rule in rules:
             rule.insert(self.fields, entry)
         return entry

--- a/wazo_confd/plugins/user_import/csvparse.py
+++ b/wazo_confd/plugins/user_import/csvparse.py
@@ -37,7 +37,7 @@ class Rule:
         self.name = name
 
     def parse(self, value):
-        raise NotImplementedError
+        raise NotImplementedError()
 
     def insert(self, fields, entry):
         if self.csv_name in fields:

--- a/wazo_confd/plugins/user_import/csvparse.py
+++ b/wazo_confd/plugins/user_import/csvparse.py
@@ -36,6 +36,9 @@ class Rule:
         self.csv_name = csv_name
         self.name = name
 
+    def parse(self, value):
+        raise NotImplementedError
+
     def insert(self, fields, entry):
         if self.csv_name in fields:
             value = fields.get(self.csv_name, "")

--- a/wazo_confd/plugins/user_import/entry.py
+++ b/wazo_confd/plugins/user_import/entry.py
@@ -1,9 +1,9 @@
-# Copyright 2015-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, TypedDict
+from typing import TYPE_CHECKING, Any, TypedDict
 
 from xivo_dao.helpers import errors
 
@@ -19,7 +19,7 @@ class UserDict(TypedDict):
     firstname: str
     lastname: str
     username: str
-    emails: list[str]
+    emails: list[dict[str, Any]]
 
 
 class Entry:

--- a/wazo_confd/plugins/user_import/entry.py
+++ b/wazo_confd/plugins/user_import/entry.py
@@ -37,7 +37,7 @@ class Entry:
         self.extension = None
         self.extension_incall = None
         self.incall = None
-        self.call_permissions = []
+        self.call_permissions: list[Any] = []
 
     def extract_ids(self):
         if self.sip:

--- a/wazo_confd/plugins/user_import/tests/test_wazo_user_service.py
+++ b/wazo_confd/plugins/user_import/tests/test_wazo_user_service.py
@@ -1,7 +1,8 @@
-# Copyright 2019-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import unittest
+from typing import Any
 from unittest.mock import Mock
 from unittest.mock import sentinel as s
 
@@ -26,7 +27,7 @@ class TestWazoUserService(unittest.TestCase):
         )
 
     def test_that_a_missing_tenant_uuid_does_not_raise(self):
-        user = {}
+        user: dict[str, Any] = {}
 
         self.service.create(user)
 

--- a/wazo_confd/plugins/user_voicemail/validator.py
+++ b/wazo_confd/plugins/user_voicemail/validator.py
@@ -1,12 +1,12 @@
-# Copyright 2013-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2013-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from xivo_dao.helpers import errors
 
-from wazo_confd.helpers.validator import ValidationAssociation, Validator
+from wazo_confd.helpers.validator import ValidationAssociation, ValidatorAssociation
 
 
-class UserHasNoVoicemail(Validator):
+class UserHasNoVoicemail(ValidatorAssociation):
     def validate(self, user, voicemail):
         self.validate_same_tenant(user, voicemail)
         self.validate_user_has_no_voicemail(user, voicemail)
@@ -25,7 +25,7 @@ class UserHasNoVoicemail(Validator):
             )
 
 
-class VoicemailIsNotGlobal(Validator):
+class VoicemailIsNotGlobal(ValidatorAssociation):
     def validate(self, user, voicemail):
         if voicemail and voicemail.accesstype == 'global':
             raise errors.not_permitted(

--- a/wazo_confd/plugins/voicemail/service.py
+++ b/wazo_confd/plugins/voicemail/service.py
@@ -1,17 +1,17 @@
-# Copyright 2016-2020 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from xivo_dao.helpers.db_manager import Session
 from xivo_dao.resources.voicemail import dao as voicemail_dao
 
 from wazo_confd import sysconfd
-from wazo_confd.helpers.resource import CRUDService
+from wazo_confd.helpers.resource import ReadService
 
 from .notifier import build_notifier
 from .validator import build_validator
 
 
-class VoicemailService(CRUDService):
+class VoicemailService(ReadService):
     def __init__(self, dao, validator, notifier, sysconf, extra=None):
         super().__init__(dao, validator, notifier, extra)
         self.sysconf = sysconf

--- a/wazo_confd/plugins/voicemail/service.py
+++ b/wazo_confd/plugins/voicemail/service.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2020 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from xivo_dao.helpers.db_manager import Session
@@ -16,13 +16,13 @@ class VoicemailService(CRUDService):
         super().__init__(dao, validator, notifier, extra)
         self.sysconf = sysconf
 
-    def create(self, resource, tenant_uuids):
+    def create(self, resource, tenant_uuids):  # type: ignore[override]
         self.validator.validate_create(resource, tenant_uuids=tenant_uuids)
         created_resource = self.dao.create(resource)
         self.notifier.created(created_resource)
         return created_resource
 
-    def edit(self, voicemail, tenant_uuids, updated_fields=None):
+    def edit(self, voicemail, tenant_uuids, updated_fields=None):  # type: ignore[override]
         old_number, old_context = voicemail.get_old_number_context()
         with Session.no_autoflush:
             self.validator.validate_edit(voicemail, tenant_uuids=tenant_uuids)

--- a/wazo_confd/plugins/voicemail/service.py
+++ b/wazo_confd/plugins/voicemail/service.py
@@ -1,17 +1,17 @@
-# Copyright 2016-2026 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from xivo_dao.helpers.db_manager import Session
 from xivo_dao.resources.voicemail import dao as voicemail_dao
 
 from wazo_confd import sysconfd
-from wazo_confd.helpers.resource import ReadService
+from wazo_confd.helpers.resource import CRUDService
 
 from .notifier import build_notifier
 from .validator import build_validator
 
 
-class VoicemailService(ReadService):
+class VoicemailService(CRUDService):
     def __init__(self, dao, validator, notifier, sysconf, extra=None):
         super().__init__(dao, validator, notifier, extra)
         self.sysconf = sysconf

--- a/wazo_confd/representations/tests/test_csv.py
+++ b/wazo_confd/representations/tests/test_csv.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from unittest import TestCase
@@ -8,7 +8,7 @@ from hamcrest import assert_that, equal_to, has_entry
 from ..csv_ import output_csv
 
 SOME_STATUS_CODE = 200
-SOME_INPUT = {'headers': [], 'content': []}
+SOME_INPUT: dict[str, list] = {'headers': [], 'content': []}
 
 
 class TestCSVRepresentation(TestCase):

--- a/wazo_confd/tests/test_sysconfd.py
+++ b/wazo_confd/tests/test_sysconfd.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2013-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from unittest import TestCase
@@ -157,7 +157,7 @@ class TestSysconfdClient(TestCase):
     def test_exec_request_handlers_live_reload_disabled(self):
         self.dao.is_live_reload_enabled.return_value = False
 
-        commands = {'ipbx': []}
+        commands: dict[str, list[str]] = {'ipbx': []}
 
         self.client.exec_request_handlers(commands)
         self.client.flush()


### PR DESCRIPTION


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly type-hinting and mypy-prep refactors, but it also changes a few runtime behaviors (e.g., `UserCallerIDSchema` omits numbers for anonymous, sound path fragment filtering, and DHCP/ auth client exception wiring), so there’s some risk of subtle API/output differences.
> 
> **Overview**
> Adds mypy to pre-commit and introduces a baseline `[tool.mypy]` configuration in `pyproject.toml`.
> 
> Across the codebase, updates many resources/schemas/services to be mypy-friendly: adds/adjusts type annotations, loosens `ListResource.get/post` signatures, aligns Marshmallow `_deserialize` signatures and marks overrides, and fixes CRUDService subclass signature mismatches with targeted `type: ignore`.
> 
> Also includes a few functional tweaks discovered during typing work: fixes `AuthClientProxy.edit_user` to call `self._auth_client`, makes `InvalidInterfaces` initialize `HTTPException` safely with `None`, prevents leaking caller ID numbers for `anonymous` via `UserCallerIDSchema`, and hardens path building in sound storage by filtering fragments before validation/joining.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f2c184b68c5090f0752797f9fd4924b0122db1ba. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->