### PR TITLE
ITEM-447-dynamic-thread-pool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 26.08
+
+* New `rest_api.min_threads` option: threads kept ready at all times.
+  `max_threads` is now a ceiling the pool grows to under load, not a fixed
+  thread count.
+
 ## 26.05
 
 * Removed `calllistening` function key service destination.

--- a/etc/wazo-confd/config.yml
+++ b/etc/wazo-confd/config.yml
@@ -29,10 +29,16 @@ rest_api:
     # Allow JSON preflight requests
     allow_headers: [Content-Type, X-Auth-Token, Wazo-Tenant]
 
-  # Maximum of concurrent threads processing requests
+  # Minimum of concurrent threads processing requests. This many threads
+  # (and database connections) are kept ready at all times.
+  min_threads: 10
+
+  # Maximum of concurrent threads processing requests. The number of threads
+  # (and database connections) scales with demand between min_threads and
+  # max_threads.
   # See the performance documentation for more details
   # https://wazo-platform.org/uc-doc/system/performance/
-  max_threads: 10
+  max_threads: 100
 
 # wazo-auth connection settings
 auth:

--- a/wazo_confd/config.py
+++ b/wazo_confd/config.py
@@ -28,7 +28,8 @@ DEFAULT_CONFIG = {
             'enabled': True,
             'allow_headers': ['Content-Type', 'X-Auth-Token', 'Wazo-Tenant'],
         },
-        'max_threads': 10,
+        'min_threads': 10,
+        'max_threads': 100,
     },
     'auth': {
         'host': 'localhost',

--- a/wazo_confd/http_server.py
+++ b/wazo_confd/http_server.py
@@ -111,10 +111,11 @@ class HTTPServer:
         wsgi_app = ReverseProxied(ProxyFix(wsgi.WSGIPathInfoDispatcher({'/': app})))
 
         bind_addr = (self.config['listen'], self.config['port'])
-        self.server = wsgi.WSGIServer(
+        self.server = wsgi.DynamicWSGIServer(
             bind_addr=bind_addr,
             wsgi_app=wsgi_app,
-            numthreads=self.config['max_threads'],
+            numthreads=self.config['min_threads'],
+            max=self.config['max_threads'],
         )
         if self.config['certificate'] and self.config['private_key']:
             logger.warning(


### PR DESCRIPTION

Depends-on: https://github.com/wazo-platform/xivo-dao/pull/350
Depends-on: https://github.com/wazo-platform/xivo-lib-python/pull/187

Why: max_threads was a fixed thread count spawned at startup, wasting
idle threads and DB connections on quiet systems. The pool now grows
and shrinks between the new min_threads setting and max_threads, which
becomes a real ceiling.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes REST API concurrency and how many DB connections can be opened at peak; wrong min/max tuning could starve or overload the service, though defaults aim to reduce idle waste.
> 
> **Overview**
> Switches wazo-confd’s REST server from a **fixed** thread pool sized by `rest_api.max_threads` to a **dynamic** pool via `DynamicWSGIServer`: `min_threads` (default **10**) keeps that many worker threads (and DB connections) warm, while `max_threads` (default **100** in sample config, up from the old fixed **10**) is only the upper bound under load.
> 
> Defaults and docs are updated in `wazo_confd/config.py`, `etc/wazo-confd/config.yml`, and **CHANGELOG 26.08**. Actual pool behavior lives in dependent **xivo-lib-python** changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 04f01eaca6f5308c8363ba3731e7818a8ae29f2a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->