### PR TITLE
[ITEM-307] do not reset device to autoprov when deleting line from user

### DIFF
--- a/integration_tests/suite/base/test_users.py
+++ b/integration_tests/suite/base/test_users.py
@@ -36,6 +36,7 @@ from ..helpers.config import (
     OUTCALL_CONTEXT,
     SUB_TENANT,
 )
+from ..helpers.helpers.line_fellowship import line_fellowship
 from . import BaseIntegrationTest
 from . import auth as authentication
 from . import confd, provd
@@ -1688,6 +1689,38 @@ def test_delete_simple_user_with_recursive_true(user):
     # check that the user does not exist anymore
     response = confd.users(user['uuid']).get()
     response.assert_status(404)
+
+
+@fixtures.device()
+def test_delete_user_with_shared_device_keeps_other_user_associated(device):
+    # Two SIP lines on the same device require distinct backup hosts on the registrar
+    registrar = confd.registrars('default').get().item
+    registrar['proxy_backup_host'] = '127.0.0.2'
+    registrar['backup_host'] = '127.0.0.2'
+    confd.registrars(registrar['id']).put(registrar).assert_updated()
+
+    with line_fellowship('sip', generate_username_password=True) as (
+        user1,
+        line1,
+        _,
+        _,
+    ), line_fellowship('sip', generate_username_password=True) as (
+        user2,
+        line2,
+        _,
+        _,
+    ):
+        confd.lines(line2['id']).put(position=2).assert_updated()
+        confd.lines(line1['id']).devices(device['id']).put().assert_updated()
+        confd.lines(line2['id']).devices(device['id']).put().assert_updated()
+
+        confd.users(user1['uuid']).delete(recursive=True).assert_deleted()
+
+        confd.lines(line1['id']).get().assert_status(404)
+        assert_that(
+            confd.lines(line2['id']).get().item,
+            has_entries(device_id=device['id']),
+        )
 
 
 @fixtures.device(wazo_tenant=MAIN_TENANT)

--- a/integration_tests/suite/base/test_users.py
+++ b/integration_tests/suite/base/test_users.py
@@ -1723,6 +1723,57 @@ def test_delete_user_with_shared_device_keeps_other_user_associated(device):
         )
 
 
+@fixtures.device()
+@fixtures.device()
+def test_update_user_line_device_with_shared_device_keeps_other_user_associated(
+    shared_device, new_device
+):
+    # Two SIP lines on the same device require distinct backup hosts on the registrar
+    registrar = confd.registrars('default').get().item
+    registrar['proxy_backup_host'] = '127.0.0.2'
+    registrar['backup_host'] = '127.0.0.2'
+    confd.registrars(registrar['id']).put(registrar).assert_updated()
+
+    user_resources = generate_user_resources_bodies(
+        context_name=CONTEXT, device=shared_device, endpoint_name='abc'
+    )
+    user_a = confd.users.post(
+        {'lines': [user_resources.line], **user_resources.user},
+    ).item
+
+    with line_fellowship('sip', generate_username_password=True) as (
+        _,
+        line_b,
+        _,
+        _,
+    ):
+        confd.lines(line_b['id']).put(position=2).assert_updated()
+        confd.lines(line_b['id']).devices(shared_device['id']).put().assert_updated()
+
+        user_a_payload = confd.users(user_a['uuid']).get().item
+        user_a_payload.pop('call_record_enabled', None)
+        user_a_payload['lines'][0].pop('caller_id', None)
+        user_a_payload['lines'][0].pop('caller_id_name', None)
+        user_a_payload['lines'][0].pop('caller_id_num', None)
+        user_a_payload['lines'][0]['device_id'] = new_device['id']
+
+        confd.users(user_a['uuid']).put(
+            user_a_payload,
+            query_string="recursive=True",
+        ).assert_updated()
+
+        assert_that(
+            confd.lines(user_a_payload['lines'][0]['id']).get().item,
+            has_entries(device_id=new_device['id']),
+        )
+        assert_that(
+            confd.lines(line_b['id']).get().item,
+            has_entries(device_id=shared_device['id']),
+        )
+
+    confd.users(user_a['uuid']).delete(recursive=True).assert_deleted()
+
+
 @fixtures.device(wazo_tenant=MAIN_TENANT)
 @fixtures.context(wazo_tenant=SUB_TENANT, name='default2')
 def test_post_delete_minimalistic_user_with_unallocated_device_no_error(

--- a/wazo_confd/plugins/user/middleware.py
+++ b/wazo_confd/plugins/user/middleware.py
@@ -279,7 +279,9 @@ class UserMiddleWare(ResourceMiddleware):
 
     def delete_line(self, device_id, line_id, user_id, tenant_uuid, tenant_uuids):
         if device_id:
-            self._middleware_handle.get('device').reset_autoprov(device_id, tenant_uuid)
+            self._middleware_handle.get('line_device_association').dissociate(
+                line_id, device_id, tenant_uuid, tenant_uuids
+            )
 
         self._middleware_handle.get('line').delete(
             line_id, tenant_uuid, tenant_uuids, recursive=True

--- a/wazo_confd/plugins/user/middleware.py
+++ b/wazo_confd/plugins/user/middleware.py
@@ -491,9 +491,11 @@ class UserMiddleWare(ResourceMiddleware):
                         recursive=True,
                     )
                     # if device_id not the same, so we must dissociate the old one and associate the new line
-                    if device_id != old_device_id:
-                        self._middleware_handle.get('device').reset_autoprov(
-                            old_device_id, tenant_uuid
+                    if device_id != old_device_id and old_device_id:
+                        self._middleware_handle.get(
+                            'line_device_association'
+                        ).dissociate(
+                            line_body['id'], old_device_id, tenant_uuid, tenant_uuids
                         )
                     self.associate_line_device(
                         {'id': line_body['id']}, device_id, tenant_uuid, tenant_uuids


### PR DESCRIPTION
Why: causes issues when a device is shared

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how line↔device associations are removed during recursive user delete/update, which can affect device provisioning/association behavior especially for shared devices. Risk is moderated by added integration coverage but touches core user/line/device lifecycle logic.
> 
> **Overview**
> Stops treating line removal as a full device reset when a user is deleted or when a user’s line changes devices.
> 
> In `UserMiddleWare`, recursive user deletion now **dissociates the specific `line_device_association`** before deleting the line (instead of calling `device.reset_autoprov`), and recursive user updates dissociate the *old* device association only when present before associating the new one.
> 
> Adds integration tests to ensure that when two users share the same device, deleting one user or moving one user’s line to another device **does not break the other user’s line→device association**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51c988ba3d333c1a7db65813ed91c1a31e8cf94e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->