### PR TITLE
[BUG-32] [WP-1719] Expose caller ID name in outgoing caller ids 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 26.05
+
+* The `/1.1/users/{uuid}/callerids/outgoing` now has a `caller_id_name` field for `main`, `associated`, and `shared` caller ID types.
+
 ## 26.03
 
 * `GET /1.1/users` using the summary view now has a read-only `is_webrtc` field for each user. The value is based on the main line of the user.

--- a/integration_tests/suite/base/test_user_callerid.py
+++ b/integration_tests/suite/base/test_user_callerid.py
@@ -29,7 +29,7 @@ def test_list_with_associated_type(extension, incall, user):
         response = confd.users(user['uuid']).callerids.outgoing.get()
 
     expected = [
-        {'type': 'associated', 'number': '5555556789'},
+        {'type': 'associated', 'number': '5555556789', 'caller_id_name': ''},
         {'type': 'anonymous'},
     ]
     assert_that(response.items, contains_inanyorder(*expected))
@@ -46,7 +46,7 @@ def test_list_with_main_type(phone_number, extension, incall, user):
 
     # The first created is the main and other are ignored
     expected = [
-        {'type': 'main', 'number': '5555551234'},
+        {'type': 'main', 'number': '5555551234', 'caller_id_name': ''},
         {'type': 'anonymous'},
     ]
     assert_that(response.items, contains_inanyorder(*expected))
@@ -60,16 +60,16 @@ def test_list_with_shared(phone_number, user):
 
     # The first created is the main and other are ignored
     expected = [
-        {'type': 'shared', 'number': '5555551234'},
+        {'type': 'shared', 'number': '5555551234', 'caller_id_name': ''},
         {'type': 'anonymous'},
     ]
     assert_that(response.items, contains_inanyorder(*expected))
     assert_that(response.total, equal_to(2))
 
 
-@fixtures.phone_number(main=True, number='5555551234')
+@fixtures.phone_number(main=True, number='5555551234', caller_id_name='Acme Corp')
 @fixtures.phone_number(shared=True, number='5555551235')
-@fixtures.phone_number(shared=True, number='5555551236')
+@fixtures.phone_number(shared=True, number='5555551236', caller_id_name='Support Line')
 @fixtures.extension(exten='5555551235', context=INCALL_CONTEXT)
 @fixtures.incall()
 @fixtures.user()
