### PR TITLE
feat(mobile-gsm-fallback): add mobile_fallback_enabled user config option

### DIFF
--- a/integration_tests/suite/base/test_users.py
+++ b/integration_tests/suite/base/test_users.py
@@ -46,6 +46,7 @@ FULL_USER = {
     "username": "jsmeth",
     "email": "jsmeth@smeth.com",
     "mobile_phone_number": "+4185551234*2",
+    "mobile_fallback_enabled": True,
     "userfield": "userfield",
     "caller_id": '"Jôhnny Smith" <4185551234>',
     "outgoing_caller_id": '"Johnny" <123>',
@@ -76,6 +77,7 @@ NULL_USER = {
     "username": None,
     "email": None,
     "mobile_phone_number": None,
+    "mobile_fallback_enabled": False,
     "userfield": None,
     "outgoing_caller_id": None,
     "music_on_hold": None,
@@ -171,6 +173,10 @@ def error_checks(url):
     s.check_bogus_field_returns_error(url, 'mobile_phone_number', s.random_string(81))
     s.check_bogus_field_returns_error(url, 'mobile_phone_number', {})
     s.check_bogus_field_returns_error(url, 'mobile_phone_number', [])
+    s.check_bogus_field_returns_error(url, 'mobile_fallback_enabled', 'yeah')
+    s.check_bogus_field_returns_error(url, 'mobile_fallback_enabled', 123)
+    s.check_bogus_field_returns_error(url, 'mobile_fallback_enabled', {})
+    s.check_bogus_field_returns_error(url, 'mobile_fallback_enabled', [])
     s.check_bogus_field_returns_error(url, 'username', 123)
     s.check_bogus_field_returns_error(url, 'username', 'invalid_régex')
     s.check_bogus_field_returns_error(url, 'username', s.random_string(1))
@@ -294,6 +300,7 @@ def put_error_checks(url):
     )
     s.check_bogus_field_returns_error(url, 'online_call_record_enabled', None)
     s.check_bogus_field_returns_error(url, 'supervision_enabled', None)
+    s.check_bogus_field_returns_error(url, 'mobile_fallback_enabled', None)
     s.check_bogus_field_returns_error(url, 'ring_seconds', None)
     s.check_bogus_field_returns_error(url, 'simultaneous_calls', None)
     s.check_bogus_field_returns_error(url, 'ring_seconds', None)

--- a/wazo_confd/plugins/user/api.yml
+++ b/wazo_confd/plugins/user/api.yml
@@ -404,6 +404,10 @@ definitions:
         mobile_phone_number:
           type: string
           description: Phone number for the user’s mobile device
+        mobile_fallback_enabled:
+          type: boolean
+          default: false
+          description: Enable PSTN fallback when push notification is not answered in time
         username:
           type: string
           description: Username for connecting to the CTI (deprecated)
@@ -692,6 +696,10 @@ definitions:
       mobile_phone_number:
         type: string
         description: Phone number for the user’s mobile device
+      mobile_fallback_enabled:
+        type: boolean
+        default: false
+        description: Enable PSTN fallback when push notification is not answered in time
       username:
         type: string
         description: Username for connecting to the CTI (deprecated)

--- a/wazo_confd/plugins/user/schema.py
+++ b/wazo_confd/plugins/user/schema.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from marshmallow import (
@@ -55,6 +55,7 @@ class UserSchema(BaseSchema):
     mobile_phone_number = fields.String(
         validate=(Regexp(MOBILE_PHONE_NUMBER_REGEX), Length(max=80)), allow_none=True
     )
+    mobile_fallback_enabled = StrictBoolean()
     username = fields.String(validate=Regexp(USERNAME_REGEX), allow_none=True)
     password = fields.String(validate=Regexp(PASSWORD_REGEX), allow_none=True)
     music_on_hold = fields.String(validate=Length(max=128), allow_none=True)

--- a/wazo_confd/plugins/user/tests/test_schema.py
+++ b/wazo_confd/plugins/user/tests/test_schema.py
@@ -1,12 +1,19 @@
-# Copyright 2019-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import unittest
 from unittest.mock import Mock
 
 from hamcrest import assert_that, equal_to
+from marshmallow import ValidationError
+
+from wazo_confd.helpers.mallow import BaseSchema, StrictBoolean
 
 from ..schema import UserSchema
+
+
+class _MobileFallbackSchema(BaseSchema):
+    mobile_fallback_enabled = StrictBoolean()
 
 
 class TestSchema(unittest.TestCase):
@@ -21,3 +28,26 @@ class TestSchema(unittest.TestCase):
         ]
         result = list(UserSchema._flatten(data_to_flatten))
         assert_that(result, equal_to([user_1, user_2, user_3, user_4, user_5]))
+
+
+class TestMobileFallbackEnabledField(unittest.TestCase):
+    def setUp(self):
+        self.schema = _MobileFallbackSchema(handle_error=False)
+
+    def test_load_true(self):
+        result = self.schema.load({'mobile_fallback_enabled': True})
+        assert_that(result['mobile_fallback_enabled'], equal_to(True))
+
+    def test_load_false(self):
+        result = self.schema.load({'mobile_fallback_enabled': False})
+        assert_that(result['mobile_fallback_enabled'], equal_to(False))
+
+    def test_load_string_rejects(self):
+        self.assertRaises(
+            ValidationError, self.schema.load, {'mobile_fallback_enabled': 'true'}
+        )
+
+    def test_load_integer_rejects(self):
+        self.assertRaises(
+            ValidationError, self.schema.load, {'mobile_fallback_enabled': 1}
+        )

--- a/wazo_confd/plugins/user/tests/test_validator.py
+++ b/wazo_confd/plugins/user/tests/test_validator.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2013-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import unittest
@@ -30,6 +30,17 @@ class TestNoEmptyFieldWhenEnabled(unittest.TestCase):
     def setUp(self):
         self.validator = NoEmptyFieldWhenEnabled('destination_field', 'enabled_field')
         self.model = Mock()
+
+    def test_custom_error_func_is_called_when_provided(self):
+        custom_error_func = Mock(return_value=ResourceError('custom message'))
+        validator = NoEmptyFieldWhenEnabled(
+            'destination_field', 'enabled_field', error_func=custom_error_func
+        )
+        self.model.destination_field = None
+        self.model.enabled_field = True
+
+        self.assertRaises(ResourceError, validator.validate, self.model)
+        custom_error_func.assert_called_once()
 
     def test_given_required_field_are_none_and_enabled_true_when_validating_then_raises_error(
         self,

--- a/wazo_confd/plugins/user/validator.py
+++ b/wazo_confd/plugins/user/validator.py
@@ -24,14 +24,15 @@ class NoVoicemailAssociated(Validator):
 
 
 class NoEmptyFieldWhenEnabled(Validator):
-    def __init__(self, field, enabled):
+    def __init__(self, field, enabled, error_func=None):
         self.field = field
         self.enabled = enabled
+        self._error_func = error_func or errors.forward_destination_null
 
     def validate(self, model):
         if getattr(model, self.enabled):
             if getattr(model, self.field) is None:
-                raise errors.forward_destination_null()
+                raise self._error_func()
 
 
 class NonGlobalVoicemailAssigned(Validator):
@@ -45,7 +46,9 @@ class NonGlobalVoicemailAssigned(Validator):
 def build_validator():
     moh_validator = MOHExists('music_on_hold', moh_dao.get_by)
     pstn_fallback_validator = NoEmptyFieldWhenEnabled(
-        'mobile_phone_number', 'mobile_fallback_enabled'
+        'mobile_phone_number',
+        'mobile_fallback_enabled',
+        error_func=errors.mobile_fallback_number_null,
     )
     return ValidationGroup(
         delete=[NoVoicemailAssociated()],

--- a/wazo_confd/plugins/user/validator.py
+++ b/wazo_confd/plugins/user/validator.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2013-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from xivo_dao.helpers import errors
@@ -44,6 +44,9 @@ class NonGlobalVoicemailAssigned(Validator):
 
 def build_validator():
     moh_validator = MOHExists('music_on_hold', moh_dao.get_by)
+    pstn_fallback_validator = NoEmptyFieldWhenEnabled(
+        'mobile_phone_number', 'mobile_fallback_enabled'
+    )
     return ValidationGroup(
         delete=[NoVoicemailAssociated()],
         create=[
@@ -63,6 +66,7 @@ def build_validator():
             ),
             moh_validator,
             NonGlobalVoicemailAssigned(),
+            Optional('mobile_fallback_enabled', pstn_fallback_validator),
         ],
         edit=[
             Optional('email', UniqueFieldChanged('email', user_dao.find_by, 'User')),
@@ -71,6 +75,7 @@ def build_validator():
             ),
             moh_validator,
             NonGlobalVoicemailAssigned(),
+            Optional('mobile_fallback_enabled', pstn_fallback_validator),
         ],
     )
 


### PR DESCRIPTION
Depends-On: https://github.com/wazo-platform/xivo-dao/pull/344

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Introduces a new user-setting flag and new validation path that can reject create/update requests when enabled without a mobile number, potentially impacting existing API clients and provisioning flows.
> 
> **Overview**
> Adds a new user configuration flag, `mobile_fallback_enabled`, exposed in the user OpenAPI spec and enforced in the user Marshmallow schema as a strict boolean.
> 
> Updates user validation to require `mobile_phone_number` when `mobile_fallback_enabled` is true, by extending `NoEmptyFieldWhenEnabled` to accept a custom error generator and wiring a dedicated validator into user create/edit.
> 
> Extends integration and unit tests to cover the new field’s serialization/validation behavior and to ensure invalid types (including `None` on PUT) are rejected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9599ec21064c67fef976b21410791d63eaefcfab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->