### PR TITLE
[ITEM-245] trigger res_pjsip reload after deleting trunk

### DIFF
--- a/integration_tests/suite/base/test_configuration.py
+++ b/integration_tests/suite/base/test_configuration.py
@@ -39,6 +39,9 @@ def test_live_reload_false():
     response = confd.configuration.live_reload.get()
     assert_that(response.item, expected)
 
+    # Reset to True so tests using sysconfd are not noop
+    confd.configuration.live_reload.put({'enabled': True})
+
 
 def test_restrict_only_master_tenant():
     response = confd.configuration.live_reload.get(token=TOKEN_SUB_TENANT)

--- a/integration_tests/suite/base/test_event_handlers.py
+++ b/integration_tests/suite/base/test_event_handlers.py
@@ -68,7 +68,7 @@ def test_delete_tenant_reloads_pjsip_for_trunks(trunk, sip):
             response = confd.trunks(trunk['id']).get(wazo_tenant=DELETED_TENANT)
             response.assert_status(404)
 
-        until.assert_(pjsip_reloaded_and_trunk_deleted, tries=5, interval=5)
+        until.assert_(pjsip_reloaded_and_trunk_deleted, tries=5)
 
 
 @pytest.mark.skip(reason="Too flaky because of WAZO-2752")

--- a/integration_tests/suite/base/test_event_handlers.py
+++ b/integration_tests/suite/base/test_event_handlers.py
@@ -53,22 +53,17 @@ def test_create_default_templates_when_not_exist():
 @fixtures.trunk(wazo_tenant=DELETED_TENANT)
 @fixtures.sip(wazo_tenant=DELETED_TENANT)
 def test_delete_tenant_reloads_pjsip_for_trunks(trunk, sip):
+    sysconfd.clear()
     with associations.trunk_endpoint_sip(trunk, sip, check=False):
-        sysconfd.clear()
-
         with BaseIntegrationTest.delete_auth_tenant(DELETED_TENANT):
             BusClient.send_tenant_deleted(DELETED_TENANT, 'slug3')
 
         def pjsip_reloaded_and_trunk_deleted():
-            results = sysconfd.requests_matching(
-                '/exec_request_handlers', method='POST'
+            sysconfd.assert_request(
+                '/exec_request_handlers',
+                method='POST',
+                json={'ipbx': ['module reload res_pjsip.so']},
             )
-            ipbx_commands = []
-            for result in results:
-                ipbx_commands.extend(result.get('json', {}).get('ipbx', []))
-            assert (
-                'module reload res_pjsip.so' in ipbx_commands
-            ), f'Expected pjsip reload in sysconfd requests, got: {ipbx_commands}'
 
             response = confd.trunks(trunk['id']).get(wazo_tenant=DELETED_TENANT)
             response.assert_status(404)

--- a/integration_tests/suite/base/test_event_handlers.py
+++ b/integration_tests/suite/base/test_event_handlers.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2020-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import pytest
@@ -18,7 +18,7 @@ from wazo_test_helpers import until
 from ..helpers import associations, fixtures
 from ..helpers.bus import BusClient
 from ..helpers.config import CREATED_TENANT, DELETED_TENANT
-from . import BaseIntegrationTest, confd, provd
+from . import BaseIntegrationTest, confd, provd, sysconfd
 
 
 def test_create_default_templates_when_not_exist():
@@ -48,6 +48,32 @@ def test_create_default_templates_when_not_exist():
 
     until.assert_(templates_created, tries=5)
     until.assert_(slug_created, tries=5)
+
+
+@fixtures.trunk(wazo_tenant=DELETED_TENANT)
+@fixtures.sip(wazo_tenant=DELETED_TENANT)
+def test_delete_tenant_reloads_pjsip_for_trunks(trunk, sip):
+    with associations.trunk_endpoint_sip(trunk, sip, check=False):
+        sysconfd.clear()
+
+        with BaseIntegrationTest.delete_auth_tenant(DELETED_TENANT):
+            BusClient.send_tenant_deleted(DELETED_TENANT, 'slug3')
+
+        def pjsip_reloaded_and_trunk_deleted():
+            results = sysconfd.requests_matching(
+                '/exec_request_handlers', method='POST'
+            )
+            ipbx_commands = []
+            for result in results:
+                ipbx_commands.extend(result.get('json', {}).get('ipbx', []))
+            assert (
+                'module reload res_pjsip.so' in ipbx_commands
+            ), f'Expected pjsip reload in sysconfd requests, got: {ipbx_commands}'
+
+            response = confd.trunks(trunk['id']).get(wazo_tenant=DELETED_TENANT)
+            response.assert_status(404)
+
+        until.assert_(pjsip_reloaded_and_trunk_deleted, tries=5, interval=5)
 
 
 @pytest.mark.skip(reason="Too flaky because of WAZO-2752")

--- a/wazo_confd/sync_db.py
+++ b/wazo_confd/sync_db.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2020-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import argparse
@@ -18,6 +18,7 @@ from xivo_dao.resources.moh import dao as moh_dao
 from xivo_dao.resources.pjsip_transport import dao as transport_dao
 from xivo_dao.resources.queue import dao as queue_dao
 from xivo_dao.resources.tenant import dao as tenant_resources_dao
+from xivo_dao.resources.trunk import dao as trunk_dao
 
 from wazo_confd._sysconfd import SysconfdPublisher
 from wazo_confd.config import DEFAULT_CONFIG, _load_key_file
@@ -139,6 +140,15 @@ def remove_tenant(tenant_uuid, sysconfd):
         groups_list = group_dao.search(tenant_uuids=[tenant_uuid])
         for group in groups_list.items:
             group_dao.delete(group)
+
+        logger.debug('Deleting all trunks for tenant: %s', tenant_uuid)
+        trunks_list = trunk_dao.search(tenant_uuids=[tenant_uuid])
+        for trunk in trunks_list.items:
+            if trunk.endpoint_sip_uuid:
+                sysconfd.exec_request_handlers({'ipbx': ['module reload res_pjsip.so']})
+            if trunk.endpoint_iax_id:
+                sysconfd.exec_request_handlers({'ipbx': ['iax2 reload']})
+            trunk_dao.delete(trunk)
 
         tenant = tenant_resources_dao.get(tenant_uuid)
         tenant_resources_dao.delete(tenant)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds PBX reload side-effects to tenant-removal cleanup and asserts the behavior in integration tests, which could impact production reload frequency/timing during bulk deletions. Logic is straightforward but touches teardown of tenant resources and sysconfd handler execution.
> 
> **Overview**
> When a tenant is removed via `wazo_confd/sync_db.py`, trunk cleanup is now included: all trunks for the tenant are deleted and `sysconfd` reload handlers are queued (`module reload res_pjsip.so` for SIP trunks, `iax2 reload` for IAX trunks).
> 
> Integration tests add coverage ensuring tenant deletion triggers a PJSIP reload when a SIP trunk exists, and `test_live_reload_false` now resets live reload to `True` to avoid making `sysconfd` assertions a no-op.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6fb5156aff9117464e24e9904dc815d28d8953f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->