### PR TITLE
docker: pin rabbitmq to version 3

### DIFF
--- a/integration_tests/assets/docker-compose.yml
+++ b/integration_tests/assets/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       - "5432"
 
   rabbitmq:
-    image: rabbitmq
+    image: rabbitmq:3
     ports:
       - "5672"
     volumes:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: only changes the Docker image tag used by integration tests, with no application code impact; potential risk is minor test behavior differences if the previously-latest image was newer/older.
> 
> **Overview**
> Updates `integration_tests/assets/docker-compose.yml` to pin the `rabbitmq` service from `rabbitmq` (latest) to `rabbitmq:3`, making integration test runs more reproducible across environments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 42b9b9d41e8d5233b61026b0f4cb6a7c5dec1f26. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->