@@ -83,9 +83,9 @@ def test_list_with_all_type(
         response = confd.users(user['uuid']).callerids.outgoing.get()
 
     expected = [
-        {'type': 'main', 'number': '5555551234'},
-        {'type': 'associated', 'number': '5555551235'},
-        {'type': 'shared', 'number': '5555551236'},
+        {'type': 'main', 'number': '5555551234', 'caller_id_name': 'Acme Corp'},
+        {'type': 'associated', 'number': '5555551235', 'caller_id_name': ''},
+        {'type': 'shared', 'number': '5555551236', 'caller_id_name': 'Support Line'},
         {'type': 'anonymous'},
     ]
     assert_that(response.items, contains_inanyorder(*expected))

--- a/wazo_confd/plugins/user_callerid/api.yml
+++ b/wazo_confd/plugins/user_callerid/api.yml
@@ -22,6 +22,9 @@ definitions:
       number:
         type: string
         description: Caller ID number. Only valid for `main` `associated` and `shared` types
+      caller_id_name:
+        type: string
+        description: Caller ID name. Only valid for `main` and `shared` types
       type:
         type: string
         description: |

--- a/wazo_confd/plugins/user_callerid/api.yml
+++ b/wazo_confd/plugins/user_callerid/api.yml
@@ -21,7 +21,7 @@ definitions:
     properties:
       number:
         type: string
-        description: Caller ID number. Only valid for `main` `associated` type
+        description: Caller ID number. Only valid for `main` `associated` and `shared` types
       type:
         type: string
         description: |

--- a/wazo_confd/plugins/user_callerid/schema.py
+++ b/wazo_confd/plugins/user_callerid/schema.py
@@ -9,9 +9,11 @@ from wazo_confd.helpers.mallow import BaseSchema
 class UserCallerIDSchema(BaseSchema):
     number = fields.String(dump_only=True)
     type = fields.String(dump_only=True)
+    caller_id_name = fields.String(dump_only=True)
 
     @post_dump
-    def omit_number_for_anonymous(self, data, **kwargs):
+    def omit_fields_for_anonymous(self, data, **kwargs):
         if data.get('type') == 'anonymous':
             data.pop('number', None)
+            data.pop('caller_id_name', None)
         return data

--- a/wazo_confd/plugins/user_callerid/service.py
+++ b/wazo_confd/plugins/user_callerid/service.py
@@ -15,6 +15,7 @@ from .types import CallerIDType
 class CallerID:
     type: CallerIDType
     number: str = ''
+    caller_id_name: str = ''
 
 
 CallerIDAnonymous = CallerID(type='anonymous')
@@ -42,12 +43,18 @@ class UserCallerIDService:
         if main_callerid := self.phone_number_dao.find_by(
             main=True, tenant_uuids=[tenant_uuid]
         ):
-            callerids.append(CallerID(type='main', number=main_callerid.number))
+            callerids.append(
+                CallerID(
+                    type='main',
+                    number=main_callerid.number,
+                    caller_id_name=main_callerid.caller_id_name or '',
+                )
+            )
 
         # consider "associated" caller ids from incalls
         # as having precedence over shared phone numbers
         callerids.extend(
-            callerid
+            CallerID(type='associated', number=callerid.number)
             for callerid in self.user_dao.list_outgoing_callerid_associated(user_id)
             if not any(same_phone_number(callerid.number, c.number) for c in callerids)
         )
@@ -55,7 +62,11 @@ class UserCallerIDService:
             shared=True, main=False, tenant_uuids=[tenant_uuid]
         )
         callerids.extend(
-            CallerID(type='shared', number=callerid.number)
+            CallerID(
+                type='shared',
+                number=callerid.number,
+                caller_id_name=callerid.caller_id_name or '',
+            )
             for callerid in shared_callerids
             if not any(same_phone_number(callerid.number, c.number) for c in callerids)
         )

--- a/wazo_confd/plugins/user_callerid/tests/test_service.py
+++ b/wazo_confd/plugins/user_callerid/tests/test_service.py
@@ -1,6 +1,8 @@
 import unittest
+from types import SimpleNamespace
+from unittest.mock import Mock
 
-from ..service import same_phone_number
+from ..service import UserCallerIDService, same_phone_number
 
 
 class TestSamePhoneNumber(unittest.TestCase):
@@ -23,3 +25,62 @@ class TestSamePhoneNumber(unittest.TestCase):
         number1 = '+11234567890'
         number2 = '21234567890'
         self.assertFalse(same_phone_number(number1, number2), (number1, number2))
+
+
+class TestUserCallerIDService(unittest.TestCase):
+    def setUp(self):
+        self.user_dao = Mock()
+        self.incall_dao = Mock()
+        self.phone_number_dao = Mock()
+        self.service = UserCallerIDService(
+            self.user_dao, self.incall_dao, self.phone_number_dao
+        )
+        self.user_dao.list_outgoing_callerid_associated.return_value = []
+        self.phone_number_dao.find_by.return_value = None
+        self.phone_number_dao.find_all_by.return_value = []
+
+    def test_main_callerid_has_caller_id_name(self):
+        self.phone_number_dao.find_by.return_value = SimpleNamespace(
+            number='5551234', caller_id_name='Acme Corp'
+        )
+
+        total, callerids = self.service.search(1, 'tenant-uuid', {})
+
+        main = [c for c in callerids if c.type == 'main'][0]
+        self.assertEqual(main.caller_id_name, 'Acme Corp')
+
+    def test_main_callerid_without_caller_id_name(self):
+        self.phone_number_dao.find_by.return_value = SimpleNamespace(
+            number='5551234', caller_id_name=None
+        )
+
+        total, callerids = self.service.search(1, 'tenant-uuid', {})
+
+        main = [c for c in callerids if c.type == 'main'][0]
+        self.assertEqual(main.caller_id_name, '')
+
+    def test_shared_callerid_has_caller_id_name(self):
+        self.phone_number_dao.find_all_by.return_value = [
+            SimpleNamespace(number='5559876', caller_id_name='Support Line')
+        ]
+
+        total, callerids = self.service.search(1, 'tenant-uuid', {})
+
+        shared = [c for c in callerids if c.type == 'shared'][0]
+        self.assertEqual(shared.caller_id_name, 'Support Line')
+
+    def test_anonymous_callerid_has_empty_caller_id_name(self):
+        total, callerids = self.service.search(1, 'tenant-uuid', {})
+
+        anon = [c for c in callerids if c.type == 'anonymous'][0]
+        self.assertEqual(anon.caller_id_name, '')
+
+    def test_associated_callerid_has_empty_caller_id_name(self):
+        self.user_dao.list_outgoing_callerid_associated.return_value = [
+            SimpleNamespace(type='associated', number='5555678')
+        ]
+
+        total, callerids = self.service.search(1, 'tenant-uuid', {})
+
+        associated = [c for c in callerids if c.type == 'associated'][0]
+        self.assertEqual(associated.caller_id_name, '')

