### PR TITLE
Use nginx for internal wazo-auth requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 26.09
+
+* Requests to wazo-auth now default to `localhost:80`, through nginx.
+
 ## 26.08
 
 * New `rest_api.min_threads` option: threads kept ready at all times.

--- a/etc/wazo-confd/config.yml
+++ b/etc/wazo-confd/config.yml
@@ -43,8 +43,7 @@ rest_api:
 # wazo-auth connection settings
 auth:
     host: localhost
-    port: 9497
-    prefix: null
+    port: 80
     https: false
 
 # Asterisk ARI connection settings

--- a/integration_tests/assets/etc/wazo-confd/conf.d/50-default.yml
+++ b/integration_tests/assets/etc/wazo-confd/conf.d/50-default.yml
@@ -5,6 +5,8 @@ rest_api:
   listen: 0.0.0.0
 auth:
     host: auth
+    port: 9497
+    prefix: null
     username: confd-service
     password: confd-password
 ari:

--- a/integration_tests/assets/etc/wazo-provd/config.yml
+++ b/integration_tests/assets/etc/wazo-provd/config.yml
@@ -2,3 +2,5 @@ rest_api:
   ip: 0.0.0.0
 auth:
   host: auth
+  port: 9497
+  prefix: null

--- a/wazo_confd/config.py
+++ b/wazo_confd/config.py
@@ -33,8 +33,7 @@ DEFAULT_CONFIG = {
     },
     'auth': {
         'host': 'localhost',
-        'port': 9497,
-        'prefix': None,
+        'port': 80,
         'https': False,
         'key_file': '/var/lib/wazo-auth-keys/wazo-confd-key.yml',
     },


### PR DESCRIPTION
Points requests to wazo-auth at the nginx internal entry point
(`localhost:80`) instead of the wazo-auth process port, in both the Python
defaults and the shipped `config.yml` (the YAML is loaded on top of the Python
defaults, so both must change).

The `prefix` override is dropped rather than set: `wazo-auth-client` already
defaults to `/api/auth`.

Depends on:

* wazo-platform/wazo-nginx#23 — the internal entry point itself
* wazo-platform/wazo-auth#449 — the wazo-auth location served on it

Both must be deployed before this merges, otherwise internal auth calls 404.
Ticket: TASK-504

Notes:

* Integration test assets now pin `port: 9497` and `prefix: null` explicitly:
  their stacks have no nginx, and those values used to come from the defaults
  changed here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes how all internal auth traffic is reached and requires coordinated deployment with wazo-nginx and wazo-auth; merging or deploying alone can break service authentication with 404s.
> 
> **Overview**
> **Default wazo-auth connectivity** now targets nginx at `localhost:80` instead of the wazo-auth process on port `9497`. The shipped `etc/wazo-confd/config.yml` and `DEFAULT_CONFIG` in `wazo_confd/config.py` are both updated so layered config stays consistent; the explicit `prefix: null` override is removed so `wazo-auth-client` uses its default `/api/auth`.
> 
> **Integration test assets** (`wazo-confd` and `wazo-provd` override YAML) now set `port: 9497` and `prefix: null` explicitly, because those stacks talk to auth directly with no nginx.
> 
> **Changelog** documents the 26.09 behavior change for operators.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 598f008233c283ada555db324e4b36f20e75d584. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->