### PR TITLE
feat(user): add line_presence user view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 26.07
+
+* The `line_presence` view has been added to `/users` (GET `/users?view=line_presence`)
+
 ## 26.05
 
 * Removed `calllistening` function key service destination.

--- a/integration_tests/suite/base/test_users.py
+++ b/integration_tests/suite/base/test_users.py
@@ -574,6 +574,66 @@ def test_summary_view_on_user_without_line(user):
     )
 
 
+@fixtures.user(services={'dnd': {'enabled': True}})
+@fixtures.line()
+@fixtures.sip()
+@fixtures.extension()
+def test_line_presence_view_on_sip_endpoint(user, line, sip, extension):
+    with a.line_endpoint_sip(line, sip), a.line_extension(line, extension), a.user_line(
+        user, line
+    ):
+        # the line's name is only generated server-side once a SIP endpoint
+        # is associated, so the original `line` fixture dict is stale here
+        updated_line = confd.lines(line['id']).get().item
+        response = confd.users.get(view='line_presence', id=user['id'])
+        assert_that(
+            response.items,
+            contains_exactly(
+                has_entries(
+                    uuid=user['uuid'],
+                    tenant_uuid=user['tenant_uuid'],
+                    lines=contains_exactly(
+                        has_entries(
+                            id=line['id'], name=updated_line['name'], protocol='sip'
+                        )
+                    ),
+                    services=has_entries(dnd=has_entries(enabled=True)),
+                )
+            ),
+        )
+
+
+@fixtures.user()
+def test_line_presence_view_on_user_without_line(user):
+    response = confd.users.get(view='line_presence', id=user['id'])
+    assert_that(
+        response.items,
+        contains_exactly(
+            has_entries(
+                uuid=user['uuid'],
+                tenant_uuid=user['tenant_uuid'],
+                lines=empty(),
+                services=has_entries(dnd=has_entries(enabled=False)),
+            )
+        ),
+    )
+
+
+@fixtures.user(firstname='Zoé-Alice')
+@fixtures.user(firstname='Zoé-Bob')
+@fixtures.user(firstname='Zoé-Charlie')
+def test_line_presence_view_collated_sort(user_a, user_b, user_c):
+    response = confd.users.get(view='line_presence', order='firstname', direction='asc')
+    created_uuids = {user_a['uuid'], user_b['uuid'], user_c['uuid']}
+    ordered_created = [
+        item['uuid'] for item in response.items if item['uuid'] in created_uuids
+    ]
+    assert_that(
+        ordered_created,
+        contains_exactly(user_a['uuid'], user_b['uuid'], user_c['uuid']),
+    )
+
+
 @fixtures.user(
     firstname="Léeroy",
     lastname="Jénkins",

--- a/wazo_confd/plugins/api/api.yml
+++ b/wazo_confd/plugins/api/api.yml
@@ -157,6 +157,7 @@ parameters:
     enum:
     - directory
     - summary
+    - line_presence
     description: Different view of the list of users.
 responses:
   AlreadyConfiguredError:

--- a/wazo_confd/plugins/user/resource.py
+++ b/wazo_confd/plugins/user/resource.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from flask import request, url_for
@@ -14,6 +14,7 @@ from wazo_confd.helpers.restful import (
 
 from .schema import (
     UserDirectorySchema,
+    UserLinePresenceSchema,
     UserListItemSchema,
     UserSchema,
     UserSummarySchema,
@@ -23,7 +24,11 @@ from .schema import (
 class UserList(ListResource):
     model = User
     schema = UserListItemSchema
-    view_schemas = {'directory': UserDirectorySchema, 'summary': UserSummarySchema}
+    view_schemas = {
+        'directory': UserDirectorySchema,
+        'summary': UserSummarySchema,
+        'line_presence': UserLinePresenceSchema,
+    }
 
     def __init__(self, service, middleware):
         super().__init__(service)

--- a/wazo_confd/plugins/user/schema.py
+++ b/wazo_confd/plugins/user/schema.py
@@ -243,13 +243,15 @@ class LinePresenceSchema(BaseSchema):
 
 
 class UserLinePresenceSchema(BaseSchema):
+    _services_schema = ServicesSchema(only=['dnd'])
+
     uuid = fields.String(dump_only=True)
     tenant_uuid = fields.String(dump_only=True)
     lines = Nested(LinePresenceSchema, many=True, dump_only=True)
     services = fields.Method('_dump_services', dump_only=True)
 
     def _dump_services(self, user):
-        return ServicesSchema(only=['dnd']).dump(user)
+        return self._services_schema.dump(user)
 
 
 class UserSchemaNullable(UserSchema):

--- a/wazo_confd/plugins/user/schema.py
+++ b/wazo_confd/plugins/user/schema.py
@@ -18,6 +18,8 @@ from wazo_confd.plugins.agent.schema import NUMBER_REGEX, AgentSchema
 from wazo_confd.plugins.endpoint_sip.schema import EndpointSIPSchema
 from wazo_confd.plugins.line.schema import LineSchema
 
+from .sub_resources.schema import ServicesSchema
+
 MOBILE_PHONE_NUMBER_REGEX = r"^\+?[0-9\*#]+$"
 CALLER_ID_REGEX = r'^"(.*)"( <\+?\d+>)?$'
 USERNAME_REGEX = r"^[a-zA-Z0-9-\._~\!\$&\'\(\)\*\+,;=%@]{2,254}$"
@@ -232,6 +234,22 @@ class UserSummarySchema(BaseSchema):
     enabled = StrictBoolean()
     subscription_type = fields.Integer(validate=Range(min=0, max=10))
     is_webrtc = fields.Boolean()
+
+
+class LinePresenceSchema(BaseSchema):
+    id = fields.Integer(dump_only=True)
+    name = fields.String(dump_only=True)
+    protocol = fields.String(dump_only=True)
+
+
+class UserLinePresenceSchema(BaseSchema):
+    uuid = fields.String(dump_only=True)
+    tenant_uuid = fields.String(dump_only=True)
+    lines = Nested(LinePresenceSchema, many=True, dump_only=True)
+    services = fields.Method('_dump_services', dump_only=True)
+
+    def _dump_services(self, user):
+        return ServicesSchema(only=['dnd']).dump(user)
 
 
 class UserSchemaNullable(UserSchema):

--- a/wazo_confd/plugins/user/tests/test_schema.py
+++ b/wazo_confd/plugins/user/tests/test_schema.py
@@ -9,11 +9,60 @@ from marshmallow import ValidationError
 
 from wazo_confd.helpers.mallow import BaseSchema, StrictBoolean
 
-from ..schema import UserSchema
+from ..schema import UserLinePresenceSchema, UserSchema
 
 
 class _MobileFallbackSchema(BaseSchema):
     mobile_fallback_enabled = StrictBoolean()
+
+
+class TestUserLinePresenceSchema(unittest.TestCase):
+    def setUp(self):
+        self.schema = UserLinePresenceSchema()
+
+    def test_dump_lines_and_dnd_service(self):
+        user = Mock(
+            uuid='abcd-uuid',
+            tenant_uuid='tenant-uuid',
+            dnd_enabled=True,
+            lines=[{'id': 1, 'name': 'line1', 'protocol': 'sip'}],
+        )
+
+        result = self.schema.dump(user)
+
+        assert_that(
+            result,
+            equal_to(
+                {
+                    'uuid': 'abcd-uuid',
+                    'tenant_uuid': 'tenant-uuid',
+                    'lines': [{'id': 1, 'name': 'line1', 'protocol': 'sip'}],
+                    'services': {'dnd': {'enabled': True}},
+                }
+            ),
+        )
+
+    def test_dump_without_line_and_dnd_disabled(self):
+        user = Mock(
+            uuid='abcd-uuid',
+            tenant_uuid='tenant-uuid',
+            dnd_enabled=False,
+            lines=[],
+        )
+
+        result = self.schema.dump(user)
+
+        assert_that(
+            result,
+            equal_to(
+                {
+                    'uuid': 'abcd-uuid',
+                    'tenant_uuid': 'tenant-uuid',
+                    'lines': [],
+                    'services': {'dnd': {'enabled': False}},
+                }
+            ),
+        )
 
 
 class TestSchema(unittest.TestCase):


### PR DESCRIPTION
Depends-On: https://github.com/wazo-platform/xivo-dao/pull/347

## Summary

Adds the `line_presence` user-list view on the API side, consuming the matching xivo-dao view.

- `api.yml`: adds `line_presence` to the user-list `view` enum.
- `resource.py`: registers `UserLinePresenceSchema` in `UserList.view_schemas`.
- `schema.py`: `UserLinePresenceSchema` dumps `uuid`, `tenant_uuid`, `lines` (`id`/`name`/`protocol`), and `services.dnd.enabled`.

## Tests

`TestUserLinePresenceSchema` covers the lines + `services.dnd` payload and the empty-lines / DND-off case. User-plugin suite passes; pre-commit clean (flake8/black/isort/mypy).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only list view and serialization only; no write paths or auth changes beyond existing confd.users.read.
> 
> **Overview**
> Adds **`line_presence`** as a new `view` on **`GET /users`**, aimed at presence UIs that need line identity and DND without the full user payload.
> 
> Clients can call **`GET /users?view=line_presence`** (same list filters, ordering, and tenant behavior as other views). The response shape is **`UserLinePresenceSchema`**: **`uuid`**, **`tenant_uuid`**, **`lines`** with **`id`**, **`name`**, and **`protocol`**, plus **`services.dnd.enabled`**. OpenAPI documents the new enum value; **`UserList`** selects this schema when `view=line_presence`.
> 
> Unit tests cover schema dumping with and without lines; integration tests cover SIP lines, users without lines, and collated **`firstname`** sort.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e789cb9fd3498c06f41dba0b9d11b48792d75fff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->