--- a/wazo_confd/plugins/user_callerid/tests/test_service.py
+++ b/wazo_confd/plugins/user_callerid/tests/test_service.py
@@ -44,7 +44,7 @@ class TestUserCallerIDService(unittest.TestCase):
             number='5551234', caller_id_name='Acme Corp'
         )
 
-        total, callerids = self.service.search(1, 'tenant-uuid', {})
+        _, callerids = self.service.search(1, 'tenant-uuid', {})
 
         main = [c for c in callerids if c.type == 'main'][0]
         self.assertEqual(main.caller_id_name, 'Acme Corp')
@@ -54,7 +54,7 @@ class TestUserCallerIDService(unittest.TestCase):
             number='5551234', caller_id_name=None
         )
 
-        total, callerids = self.service.search(1, 'tenant-uuid', {})
+        _, callerids = self.service.search(1, 'tenant-uuid', {})
 
         main = [c for c in callerids if c.type == 'main'][0]
         self.assertEqual(main.caller_id_name, '')
@@ -64,13 +64,13 @@ class TestUserCallerIDService(unittest.TestCase):
             SimpleNamespace(number='5559876', caller_id_name='Support Line')
         ]
 
-        total, callerids = self.service.search(1, 'tenant-uuid', {})
+        _, callerids = self.service.search(1, 'tenant-uuid', {})
 
         shared = [c for c in callerids if c.type == 'shared'][0]
         self.assertEqual(shared.caller_id_name, 'Support Line')
 
     def test_anonymous_callerid_has_empty_caller_id_name(self):
-        total, callerids = self.service.search(1, 'tenant-uuid', {})
+        _, callerids = self.service.search(1, 'tenant-uuid', {})
 
         anon = [c for c in callerids if c.type == 'anonymous'][0]
         self.assertEqual(anon.caller_id_name, '')
@@ -80,7 +80,7 @@ class TestUserCallerIDService(unittest.TestCase):
             SimpleNamespace(type='associated', number='5555678')
         ]
 
-        total, callerids = self.service.search(1, 'tenant-uuid', {})
+        _, callerids = self.service.search(1, 'tenant-uuid', {})
 
         associated = [c for c in callerids if c.type == 'associated'][0]
         self.assertEqual(associated.caller_id_name, '')


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk additive API change: extends `GET /1.1/users/{uuid}/callerids/outgoing` responses with a new read-only `caller_id_name` field and updates tests/docs accordingly.
> 
> **Overview**
> Adds a read-only `caller_id_name` to `GET /1.1/users/{uuid}/callerids/outgoing` items, populating it for `main` and `shared` caller IDs from the underlying phone-number record (defaulting to an empty string when unset).
> 
> Updates the OpenAPI schema, marshmallow serialization (omitting the new field for `anonymous` entries), changelog, and integration/unit tests to validate the new response shape.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0a1a3064327244ac151618a1b56c97639368445d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->